### PR TITLE
fix: pass API key management base URL to frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
           VITE_SUPABASE_PROJECT_ID: ${{ secrets.VITE_SUPABASE_PROJECT_ID }}
+          VITE_API_KEY_MANAGEMENT_BASE_URL: ${{ secrets.VITE_API_KEY_MANAGEMENT_BASE_URL }}
         run: bun run build
         
       - name: Setup Pages


### PR DESCRIPTION
## Summary
- inject VITE_API_KEY_MANAGEMENT_BASE_URL into the GitHub Pages build step
- keep frontend deploy behavior consistent with the existing VITE Supabase env wiring

## Why
Without this, the built frontend falls back to same-origin /api/v1/keys instead of using the configured backend base URL.