### PR TITLE
fix: correct last updated attribution

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -928,7 +928,17 @@ export default function Dashboard() {
           // If we have a vault_publication, we need to copy its data directly
           if (vaultPub) {
             // Copy the vault_publication data to the new vault
-            const { id, vault_id, original_publication_id, created_at, updated_at, ...pubData } = vaultPub;
+            const {
+              id,
+              vault_id,
+              original_publication_id,
+              created_at,
+              updated_at,
+              created_by: _createdBy,
+              updated_by: _updatedBy,
+              version: _version,
+              ...pubData
+            } = vaultPub;
             const { error: insertError } = await supabase
               .from('vault_publications')
               .insert({
@@ -937,6 +947,7 @@ export default function Dashboard() {
                 original_publication_id: original_publication_id || null,
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
+                created_by: user.id,
               });
 
             if (insertError) throw insertError;

--- a/src/pages/PublicVaultSimple.tsx
+++ b/src/pages/PublicVaultSimple.tsx
@@ -36,7 +36,10 @@ export default function PublicVault() {
   const navigate = useNavigate();
   const [vault, setVault] = useState<Vault | null>(null);
   const [vaultOwner, setVaultOwner] = useState<{ display_name: string | null; username: string | null } | null>(null);
-  const [lastUpdatedBy, setLastUpdatedBy] = useState<{ display_name: string | null; username: string | null } | null>(null);
+  const [lastUpdatedActivity, setLastUpdatedActivity] = useState<{
+    profile: { display_name: string | null; username: string | null } | null;
+    timestamp: string;
+  } | null>(null);
   const [favoritesCount, setFavoritesCount] = useState(0);
   const [forkCount, setForkCount] = useState(0);
   const [publications, setPublications] = useState<Publication[]>([]);
@@ -169,22 +172,33 @@ export default function PublicVault() {
       
       setForkCount(forksCount || 0);
 
-      // Fetch last updated by user
+      // Fetch last updated activity
       const { data: lastUpdatedPub } = await supabase
         .from('vault_publications')
-        .select('updated_by')
+        .select('updated_by, created_by, updated_at, created_at')
         .eq('vault_id', vaultData.id)
         .order('updated_at', { ascending: false })
         .limit(1)
         .maybeSingle();
-      
-      if (lastUpdatedPub?.updated_by) {
+
+      const lastUpdatedActorId = lastUpdatedPub?.updated_by || lastUpdatedPub?.created_by || null;
+      const lastUpdatedTimestamp = lastUpdatedPub?.updated_at || lastUpdatedPub?.created_at || vaultData.updated_at;
+
+      if (lastUpdatedActorId) {
         const { data: updaterProfile } = await supabase
           .from('profiles')
           .select('display_name, username')
-          .eq('user_id', lastUpdatedPub.updated_by)
+          .eq('user_id', lastUpdatedActorId)
           .maybeSingle();
-        setLastUpdatedBy(updaterProfile);
+        setLastUpdatedActivity({
+          profile: updaterProfile,
+          timestamp: lastUpdatedTimestamp,
+        });
+      } else {
+        setLastUpdatedActivity({
+          profile: null,
+          timestamp: lastUpdatedTimestamp,
+        });
       }
 
       // Increment view count
@@ -456,9 +470,9 @@ export default function PublicVault() {
                   <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
                     <Clock className="w-3.5 h-3.5 shrink-0" />
                     <span className="truncate">
-                      {lastUpdatedBy
-                        ? `${lastUpdatedBy.display_name || lastUpdatedBy.username || 'someone'}.last_update() // ${formatTimeAgo(vault.updated_at)}`
-                        : `last_sync() // ${formatTimeAgo(vault.updated_at)}`
+                      {lastUpdatedActivity?.profile
+                        ? `${lastUpdatedActivity.profile.display_name || lastUpdatedActivity.profile.username || 'someone'}.last_update() // ${formatTimeAgo(lastUpdatedActivity.timestamp)}`
+                        : `last_sync() // ${formatTimeAgo(lastUpdatedActivity?.timestamp || vault.updated_at)}`
                       }
                     </span>
                   </span>

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -810,7 +810,17 @@ export default function VaultDetail() {
           // If we have a vault_publication, we need to copy its data directly
           if (vaultPub) {
             // Copy the vault_publication data to the new vault
-            const { id, vault_id, original_publication_id, created_at, updated_at, ...pubData } = vaultPub;
+            const {
+              id,
+              vault_id,
+              original_publication_id,
+              created_at,
+              updated_at,
+              created_by: _createdBy,
+              updated_by: _updatedBy,
+              version: _version,
+              ...pubData
+            } = vaultPub;
             const { error: insertError } = await supabase
               .from('vault_publications')
               .insert({
@@ -819,6 +829,7 @@ export default function VaultDetail() {
                 original_publication_id: original_publication_id || null,
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
+                created_by: user.id,
               });
 
             if (insertError) throw insertError;


### PR DESCRIPTION
## Summary\n- fix last-updated attribution on public vault views to use the actual activity actor and timestamp\n- preserve correct creator attribution when copying publications into another vault\n- avoid carrying stale updater metadata into copied rows\n\n## Why\nThis addresses issue #38, where RefHub sometimes showed the wrong user for the last update.\n\n## Notes\n- public vault UI now falls back more honestly when no actor can be resolved\n- copy flows now set  to the current user instead of leaking prior updater metadata\n\nCloses #38