### PR TITLE
Fix auth UI polish and narrow account settings layout

### DIFF
--- a/src/components/auth/AuthProviderBadge.tsx
+++ b/src/components/auth/AuthProviderBadge.tsx
@@ -10,14 +10,14 @@ export function AuthProviderBadge({ provider, className }: AuthProviderBadgeProp
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] font-mono',
+        'inline-flex items-center rounded-full border px-3 py-1.5 text-[10px] font-semibold tracking-[0.22em] font-mono lowercase shadow-sm backdrop-blur-sm',
         provider === 'google'
-          ? 'border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-200'
-          : 'border-pink-500/30 bg-pink-500/10 text-pink-200',
+          ? 'border-fuchsia-500/20 bg-fuchsia-500/8 text-fuchsia-700 dark:border-fuchsia-400/30 dark:bg-fuchsia-500/10 dark:text-fuchsia-200'
+          : 'border-slate-400/30 bg-slate-500/8 text-slate-700 dark:border-pink-400/30 dark:bg-pink-500/10 dark:text-pink-200',
         className
       )}
     >
-      last_login: {getAuthProviderLabel(provider)}
+      last login: {getAuthProviderLabel(provider).toLowerCase()}
     </span>
   );
 }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -31,6 +31,10 @@ function GoogleIcon() {
   );
 }
 
+function GitHubIcon() {
+  return <Github className="h-4 w-4" aria-hidden="true" />;
+}
+
 function OAuthButton({
   provider,
   onClick,
@@ -42,24 +46,27 @@ function OAuthButton({
   disabled: boolean;
   loading: boolean;
 }) {
-  const Icon = provider === 'google' ? GoogleIcon : Github;
+  const Icon = provider === 'google' ? GoogleIcon : GitHubIcon;
 
   return (
     <Button
       type="button"
       variant="outline"
       className={cn(
-        'h-11 w-full justify-between border-fuchsia-400/30 bg-slate-950/60 font-mono text-fuchsia-100 shadow-[0_0_0_1px_rgba(244,114,182,0.04)] hover:bg-fuchsia-500/10 hover:text-white',
-        provider === 'github' && 'border-pink-400/30 text-pink-100 hover:bg-pink-500/10'
+        'h-11 w-full justify-between rounded-xl border bg-white/75 font-mono text-slate-700 shadow-sm transition-all hover:-translate-y-0.5 hover:bg-white hover:text-slate-900 dark:bg-slate-900/75 dark:text-slate-100 dark:hover:bg-slate-900',
+        'border-fuchsia-300/50 hover:border-fuchsia-400/70 dark:border-fuchsia-400/25 dark:hover:border-fuchsia-300/45',
+        provider === 'github' && 'border-slate-300/70 hover:border-slate-400 dark:border-pink-400/25 dark:hover:border-pink-300/45'
       )}
       onClick={onClick}
       disabled={disabled}
     >
       <span className="flex items-center gap-3">
-        <Icon className="h-4 w-4 shrink-0" />
+        <span className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-300/70 bg-white text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-100">
+          <Icon />
+        </span>
         {loading ? `connecting_${provider}...` : `continue_with_${provider}`}
       </span>
-      <ArrowRight className="w-4 h-4 text-current opacity-80" />
+      <ArrowRight className="h-4 w-4 text-slate-500 dark:text-fuchsia-200" />
     </Button>
   );
 }
@@ -294,7 +301,19 @@ export default function Auth() {
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="space-y-3 rounded-2xl border border-fuchsia-500/20 bg-black/20 p-3">
+              <div className="space-y-3 rounded-2xl border border-fuchsia-300/40 bg-white/55 p-3 shadow-sm backdrop-blur-sm dark:border-fuchsia-500/20 dark:bg-black/20">
+                <div className="flex flex-wrap items-center justify-between gap-3 px-1">
+                  {lastOAuthProvider ? (
+                    <AuthProviderBadge provider={lastOAuthProvider} />
+                  ) : (
+                    <span className="text-[10px] font-mono lowercase tracking-[0.22em] text-muted-foreground">
+                      last login: email
+                    </span>
+                  )}
+                  <span className="text-[10px] font-mono lowercase tracking-[0.18em] text-muted-foreground">
+                    social login
+                  </span>
+                </div>
                 <OAuthButton
                   provider="google"
                   onClick={() => handleOAuthSignIn('google')}
@@ -307,11 +326,10 @@ export default function Auth() {
                   disabled={isBusy}
                   loading={oauthProviderLoading === 'github'}
                 />
-                <div className="flex items-center justify-between gap-3 px-1 pt-1">
+                <div className="px-1 pt-1">
                   <p className="text-[11px] font-mono text-muted-foreground">
                     // social login keeps email/password available below
                   </p>
-                  {lastOAuthProvider && <AuthProviderBadge provider={lastOAuthProvider} />}
                 </div>
               </div>
 

--- a/src/pages/ProfileEdit.tsx
+++ b/src/pages/ProfileEdit.tsx
@@ -164,34 +164,34 @@ export default function ProfileEdit() {
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-6xl p-4 sm:p-8">
         {/* Header */}
-        <div className="flex items-center gap-4 mb-8">
-          <Button variant="ghost" size="icon" onClick={handleBack}>
+        <div className="mb-8 flex flex-wrap items-start gap-3 sm:items-center sm:gap-4">
+          <Button variant="ghost" size="icon" onClick={handleBack} className="shrink-0">
             <ArrowLeft className="w-5 h-5" />
           </Button>
-          <div>
-            <h1 className="text-2xl font-bold font-mono">account_<span className="text-gradient">settings</span></h1>
-            <p className="text-sm text-muted-foreground font-mono">// manage your profile, security, and API access</p>
+          <div className="min-w-0 flex-1">
+            <h1 className="text-xl font-bold font-mono sm:text-2xl">account_<span className="text-gradient">settings</span></h1>
+            <p className="text-xs text-muted-foreground font-mono sm:text-sm">// manage your profile, security, and API access</p>
           </div>
-          {oauthProvider && <AuthProviderBadge provider={oauthProvider} className="ml-auto hidden sm:inline-flex" />}
+          {oauthProvider && <AuthProviderBadge provider={oauthProvider} className="w-full justify-center sm:ml-auto sm:w-auto" />}
         </div>
 
         <Tabs defaultValue="profile" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-2 gap-2 font-mono sm:grid-cols-4">
-            <TabsTrigger value="profile" className="gap-2">
-              <User className="w-4 h-4" />
-              <span className="hidden sm:inline">profile</span>
+          <TabsList className="grid w-full grid-cols-2 gap-2 rounded-2xl p-1 font-mono sm:grid-cols-4">
+            <TabsTrigger value="profile" className="min-h-11 gap-2 px-3">
+              <User className="w-4 h-4 shrink-0" />
+              <span className="truncate text-[11px] sm:text-xs">profile</span>
             </TabsTrigger>
-            <TabsTrigger value="password" className="gap-2">
-              <Lock className="w-4 h-4" />
-              <span className="hidden sm:inline">password</span>
+            <TabsTrigger value="password" className="min-h-11 gap-2 px-3">
+              <Lock className="w-4 h-4 shrink-0" />
+              <span className="truncate text-[11px] sm:text-xs">password</span>
             </TabsTrigger>
-            <TabsTrigger value="email" className="gap-2">
-              <Mail className="w-4 h-4" />
-              <span className="hidden sm:inline">email</span>
+            <TabsTrigger value="email" className="min-h-11 gap-2 px-3">
+              <Mail className="w-4 h-4 shrink-0" />
+              <span className="truncate text-[11px] sm:text-xs">email</span>
             </TabsTrigger>
-            <TabsTrigger value="api-keys" className="gap-2">
-              <KeyRound className="w-4 h-4" />
-              <span className="hidden sm:inline">api_keys</span>
+            <TabsTrigger value="api-keys" className="min-h-11 gap-2 px-3">
+              <KeyRound className="w-4 h-4 shrink-0" />
+              <span className="truncate text-[11px] sm:text-xs">api_keys</span>
             </TabsTrigger>
           </TabsList>
 
@@ -246,7 +246,7 @@ export default function ProfileEdit() {
               
               <Button 
                 variant="glow" 
-                className="w-full font-mono" 
+                className="w-full min-h-11 font-mono text-xs sm:text-sm" 
                 onClick={handleSaveProfile}
                 disabled={saving}
               >


### PR DESCRIPTION
## Summary\n- refine auth social-login card colors for light and dark mode\n- surface the remembered last-login provider as a cleaner pill above the auth buttons\n- improve very narrow account-settings layouts so header badge and tab buttons wrap more gracefully\n- increase small-screen button resilience for the profile save action\n\n## Notes\n- keeps the same branch for the requested auth/UI polish bundle\n- includes the narrow-width account settings fix from the latest screenshot