### PR TITLE
fix: auth UX polish — last-used provider badge, dark mode, settings alignment

### DIFF
--- a/src/components/auth/AuthProviderBadge.tsx
+++ b/src/components/auth/AuthProviderBadge.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils';
-import { getAuthProviderLabel, type SupportedOAuthProvider } from '@/lib/authProviders';
+import { type SupportedOAuthProvider } from '@/lib/authProviders';
 
 interface AuthProviderBadgeProps {
   provider: SupportedOAuthProvider;
@@ -10,14 +10,14 @@ export function AuthProviderBadge({ provider, className }: AuthProviderBadgeProp
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full border px-3 py-1.5 text-[10px] font-semibold tracking-[0.22em] font-mono lowercase shadow-sm backdrop-blur-sm',
+        'inline-flex items-center rounded-full border px-3 py-1.5 text-[10px] font-semibold tracking-[0.22em] font-mono uppercase shadow-sm backdrop-blur-sm',
         provider === 'google'
-          ? 'border-fuchsia-500/20 bg-fuchsia-500/8 text-fuchsia-700 dark:border-fuchsia-400/30 dark:bg-fuchsia-500/10 dark:text-fuchsia-200'
-          : 'border-slate-400/30 bg-slate-500/8 text-slate-700 dark:border-pink-400/30 dark:bg-pink-500/10 dark:text-pink-200',
+          ? 'border-emerald-500/30 bg-emerald-500/12 text-emerald-700 dark:border-emerald-400/35 dark:bg-emerald-500/14 dark:text-emerald-200'
+          : 'border-fuchsia-500/25 bg-fuchsia-500/10 text-fuchsia-700 dark:border-fuchsia-400/30 dark:bg-fuchsia-500/14 dark:text-fuchsia-200',
         className
       )}
     >
-      last login: {getAuthProviderLabel(provider).toLowerCase()}
+      LAST USED
     </span>
   );
 }

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -68,6 +68,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const signInWithGoogle = async () => {
+    persistLastLoginProvider('google');
+
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
@@ -75,16 +77,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       },
     });
 
+    if (error) {
+      persistLastLoginProvider(null);
+    }
+
     return { error: error as Error | null };
   };
 
   const signInWithGitHub = async () => {
+    persistLastLoginProvider('github');
+
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'github',
       options: {
         redirectTo: `${window.location.origin}/auth/callback`,
       },
     });
+
+    if (error) {
+      persistLastLoginProvider(null);
+    }
 
     return { error: error as Error | null };
   };

--- a/src/lib/authProviders.ts
+++ b/src/lib/authProviders.ts
@@ -13,8 +13,25 @@ export function isSupportedOAuthProvider(value: unknown): value is SupportedOAut
 }
 
 export function getUserAuthProvider(user: User | null | undefined): SupportedOAuthProvider | null {
-  const provider = user?.app_metadata?.provider;
-  return isSupportedOAuthProvider(provider) ? provider : null;
+  const appProvider = user?.app_metadata?.provider;
+  if (isSupportedOAuthProvider(appProvider)) {
+    return appProvider;
+  }
+
+  const appProviders = Array.isArray(user?.app_metadata?.providers)
+    ? user?.app_metadata?.providers
+    : [];
+  const matchedAppProvider = appProviders.find(isSupportedOAuthProvider);
+  if (matchedAppProvider) {
+    return matchedAppProvider;
+  }
+
+  const identities = Array.isArray(user?.identities) ? user.identities : [];
+  const matchedIdentityProvider = identities
+    .map((identity) => identity.provider)
+    .find(isSupportedOAuthProvider);
+
+  return matchedIdentityProvider ?? null;
 }
 
 export function persistLastLoginProvider(provider: SupportedOAuthProvider | null) {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -40,34 +40,44 @@ function OAuthButton({
   onClick,
   disabled,
   loading,
+  isLastUsed,
 }: {
   provider: SupportedOAuthProvider;
   onClick: () => void;
   disabled: boolean;
   loading: boolean;
+  isLastUsed: boolean;
 }) {
   const Icon = provider === 'google' ? GoogleIcon : GitHubIcon;
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      className={cn(
-        'h-11 w-full justify-between rounded-xl border bg-white/75 font-mono text-slate-700 shadow-sm transition-all hover:-translate-y-0.5 hover:bg-white hover:text-slate-900 dark:bg-slate-900/75 dark:text-slate-100 dark:hover:bg-slate-900',
-        'border-fuchsia-300/50 hover:border-fuchsia-400/70 dark:border-fuchsia-400/25 dark:hover:border-fuchsia-300/45',
-        provider === 'github' && 'border-slate-300/70 hover:border-slate-400 dark:border-pink-400/25 dark:hover:border-pink-300/45'
+    <div className="relative">
+      {isLastUsed && (
+        <AuthProviderBadge provider={provider} className="absolute -top-2 right-3 z-10" />
       )}
-      onClick={onClick}
-      disabled={disabled}
-    >
-      <span className="flex items-center gap-3">
-        <span className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-300/70 bg-white text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-100">
-          <Icon />
+      <Button
+        type="button"
+        variant="outline"
+        className={cn(
+          'h-12 w-full justify-between rounded-xl border font-mono shadow-sm transition-all hover:-translate-y-0.5',
+          'bg-white/85 text-slate-700 hover:bg-white hover:text-slate-950',
+          'dark:bg-[#17151f] dark:text-slate-100 dark:hover:bg-[#1d1a28]',
+          'border-slate-300/80 hover:border-slate-400 dark:border-white/10 dark:hover:border-fuchsia-300/35',
+          provider === 'google' && 'dark:bg-[#171722] dark:hover:bg-[#1b1d2a]',
+          isLastUsed && 'ring-1 ring-emerald-500/20 dark:ring-emerald-400/20'
+        )}
+        onClick={onClick}
+        disabled={disabled}
+      >
+        <span className="flex items-center gap-3">
+          <span className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-300/70 bg-white text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-100">
+            <Icon />
+          </span>
+          {loading ? `connecting_${provider}...` : `continue_with_${provider}`}
         </span>
-        {loading ? `connecting_${provider}...` : `continue_with_${provider}`}
-      </span>
-      <ArrowRight className="h-4 w-4 text-slate-500 dark:text-fuchsia-200" />
-    </Button>
+        <ArrowRight className="h-4 w-4 text-slate-500 dark:text-slate-300" />
+      </Button>
+    </div>
   );
 }
 
@@ -301,30 +311,30 @@ export default function Auth() {
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="space-y-3 rounded-2xl border border-fuchsia-300/40 bg-white/55 p-3 shadow-sm backdrop-blur-sm dark:border-fuchsia-500/20 dark:bg-black/20">
-                <div className="flex flex-wrap items-center justify-between gap-3 px-1">
-                  {lastOAuthProvider ? (
-                    <AuthProviderBadge provider={lastOAuthProvider} />
-                  ) : (
-                    <span className="text-[10px] font-mono lowercase tracking-[0.22em] text-muted-foreground">
-                      last login: email
-                    </span>
-                  )}
+              <div className="space-y-3 rounded-2xl border border-white/10 bg-white/60 p-3 shadow-sm backdrop-blur-sm dark:border-white/8 dark:bg-[#121018]/85">
+                <div className="flex items-center justify-between px-1">
                   <span className="text-[10px] font-mono lowercase tracking-[0.18em] text-muted-foreground">
                     social login
                   </span>
+                  {!lastOAuthProvider && (
+                    <span className="text-[10px] font-mono lowercase tracking-[0.18em] text-muted-foreground">
+                      no last used yet
+                    </span>
+                  )}
                 </div>
                 <OAuthButton
                   provider="google"
                   onClick={() => handleOAuthSignIn('google')}
                   disabled={isBusy}
                   loading={oauthProviderLoading === 'google'}
+                  isLastUsed={lastOAuthProvider === 'google'}
                 />
                 <OAuthButton
                   provider="github"
                   onClick={() => handleOAuthSignIn('github')}
                   disabled={isBusy}
                   loading={oauthProviderLoading === 'github'}
+                  isLastUsed={lastOAuthProvider === 'github'}
                 />
                 <div className="px-1 pt-1">
                   <p className="text-[11px] font-mono text-muted-foreground">

--- a/src/pages/ProfileEdit.tsx
+++ b/src/pages/ProfileEdit.tsx
@@ -176,20 +176,20 @@ export default function ProfileEdit() {
         </div>
 
         <Tabs defaultValue="profile" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-2 gap-2 rounded-2xl p-1 font-mono sm:grid-cols-4">
-            <TabsTrigger value="profile" className="min-h-11 gap-2 px-3">
+          <TabsList className="grid w-full grid-cols-2 gap-2 rounded-2xl border border-border/70 bg-muted/60 p-1 font-mono dark:border-white/8 dark:bg-[#1a1722] sm:grid-cols-4">
+            <TabsTrigger value="profile" className="min-h-11 justify-center gap-2 rounded-xl px-3 text-center data-[state=active]:bg-violet-500/90 data-[state=active]:text-white data-[state=active]:shadow-none">
               <User className="w-4 h-4 shrink-0" />
               <span className="truncate text-[11px] sm:text-xs">profile</span>
             </TabsTrigger>
-            <TabsTrigger value="password" className="min-h-11 gap-2 px-3">
+            <TabsTrigger value="password" className="min-h-11 justify-center gap-2 rounded-xl px-3 text-center data-[state=active]:bg-violet-500/90 data-[state=active]:text-white data-[state=active]:shadow-none">
               <Lock className="w-4 h-4 shrink-0" />
               <span className="truncate text-[11px] sm:text-xs">password</span>
             </TabsTrigger>
-            <TabsTrigger value="email" className="min-h-11 gap-2 px-3">
+            <TabsTrigger value="email" className="min-h-11 justify-center gap-2 rounded-xl px-3 text-center data-[state=active]:bg-violet-500/90 data-[state=active]:text-white data-[state=active]:shadow-none">
               <Mail className="w-4 h-4 shrink-0" />
               <span className="truncate text-[11px] sm:text-xs">email</span>
             </TabsTrigger>
-            <TabsTrigger value="api-keys" className="min-h-11 gap-2 px-3">
+            <TabsTrigger value="api-keys" className="min-h-11 justify-center gap-2 rounded-xl px-3 text-center data-[state=active]:bg-violet-500/90 data-[state=active]:text-white data-[state=active]:shadow-none">
               <KeyRound className="w-4 h-4 shrink-0" />
               <span className="truncate text-[11px] sm:text-xs">api_keys</span>
             </TabsTrigger>


### PR DESCRIPTION
## Summary

Follow-up polish after #45 (OAuth login) was merged.

- **Last-used provider badge**: now attaches directly to the relevant OAuth button instead of floating as a header label
- **Provider detection fix**: `email` was showing incorrectly after Google login; now checks `app_metadata.provider/providers` + `user.identities[*].provider`, and persists the selected provider before the OAuth redirect
- **Dark mode cleanup**: toned down the auth card/button colors — less muddy-purple, better contrast
- **Account settings tab alignment**: tightened the segmented control

## Test plan

- [x] Sign in with Google → badge shows on Google button (not "email")
- [x] Sign in with GitHub → badge shows on GitHub button
- [x] Sign in with email → no badge shown
- [x] Dark mode: auth card clean, not washed-out purple
- [x] Account settings: tabs aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)