### PR TITLE
feat: public vault fork with RLS fix

### DIFF
--- a/src/hooks/useVaultFork.ts
+++ b/src/hooks/useVaultFork.ts
@@ -1,16 +1,19 @@
-import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
-import { Vault } from '@/types/database';
 import { useToast } from './use-toast';
+import { forkVault as forkVaultLib, getVaultForkInfo, getVaultForkCount } from '@/lib/vaultFork';
+import { Vault } from '@/types/database';
 
 export function useVaultFork() {
   const { user } = useAuth();
   const { toast } = useToast();
 
-  const forkVault = async (originalVault: Vault): Promise<Vault | null> => {
+  /**
+   * Fork a vault. Returns the new vault id on success, null on failure.
+   */
+  const forkVault = async (originalVault: Vault): Promise<string | null> => {
     if (!user) {
       toast({
-        title: 'Sign in required',
+        title: 'sign_in_required',
         description: 'Please sign in to fork this vault.',
         variant: 'destructive',
       });
@@ -18,88 +21,12 @@ export function useVaultFork() {
     }
 
     try {
-      // Check if user already forked this vault
-      const { data: existingFork } = await supabase
-        .from('vault_forks')
-        .select('forked_vault_id')
-        .eq('original_vault_id', originalVault.id)
-        .eq('forked_by', user.id)
-        .maybeSingle();
-
-      if (existingFork) {
-        toast({
-          title: 'already_forked',
-          description: 'You have already forked this vault.',
-        });
-        return null;
-      }
-
-      // Create a new vault as a copy
-      const { data: newVault, error: vaultError } = await supabase
-        .from('vaults')
-        .insert({
-          user_id: user.id,
-          name: `${originalVault.name} (Fork)`,
-          description: originalVault.description,
-          color: originalVault.color,
-          category: originalVault.category,
-          abstract: originalVault.abstract,
-          visibility: 'private',
-        })
-        .select()
-        .single();
-
-      if (vaultError) throw vaultError;
-
-      // Record the fork relationship
-      const { error: forkError } = await supabase
-        .from('vault_forks')
-        .insert({
-          original_vault_id: originalVault.id,
-          forked_vault_id: newVault.id,
-          forked_by: user.id,
-        });
-
-      if (forkError) throw forkError;
-
-      // Copy all publications from the original vault
-      const { data: originalPubs } = await supabase
-        .from('publications')
-        .select('*')
-        .eq('vault_id', originalVault.id);
-
-      if (originalPubs && originalPubs.length > 0) {
-        const pubsToInsert = originalPubs.map(pub => ({
-          user_id: user.id,
-          vault_id: newVault.id,
-          title: pub.title,
-          authors: pub.authors,
-          year: pub.year,
-          journal: pub.journal,
-          volume: pub.volume,
-          issue: pub.issue,
-          pages: pub.pages,
-          doi: pub.doi,
-          url: pub.url,
-          abstract: pub.abstract,
-          pdf_url: pub.pdf_url,
-          bibtex_key: pub.bibtex_key,
-          publication_type: pub.publication_type,
-          notes: pub.notes,
-        }));
-
-        await supabase.from('publications').insert(pubsToInsert);
-      }
-
-      toast({
-        title: 'Vault forked successfully! 🍴',
-        description: 'You can now edit and augment this collection.',
-      });
-
-      return newVault as Vault;
+      const newVaultId = await forkVaultLib(originalVault.id, user);
+      toast({ title: 'vault forked — find it in your vaults' });
+      return newVaultId;
     } catch (error) {
       toast({
-        title: 'Error forking vault',
+        title: 'fork_failed',
         description: (error as Error).message,
         variant: 'destructive',
       });
@@ -107,44 +34,10 @@ export function useVaultFork() {
     }
   };
 
-  const getForkedFrom = async (vaultId: string): Promise<Vault | null> => {
-    try {
-      const { data: forkData } = await supabase
-        .from('vault_forks')
-        .select('original_vault_id')
-        .eq('forked_vault_id', vaultId)
-        .maybeSingle();
-
-      if (!forkData) return null;
-
-      const { data: vaultData } = await supabase
-        .from('vaults')
-        .select('*')
-        .eq('id', forkData.original_vault_id)
-        .maybeSingle();
-
-      return vaultData as Vault | null;
-    } catch (error) {
-      return null;
-    }
-  };
-
-  const getForkCount = async (vaultId: string): Promise<number> => {
-    try {
-      const { count } = await supabase
-        .from('vault_forks')
-        .select('*', { count: 'exact', head: true })
-        .eq('original_vault_id', vaultId);
-
-      return count || 0;
-    } catch (error) {
-      return 0;
-    }
-  };
-
   return {
     forkVault,
-    getForkedFrom,
-    getForkCount,
+    getForkedFrom: (vaultId: string) =>
+      getVaultForkInfo(vaultId).then(info => info.forkedFrom),
+    getForkCount: getVaultForkCount,
   };
 }

--- a/src/lib/vaultFork.ts
+++ b/src/lib/vaultFork.ts
@@ -1,0 +1,158 @@
+import { User } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface VaultForkInfo {
+  forkedFrom: {
+    id: string;
+    name: string;
+    public_slug: string | null;
+    owner: { display_name: string | null; username: string | null } | null;
+  } | null;
+}
+
+/**
+ * Fork a public vault: copies the vault row and all vault_publications,
+ * records the fork relationship, and returns the new vault id.
+ */
+export async function forkVault(originalVaultId: string, user: User): Promise<string> {
+  // Fetch the original vault
+  const { data: original, error: fetchErr } = await supabase
+    .from('vaults')
+    .select('*')
+    .eq('id', originalVaultId)
+    .eq('visibility', 'public')
+    .single();
+
+  if (fetchErr || !original) {
+    throw new Error(fetchErr?.message ?? 'vault not found or not public');
+  }
+
+  // Create the forked vault (private, no slug)
+  const { data: newVault, error: vaultErr } = await supabase
+    .from('vaults')
+    .insert({
+      user_id: user.id,
+      name: `${original.name} (Fork)`,
+      description: original.description,
+      color: original.color,
+      category: original.category,
+      abstract: original.abstract,
+      visibility: 'private',
+      public_slug: null,
+    })
+    .select('id')
+    .single();
+
+  if (vaultErr || !newVault) {
+    throw new Error(vaultErr?.message ?? 'failed to create vault');
+  }
+
+  // Record the fork relationship
+  const { error: forkErr } = await supabase
+    .from('vault_forks')
+    .insert({
+      original_vault_id: originalVaultId,
+      forked_vault_id: newVault.id,
+      forked_by: user.id,
+    });
+
+  if (forkErr) throw new Error(forkErr.message);
+
+  // Copy all vault_publications from the original vault
+  const { data: originalPubs } = await supabase
+    .from('vault_publications')
+    .select('*')
+    .eq('vault_id', originalVaultId);
+
+  if (originalPubs && originalPubs.length > 0) {
+    const copies = originalPubs.map(p => ({
+      vault_id: newVault.id,
+      original_publication_id: p.original_publication_id,
+      title: p.title,
+      authors: p.authors,
+      year: p.year,
+      journal: p.journal,
+      volume: p.volume,
+      issue: p.issue,
+      pages: p.pages,
+      doi: p.doi,
+      url: p.url,
+      abstract: p.abstract,
+      pdf_url: p.pdf_url,
+      bibtex_key: p.bibtex_key,
+      publication_type: p.publication_type,
+      notes: p.notes,
+      booktitle: p.booktitle,
+      chapter: p.chapter,
+      edition: p.edition,
+      editor: p.editor,
+      howpublished: p.howpublished,
+      institution: p.institution,
+      number: p.number,
+      organization: p.organization,
+      publisher: p.publisher,
+      school: p.school,
+      series: p.series,
+      type: p.type,
+      eid: p.eid,
+      isbn: p.isbn,
+      issn: p.issn,
+      keywords: p.keywords,
+      created_by: user.id,
+    }));
+
+    const { error: pubErr } = await supabase.from('vault_publications').insert(copies);
+    if (pubErr) throw new Error(pubErr.message);
+  }
+
+  return newVault.id;
+}
+
+/**
+ * Get attribution info for a forked vault.
+ * Returns the original vault name, slug, and owner profile if this vault is a fork.
+ */
+export async function getVaultForkInfo(vaultId: string): Promise<VaultForkInfo> {
+  const { data: forkRecord } = await supabase
+    .from('vault_forks')
+    .select('original_vault_id')
+    .eq('forked_vault_id', vaultId)
+    .maybeSingle();
+
+  if (!forkRecord) return { forkedFrom: null };
+
+  const { data: originalVault } = await supabase
+    .from('vaults')
+    .select('id, name, public_slug, user_id')
+    .eq('id', forkRecord.original_vault_id)
+    .maybeSingle();
+
+  if (!originalVault) return { forkedFrom: null };
+
+  const { data: ownerProfile } = await supabase
+    .from('profiles')
+    .select('display_name, username')
+    .eq('user_id', originalVault.user_id)
+    .maybeSingle();
+
+  return {
+    forkedFrom: {
+      id: originalVault.id,
+      name: originalVault.name,
+      public_slug: originalVault.public_slug,
+      owner: ownerProfile ?? null,
+    },
+  };
+}
+
+/**
+ * Count the number of forks for a given vault.
+ */
+export async function getVaultForkCount(vaultId: string): Promise<number> {
+  const { count } = await supabase
+    .from('vault_forks')
+    .select('*', { count: 'exact', head: true })
+    .eq('original_vault_id', vaultId);
+
+  return count ?? 0;
+}

--- a/src/pages/PublicVaultSimple.tsx
+++ b/src/pages/PublicVaultSimple.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { useVaultFavorites } from '@/hooks/useVaultFavorites';
 import { useVaultFork } from '@/hooks/useVaultFork';
+import { getVaultForkInfo, VaultForkInfo } from '@/lib/vaultFork';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { PublicationList } from '@/components/publications/PublicationList';
 import { Button } from '@/components/ui/button';
@@ -43,6 +44,7 @@ export default function PublicVault() {
   const [searchQuery, setSearchQuery] = useState('');
   const [notFound, setNotFound] = useState(false);
   const [forking, setForking] = useState(false);
+  const [forkInfo, setForkInfo] = useState<VaultForkInfo | null>(null);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [userVaults, setUserVaults] = useState<Vault[]>([]);
   const [sharedVaults, setSharedVaults] = useState<Vault[]>([]);
@@ -134,6 +136,9 @@ export default function PublicVault() {
       }
 
       setVault(vaultData);
+
+      // Fetch fork attribution (if this vault is itself a fork)
+      getVaultForkInfo(vaultData.id).then(setForkInfo).catch(() => {});
 
       // Fetch vault owner profile
       const { data: ownerProfile } = await supabase
@@ -303,9 +308,9 @@ export default function PublicVault() {
     
     setForking(true);
     try {
-      const newVault = await forkVault(vault);
-      if (newVault) {
-        navigate('/dashboard');
+      const newVaultId = await forkVault(vault);
+      if (newVaultId) {
+        navigate(`/vault/${newVaultId}`);
       }
     } finally {
       setForking(false);
@@ -432,10 +437,26 @@ export default function PublicVault() {
                     public
                   </Badge>
                   <VaultAccessBadge vaultId={vault.id} />
+                  {/* Attribution badge — shown when this vault was itself forked */}
+                  {forkInfo?.forkedFrom && (
+                    <Badge variant="outline" className="gap-1 font-mono text-xs shrink-0 text-muted-foreground">
+                      <GitFork className="w-3 h-3" />
+                      {forkInfo.forkedFrom.public_slug ? (
+                        <Link
+                          to={`/public/${forkInfo.forkedFrom.public_slug}`}
+                          className="hover:text-foreground transition-colors"
+                        >
+                          forked_from_{forkInfo.forkedFrom.name.toLowerCase().replace(/\s+/g, '_')}
+                        </Link>
+                      ) : (
+                        <span>forked_from_{forkInfo.forkedFrom.name.toLowerCase().replace(/\s+/g, '_')}</span>
+                      )}
+                    </Badge>
+                  )}
                   <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
                     <Clock className="w-3.5 h-3.5 shrink-0" />
                     <span className="truncate">
-                      {lastUpdatedBy 
+                      {lastUpdatedBy
                         ? `${lastUpdatedBy.display_name || lastUpdatedBy.username || 'someone'}.last_update() // ${formatTimeAgo(vault.updated_at)}`
                         : `last_sync() // ${formatTimeAgo(vault.updated_at)}`
                       }
@@ -444,18 +465,20 @@ export default function PublicVault() {
                 </div>
 
                 <div className="flex items-center gap-2 shrink-0">
+                  {/* Fork count badge — always visible */}
+                  {forkCount > 0 && (
+                    <div className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground font-mono border border-input rounded-md px-3 h-8">
+                      <GitFork className="w-3.5 h-3.5" />
+                      <span>{forkCount}_forks</span>
+                    </div>
+                  )}
+
                   {/* Stats for owner view */}
                   {user && vault.user_id === user.id ? (
-                    <>
-                      <div className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground font-mono border border-input rounded-md px-3 h-8">
-                        <Heart className="w-3.5 h-3.5" />
-                        <span>{favoritesCount}</span>
-                      </div>
-                      <div className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground font-mono border border-input rounded-md px-3 h-8">
-                        <GitFork className="w-3.5 h-3.5" />
-                        <span>{forkCount}</span>
-                      </div>
-                    </>
+                    <div className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground font-mono border border-input rounded-md px-3 h-8">
+                      <Heart className="w-3.5 h-3.5" />
+                      <span>{favoritesCount}</span>
+                    </div>
                   ) : (
                     <>
                       <Button
@@ -475,7 +498,9 @@ export default function PublicVault() {
                         className="font-mono h-8"
                       >
                         <GitFork className="w-4 h-4" />
-                        <span className="ml-2 hidden md:inline">fork</span>
+                        <span className="ml-2 hidden md:inline">
+                          {forking ? 'forking_vault...' : 'fork vault'}
+                        </span>
                       </Button>
                     </>
                   )}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -48,6 +48,8 @@ export interface Vault {
   abstract: string | null;
   created_at: string;
   updated_at: string;
+  /** populated via vault_forks join when attribution is needed */
+  forked_from_id?: string | null;
 }
 
 export interface VaultStats {

--- a/supabase/migrations/20260326120000_public_vault_rls_and_forks.sql
+++ b/supabase/migrations/20260326120000_public_vault_rls_and_forks.sql
@@ -1,0 +1,89 @@
+-- Public vault RLS policies and vault_forks policies
+-- Fixes: anon users can't read public vaults; vault_forks has no RLS policies
+
+-- ─── vaults ──────────────────────────────────────────────────────────────────
+-- Allow anon + authenticated to SELECT vaults with visibility = 'public'
+CREATE POLICY "Public vaults are viewable by everyone"
+  ON public.vaults
+  FOR SELECT
+  TO anon, authenticated
+  USING (visibility = 'public');
+
+-- ─── vault_publications ───────────────────────────────────────────────────────
+-- Allow anon + authenticated to SELECT publications from public vaults
+CREATE POLICY "Public vault publications are viewable by everyone"
+  ON public.vault_publications
+  FOR SELECT
+  TO anon, authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.vaults v
+      WHERE v.id = vault_publications.vault_id
+        AND v.visibility = 'public'
+    )
+  );
+
+-- ─── tags ─────────────────────────────────────────────────────────────────────
+-- Allow anon + authenticated to SELECT tags that belong to public vaults
+CREATE POLICY "Public vault tags are viewable by everyone"
+  ON public.tags
+  FOR SELECT
+  TO anon, authenticated
+  USING (
+    vault_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM public.vaults v
+      WHERE v.id = tags.vault_id
+        AND v.visibility = 'public'
+    )
+  );
+
+-- ─── vault_forks ─────────────────────────────────────────────────────────────
+-- Allow anon + authenticated to SELECT fork records for public vaults
+-- (needed for fork-count display on public vault pages)
+CREATE POLICY "Fork counts on public vaults are viewable by everyone"
+  ON public.vault_forks
+  FOR SELECT
+  TO anon, authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.vaults v
+      WHERE v.id = vault_forks.original_vault_id
+        AND v.visibility = 'public'
+    )
+  );
+
+-- Allow authenticated users to view their own fork records
+-- (covers private/non-public original vaults too)
+CREATE POLICY "Users can view own fork records"
+  ON public.vault_forks
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = forked_by);
+
+-- Allow vault owners to view all forks of their vaults
+CREATE POLICY "Vault owners can view forks of their vault"
+  ON public.vault_forks
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.vaults v
+      WHERE v.id = vault_forks.original_vault_id
+        AND v.user_id = auth.uid()
+    )
+  );
+
+-- Allow authenticated users to fork public vaults
+CREATE POLICY "Authenticated users can fork public vaults"
+  ON public.vault_forks
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = forked_by
+    AND EXISTS (
+      SELECT 1 FROM public.vaults v
+      WHERE v.id = original_vault_id
+        AND v.visibility = 'public'
+    )
+  );


### PR DESCRIPTION
## Summary

- **RLS fix**: adds migration `20260326120000_public_vault_rls_and_forks.sql` with anon+authenticated SELECT policies on `vaults`, `vault_publications`, and `tags` for public vaults
- **Fork RLS**: adds INSERT + SELECT policies on `vault_forks`
- **Fork service**: new `src/lib/vaultFork.ts` with `forkVault`, `getVaultForkInfo`, `getVaultForkCount` — correctly copies `vault_publications`
- **Hook rewrite**: `useVaultFork` now delegates to the lib, returns vault id, uses spec-correct toast copy
- **UI**: `PublicVaultSimple` navigates to `/vault/:newId` after fork, shows attribution badge, fork count for all, `forking_vault...` loading state

## Test plan

- [ ] Anonymous user can visit `/public/:slug` and see vault + publications
- [ ] Fork button shows `forking_vault...` loading state, navigates to new vault after success
- [ ] Attribution badge shows `forked_from_*` when vault is a fork
- [ ] Fork count badge visible to all users
- [ ] `tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)