### PR TITLE
fix: add public/read-only publication view dialog

### DIFF
--- a/src/components/publications/PublicationCard.tsx
+++ b/src/components/publications/PublicationCard.tsx
@@ -37,8 +37,9 @@ interface PublicationCardProps {
   visibleColumns?: VisibleColumns;
   isVaultContext?: boolean; // If true, shows "remove from vault" instead of "delete"
   onToggleSelect: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
+  onOpen?: () => void;
+  primaryActionLabel?: string;
+  onDelete?: () => void;
   onExportBibtex: () => void;
 }
 
@@ -54,7 +55,8 @@ export function PublicationCard({
   visibleColumns,
   isVaultContext = false,
   onToggleSelect,
-  onEdit,
+  onOpen,
+  primaryActionLabel = 'edit',
   onDelete,
   onExportBibtex,
 }: PublicationCardProps) {
@@ -86,13 +88,14 @@ export function PublicationCard({
   return (
     <Card 
       className={cn(
-        "group transition-all duration-300 cursor-pointer border-2",
+        "group transition-all duration-300 border-2",
+        onOpen && "cursor-pointer",
         isSelected 
           ? "border-primary/50 bg-primary/5 shadow-lg glow-purple" 
           : "border-border hover:border-primary/30",
         isFocused && "ring-2 ring-[hsl(var(--cyber-blue))]/50 ring-offset-1 ring-offset-background"
       )}
-      onClick={onEdit}
+      onClick={onOpen}
     >
       <CardContent className="p-5">
         <div className="flex items-start gap-4">
@@ -163,22 +166,28 @@ export function PublicationCard({
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-48">
-                    <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onEdit(); }}>
-                      <Edit className="w-4 h-4 mr-2" />
-                      edit
-                    </DropdownMenuItem>
+                    {onOpen && (
+                      <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onOpen(); }}>
+                        <Edit className="w-4 h-4 mr-2" />
+                        {primaryActionLabel}
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onExportBibtex(); }}>
                       <Download className="w-4 h-4 mr-2" />
                       export bibtex
                     </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem 
-                      onClick={(e) => { e.stopPropagation(); onDelete(); }}
-                      className="text-destructive focus:text-destructive"
-                    >
-                      <Trash2 className="w-4 h-4 mr-2" />
-                      {isVaultContext ? 'remove from vault' : 'delete'}
-                    </DropdownMenuItem>
+                    {onDelete && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem 
+                          onClick={(e) => { e.stopPropagation(); onDelete(); }}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          {isVaultContext ? 'remove from vault' : 'delete'}
+                        </DropdownMenuItem>
+                      </>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -57,6 +57,8 @@ interface PublicationListProps {
   isVaultContext?: boolean; // If true, shows "remove from vault" instead of "delete"
   onAddPublication?: () => void;
   onEditPublication?: (pub: Publication) => void;
+  onOpenPublication?: (pub: Publication) => void;
+  publicationActionLabel?: string;
   onDeletePublication?: (pub: Publication) => void;
   onExportBibtex: (pubs: Publication[]) => void;
   onDiscoverRelated?: (pubs: Publication[]) => void;
@@ -83,6 +85,8 @@ export function PublicationList({
   isVaultContext = false,
   onAddPublication,
   onEditPublication,
+  onOpenPublication,
+  publicationActionLabel = 'edit',
   onDeletePublication,
   onExportBibtex,
   onDiscoverRelated,
@@ -95,6 +99,7 @@ export function PublicationList({
   onDeleteTag,
   onCreateTag,
 }: PublicationListProps) {
+  const openPublication = onOpenPublication || onEditPublication;
   const [searchQuery, setSearchQuery] = useState('');
   const [isTagManagerOpen, setIsTagManagerOpen] = useState(false);
   const [sortDropdownOpen, setSortDropdownOpen] = useState(false);
@@ -231,9 +236,9 @@ export function PublicationList({
   const handleKbOpen = useCallback(
     (id: string) => {
       const pub = filteredPublications.find((p) => p.id === id);
-      if (pub && onEditPublication) onEditPublication(pub);
+      if (pub && openPublication) openPublication(pub);
     },
-    [filteredPublications, onEditPublication],
+    [filteredPublications, openPublication],
   );
 
   const handleKbDelete = useCallback(
@@ -697,7 +702,8 @@ export function PublicationList({
             visibleColumns={visibleColumns}
             isVaultContext={isVaultContext}
             onToggleSelect={toggleSelection}
-            onEdit={onEditPublication}
+            onOpen={openPublication}
+            primaryActionLabel={publicationActionLabel}
             onDelete={onDeletePublication}
             onExportBibtex={(pub) => onExportBibtex([pub])}
             sortBy={sortBy}
@@ -727,8 +733,9 @@ export function PublicationList({
                   visibleColumns={visibleColumns}
                   isVaultContext={isVaultContext}
                   onToggleSelect={() => toggleSelection(pub.id)}
-                  onEdit={() => onEditPublication(pub)}
-                  onDelete={() => onDeletePublication(pub)}
+                  onOpen={openPublication ? () => openPublication(pub) : undefined}
+                  primaryActionLabel={publicationActionLabel}
+                  onDelete={onDeletePublication ? () => onDeletePublication(pub) : undefined}
                   onExportBibtex={() => onExportBibtex([pub])}
                 />
               </div>

--- a/src/components/publications/PublicationTable.tsx
+++ b/src/components/publications/PublicationTable.tsx
@@ -44,8 +44,9 @@ interface PublicationTableProps {
   visibleColumns: VisibleColumns;
   isVaultContext?: boolean; // If true, shows "remove from vault" instead of "delete"
   onToggleSelect: (id: string) => void;
-  onEdit: (pub: Publication) => void;
-  onDelete: (pub: Publication) => void;
+  onOpen?: (pub: Publication) => void;
+  primaryActionLabel?: string;
+  onDelete?: (pub: Publication) => void;
   onExportBibtex: (pub: Publication) => void;
   // Sort props
   sortBy: SortField;
@@ -67,7 +68,8 @@ export function PublicationTable({
   visibleColumns,
   isVaultContext = false,
   onToggleSelect,
-  onEdit,
+  onOpen,
+  primaryActionLabel = 'edit',
   onDelete,
   onExportBibtex,
   sortBy,
@@ -182,11 +184,12 @@ export function PublicationTable({
               <TableRow
                 key={pub.id}
                 className={cn(
-                  'cursor-pointer transition-colors',
+                  'transition-colors',
+                  onOpen && 'cursor-pointer',
                   isSelected && 'bg-primary/5',
                   isFocused && 'ring-2 ring-inset ring-[hsl(var(--cyber-blue))]/50'
                 )}
-                onClick={() => onEdit(pub)}
+                onClick={() => onOpen?.(pub)}
                 {...kbProps}
               >
                 <TableCell onClick={(e) => e.stopPropagation()}>
@@ -359,22 +362,28 @@ export function PublicationTable({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-40">
-                      <DropdownMenuItem onClick={() => onEdit(pub)}>
-                        <Edit className="w-4 h-4 mr-2" />
-                        edit
-                      </DropdownMenuItem>
+                      {onOpen && (
+                        <DropdownMenuItem onClick={() => onOpen(pub)}>
+                          <Edit className="w-4 h-4 mr-2" />
+                          {primaryActionLabel}
+                        </DropdownMenuItem>
+                      )}
                       <DropdownMenuItem onClick={() => onExportBibtex(pub)}>
                         <Download className="w-4 h-4 mr-2" />
                         export bibtex
                       </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onClick={() => onDelete(pub)}
-                        className="text-destructive focus:text-destructive"
-                      >
-                        <Trash2 className="w-4 h-4 mr-2" />
-                        {isVaultContext ? 'remove from vault' : 'delete'}
-                      </DropdownMenuItem>
+                      {onDelete && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => onDelete(pub)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="w-4 h-4 mr-2" />
+                            {isVaultContext ? 'remove from vault' : 'delete'}
+                          </DropdownMenuItem>
+                        </>
+                      )}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </TableCell>

--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -1,0 +1,195 @@
+import { Publication, Tag } from '@/types/database';
+import { formatTimeAgo } from '@/lib/utils';
+import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { HierarchicalTagBadge } from '@/components/tags/HierarchicalTagBadge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ExternalLink, FileText, Pencil } from 'lucide-react';
+
+interface PublicationViewDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  publication: Publication | null;
+  tags: Tag[];
+  allTags: Tag[];
+  onEdit?: (publication: Publication) => void;
+}
+
+const DETAIL_FIELDS: Array<{ key: keyof Publication; label: string }> = [
+  { key: 'journal', label: 'journal' },
+  { key: 'booktitle', label: 'booktitle' },
+  { key: 'publisher', label: 'publisher' },
+  { key: 'institution', label: 'institution' },
+  { key: 'school', label: 'school' },
+  { key: 'organization', label: 'organization' },
+  { key: 'volume', label: 'volume' },
+  { key: 'issue', label: 'issue' },
+  { key: 'pages', label: 'pages' },
+  { key: 'chapter', label: 'chapter' },
+  { key: 'edition', label: 'edition' },
+  { key: 'series', label: 'series' },
+  { key: 'number', label: 'number' },
+  { key: 'type', label: 'type' },
+  { key: 'eid', label: 'eid' },
+  { key: 'isbn', label: 'isbn' },
+  { key: 'issn', label: 'issn' },
+  { key: 'bibtex_key', label: 'bibtex_key' },
+  { key: 'howpublished', label: 'howpublished' },
+];
+
+export function PublicationViewDialog({
+  open,
+  onOpenChange,
+  publication,
+  tags,
+  allTags,
+  onEdit,
+}: PublicationViewDialogProps) {
+  if (!publication) return null;
+
+  const metadata = DETAIL_FIELDS.filter(({ key }) => {
+    const value = publication[key];
+    return Array.isArray(value) ? value.length > 0 : Boolean(value);
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto border-2 bg-card/95 backdrop-blur-xl">
+        <DialogHeader className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {publication.publication_type && (
+              <Badge variant="outline" className="font-mono text-xs">
+                {publication.publication_type}
+              </Badge>
+            )}
+            {publication.year && (
+              <Badge variant="secondary" className="font-mono text-xs">
+                {publication.year}
+              </Badge>
+            )}
+          </div>
+          <DialogTitle className="text-xl sm:text-2xl font-bold leading-tight">
+            {publication.title}
+          </DialogTitle>
+          <DialogDescription className="text-sm font-mono">
+            {publication.authors.length > 0 ? publication.authors.join(', ') : 'unknown author'}
+            {publication.updated_at && ` • updated ${formatTimeAgo(publication.updated_at)}`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {(publication.doi || publication.url || publication.pdf_url) && (
+            <div className="flex flex-wrap gap-2">
+              {publication.doi && (
+                <Button asChild variant="outline" size="sm" className="font-mono">
+                  <a
+                    href={`https://doi.org/${encodeURIComponent(publication.doi)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="w-4 h-4 mr-2" />
+                    doi
+                  </a>
+                </Button>
+              )}
+              {publication.url && (
+                <Button asChild variant="outline" size="sm" className="font-mono">
+                  <a href={publication.url} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="w-4 h-4 mr-2" />
+                    link
+                  </a>
+                </Button>
+              )}
+              {publication.pdf_url && (
+                <Button asChild variant="outline" size="sm" className="font-mono">
+                  <a href={publication.pdf_url} target="_blank" rel="noopener noreferrer">
+                    <FileText className="w-4 h-4 mr-2" />
+                    pdf
+                  </a>
+                </Button>
+              )}
+            </div>
+          )}
+
+          {tags.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold font-mono">tags</h3>
+              <div className="flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <HierarchicalTagBadge
+                    key={tag.id}
+                    tag={tag}
+                    allTags={allTags}
+                    size="sm"
+                    showHierarchy
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {publication.abstract && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold font-mono">abstract</h3>
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap leading-6">
+                {publication.abstract}
+              </p>
+            </section>
+          )}
+
+          {publication.notes && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold font-mono">notes</h3>
+              <div className="rounded-lg border bg-muted/20 p-4">
+                <MarkdownRenderer compact>{publication.notes}</MarkdownRenderer>
+              </div>
+            </section>
+          )}
+
+          {(metadata.length > 0 || publication.editor?.length || publication.keywords?.length) && (
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold font-mono">details</h3>
+              <dl className="grid gap-3 sm:grid-cols-2">
+                {metadata.map(({ key, label }) => (
+                  <div key={key} className="rounded-lg border bg-muted/10 p-3">
+                    <dt className="text-xs font-mono text-muted-foreground">{label}</dt>
+                    <dd className="mt-1 text-sm break-words">{String(publication[key])}</dd>
+                  </div>
+                ))}
+                {publication.editor?.length ? (
+                  <div className="rounded-lg border bg-muted/10 p-3">
+                    <dt className="text-xs font-mono text-muted-foreground">editor</dt>
+                    <dd className="mt-1 text-sm break-words">{publication.editor.join(', ')}</dd>
+                  </div>
+                ) : null}
+                {publication.keywords?.length ? (
+                  <div className="rounded-lg border bg-muted/10 p-3">
+                    <dt className="text-xs font-mono text-muted-foreground">keywords</dt>
+                    <dd className="mt-1 text-sm break-words">{publication.keywords.join(', ')}</dd>
+                  </div>
+                ) : null}
+              </dl>
+            </section>
+          )}
+        </div>
+
+        {onEdit && (
+          <DialogFooter>
+            <Button type="button" className="font-mono" onClick={() => onEdit(publication)}>
+              <Pencil className="w-4 h-4 mr-2" />
+              edit
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -76,6 +76,7 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
   const [copied, setCopied] = useState(false);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
+  const [isForkedVault, setIsForkedVault] = useState(false);
   const slugCheckTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isInitialLoadRef = useRef(true);
   const initialValuesRef = useRef<{ name: string; description: string; color: string; category: string; abstract: string; visibility: VaultVisibility; publicSlug: string } | null>(null);
@@ -239,6 +240,7 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
   useEffect(() => {
     isInitialLoadRef.current = true; // Reset on dialog open
     setHasUnsavedChanges(false); // Reset unsaved changes on dialog open
+    setIsForkedVault(false);
     if (vault) {
       const initialName = vault.name;
       const initialDescription = vault.description || '';
@@ -290,6 +292,36 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
       };
     }
   }, [vault?.id, open, fetchShares]);
+
+  useEffect(() => {
+    if (!vault || !open) {
+      setIsForkedVault(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    supabase
+      .from('vault_forks')
+      .select('id')
+      .eq('forked_vault_id', vault.id)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (!cancelled) {
+          setIsForkedVault(Boolean(data));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [vault, open]);
+
+  useEffect(() => {
+    if (isForkedVault && visibility !== 'public') {
+      setVisibility('public');
+    }
+  }, [isForkedVault, visibility]);
 
   // Track unsaved changes
   useEffect(() => {
@@ -395,8 +427,8 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
         color,
         category: category || null,
         abstract: abstract || null,
-        visibility,
-        public_slug: visibility === 'public' ? (publicSlug || generateSlug(name)) : null,
+        visibility: isForkedVault ? 'public' : visibility,
+        public_slug: (isForkedVault || visibility === 'public') ? (publicSlug || generateSlug(name)) : null,
       });
       setHasUnsavedChanges(false);
       setShowUnsavedDialog(false);
@@ -406,7 +438,7 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
     } finally {
       setSaving(false);
     }
-  }, [name, description, color, category, abstract, visibility, publicSlug, onSave, onOpenChange]);
+  }, [name, description, color, category, abstract, visibility, publicSlug, isForkedVault, onSave, onOpenChange]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -418,8 +450,8 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
         color,
         category: category || null,
         abstract: abstract || null,
-        visibility,
-        public_slug: visibility === 'public' ? (publicSlug || generateSlug(name)) : null,
+        visibility: isForkedVault ? 'public' : visibility,
+        public_slug: (isForkedVault || visibility === 'public') ? (publicSlug || generateSlug(name)) : null,
       });
       setHasUnsavedChanges(false);
       onOpenChange(false);
@@ -695,16 +727,19 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
             <div className="grid grid-cols-3 gap-2">
               {visibilityOptions.map((option) => {
                 const Icon = option.icon;
+                const isDisabled = isForkedVault && option.value !== 'public';
                 return (
                   <button
                     key={option.value}
                     type="button"
-                    onClick={() => setVisibility(option.value)}
+                    onClick={() => !isDisabled && setVisibility(option.value)}
+                    disabled={isDisabled}
                     className={cn(
                       "flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all duration-200",
                       visibility === option.value
                         ? "border-primary bg-primary/10 text-primary"
-                        : "border-border hover:border-primary/50 text-muted-foreground hover:text-foreground"
+                        : "border-border hover:border-primary/50 text-muted-foreground hover:text-foreground",
+                      isDisabled && "cursor-not-allowed opacity-40 hover:border-border hover:text-muted-foreground"
                     )}
                   >
                     <Icon className="w-4 h-4" />
@@ -714,7 +749,9 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
               })}
             </div>
             <p className="text-xs text-muted-foreground">
-              {visibilityOptions.find(o => o.value === visibility)?.description}
+              {isForkedVault
+                ? 'forked_vaults_are_always_public'
+                : visibilityOptions.find(o => o.value === visibility)?.description}
             </p>
           </div>
 

--- a/src/hooks/useVaultFork.ts
+++ b/src/hooks/useVaultFork.ts
@@ -22,7 +22,7 @@ export function useVaultFork() {
 
     try {
       const newVaultId = await forkVaultLib(originalVault.id, user);
-      toast({ title: 'vault forked — find it in your vaults' });
+      toast({ title: 'vault forked — published to your public vaults' });
       return newVaultId;
     } catch (error) {
       toast({

--- a/src/lib/vaultFork.ts
+++ b/src/lib/vaultFork.ts
@@ -10,6 +10,50 @@ export interface VaultForkInfo {
   } | null;
 }
 
+function slugifyVaultName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 50);
+}
+
+async function createUniquePublicSlug(baseName: string): Promise<string> {
+  const baseSlug = slugifyVaultName(baseName) || 'vault-fork';
+
+  for (let suffix = 0; suffix < 50; suffix += 1) {
+    const candidate = suffix === 0 ? baseSlug : `${baseSlug}-${suffix + 1}`;
+    const { data: existingVault, error } = await supabase
+      .from('vaults')
+      .select('id')
+      .eq('public_slug', candidate)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    if (!existingVault) {
+      return candidate;
+    }
+  }
+
+  throw new Error('failed to generate a unique public slug for forked vault');
+}
+
+export function getForkSourceHref(forkedFrom: NonNullable<VaultForkInfo['forkedFrom']>): string {
+  return forkedFrom.public_slug ? `/public/${forkedFrom.public_slug}` : `/vault/${forkedFrom.id}`;
+}
+
+export function getForkSourceLabel(forkedFrom: NonNullable<VaultForkInfo['forkedFrom']>): string {
+  const ownerLabel =
+    forkedFrom.owner?.username ||
+    forkedFrom.owner?.display_name ||
+    'unknown';
+
+  return `<${ownerLabel}:${forkedFrom.name}>`;
+}
+
 /**
  * Fork a public vault: copies the vault row and all vault_publications,
  * records the fork relationship, and returns the new vault id.
@@ -27,7 +71,9 @@ export async function forkVault(originalVaultId: string, user: User): Promise<st
     throw new Error(fetchErr?.message ?? 'vault not found or not public');
   }
 
-  // Create the forked vault (private, no slug)
+  const publicSlug = await createUniquePublicSlug(`${original.name}-fork`);
+
+  // Forked vaults are always public and receive a public slug.
   const { data: newVault, error: vaultErr } = await supabase
     .from('vaults')
     .insert({
@@ -37,8 +83,8 @@ export async function forkVault(originalVaultId: string, user: User): Promise<st
       color: original.color,
       category: original.category,
       abstract: original.abstract,
-      visibility: 'private',
-      public_slug: null,
+      visibility: 'public',
+      public_slug: publicSlug,
     })
     .select('id')
     .single();

--- a/src/pages/PublicVaultSimple.tsx
+++ b/src/pages/PublicVaultSimple.tsx
@@ -9,9 +9,11 @@ import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { useVaultFavorites } from '@/hooks/useVaultFavorites';
 import { useVaultFork } from '@/hooks/useVaultFork';
-import { getVaultForkInfo, VaultForkInfo } from '@/lib/vaultFork';
+import { useVaultAccess } from '@/hooks/useVaultAccess';
+import { getForkSourceHref, getForkSourceLabel, getVaultForkInfo, VaultForkInfo } from '@/lib/vaultFork';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { PublicationList } from '@/components/publications/PublicationList';
+import { PublicationViewDialog } from '@/components/publications/PublicationViewDialog';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { 
@@ -48,6 +50,8 @@ export default function PublicVault() {
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [userVaults, setUserVaults] = useState<Vault[]>([]);
   const [sharedVaults, setSharedVaults] = useState<Vault[]>([]);
+  const [viewingPublication, setViewingPublication] = useState<Publication | null>(null);
+  const { canEdit } = useVaultAccess(vault?.id || '');
 
   // Fetch user's own vaults and shared vaults
   const fetchUserVaults = useCallback(async () => {
@@ -441,16 +445,12 @@ export default function PublicVault() {
                   {forkInfo?.forkedFrom && (
                     <Badge variant="outline" className="gap-1 font-mono text-xs shrink-0 text-muted-foreground">
                       <GitFork className="w-3 h-3" />
-                      {forkInfo.forkedFrom.public_slug ? (
-                        <Link
-                          to={`/public/${forkInfo.forkedFrom.public_slug}`}
-                          className="hover:text-foreground transition-colors"
-                        >
-                          forked_from_{forkInfo.forkedFrom.name.toLowerCase().replace(/\s+/g, '_')}
-                        </Link>
-                      ) : (
-                        <span>forked_from_{forkInfo.forkedFrom.name.toLowerCase().replace(/\s+/g, '_')}</span>
-                      )}
+                      <Link
+                        to={getForkSourceHref(forkInfo.forkedFrom)}
+                        className="hover:text-foreground transition-colors"
+                      >
+                        {getForkSourceLabel(forkInfo.forkedFrom)}
+                      </Link>
                     </Badge>
                   )}
                   <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
@@ -499,7 +499,7 @@ export default function PublicVault() {
                       >
                         <GitFork className="w-4 h-4" />
                         <span className="ml-2 hidden md:inline">
-                          {forking ? 'forking_vault...' : 'fork vault'}
+                          {forking ? 'forking_public_vault...' : 'fork public vault'}
                         </span>
                       </Button>
                     </>
@@ -539,6 +539,8 @@ export default function PublicVault() {
             })()}
             relationsCountMap={{}}
             selectedVault={vault}
+            onOpenPublication={(pub) => setViewingPublication(pub)}
+            publicationActionLabel="view"
             onExportBibtex={(pubs) => {
               if (pubs.length > 0 && vault) {
                 // Increment download count
@@ -550,6 +552,29 @@ export default function PublicVault() {
             onVaultUpdate={() => {}}
           />
         )}
+
+        <PublicationViewDialog
+          open={!!viewingPublication}
+          onOpenChange={(open) => {
+            if (!open) {
+              setViewingPublication(null);
+            }
+          }}
+          publication={viewingPublication}
+          tags={viewingPublication ? tags.filter((tag) => {
+            const publicationTagIds = publicationTags
+              .filter((pt) => (pt.vault_publication_id || pt.publication_id) === viewingPublication.id)
+              .map((pt) => pt.tag_id);
+            return publicationTagIds.includes(tag.id);
+          }) : []}
+          allTags={tags}
+          onEdit={canEdit && vault ? (publication) => {
+            setViewingPublication(null);
+            navigate(`/vault/${vault.id}`, {
+              state: { publicationIdToEdit: publication.id },
+            });
+          } : undefined}
+        />
       </div>
     </div>
   );

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { Link, useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { supabase } from '@/integrations/supabase/client';
@@ -11,6 +11,7 @@ import { hasPageCache } from '@/lib/pageCache';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { PublicationList } from '@/components/publications/PublicationList';
 import { PublicationDialog } from '@/components/publications/PublicationDialog';
+import { PublicationViewDialog } from '@/components/publications/PublicationViewDialog';
 import { VaultAugmentDialog } from '@/components/publications/VaultAugmentDialog';
 import { SSPaper } from '@/lib/semanticScholar';
 import { AddImportDialog } from '@/components/publications/AddImportDialog';
@@ -26,6 +27,7 @@ import { useVaultFavorites } from '@/hooks/useVaultFavorites';
 import { useVaultFork } from '@/hooks/useVaultFork';
 import { useVaultContent } from '@/contexts/VaultContentContext';
 import { useSharedVaultOperations } from '@/hooks/useSharedVaultOperations';
+import { getForkSourceHref, getForkSourceLabel, getVaultForkInfo, VaultForkInfo } from '@/lib/vaultFork';
 import { Lock, Globe, Shield, Users, Clock, User, ExternalLink, Sparkles, Crown, Edit, Eye, Heart, GitFork } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -44,6 +46,7 @@ import {
 
 export default function VaultDetail() {
   const { id: vaultId } = useParams<{ id: string }>();
+  const location = useLocation();
   const { user, loading: authLoading } = useAuth();
   const { profile } = useProfile();
   
@@ -104,6 +107,7 @@ export default function VaultDetail() {
   const [favoritesCount, setFavoritesCount] = useState(0);
   const [forkCount, setForkCount] = useState(0);
   const [vaultOwner, setVaultOwner] = useState<{ display_name: string | null; username: string | null } | null>(null);
+  const [forkInfo, setForkInfo] = useState<VaultForkInfo | null>(null);
 
   // Loading phases for the vault loader
   const [loadingPhases, setLoadingPhases] = useState<LoadingPhase[]>([
@@ -138,6 +142,7 @@ export default function VaultDetail() {
   const [isAugmentDialogOpen, setIsAugmentDialogOpen] = useState(false);
   const [augmentPublications, setAugmentPublications] = useState<Publication[]>([]);
   const [editingPublication, setEditingPublication] = useState<Publication | null>(null);
+  const [viewingPublication, setViewingPublication] = useState<Publication | null>(null);
   const currentlyEditingPublicationId = useRef<string | null>(null);
 
   const [isVaultDialogOpen, setIsVaultDialogOpen] = useState(false);
@@ -249,6 +254,19 @@ export default function VaultDetail() {
       }
     }
   }, [publications, editingPublication]);
+
+  useEffect(() => {
+    const publicationIdToEdit = (location.state as { publicationIdToEdit?: string } | null)?.publicationIdToEdit;
+    if (!publicationIdToEdit || !canEdit) return;
+
+    const publicationToEdit = publications.find((publication) => publication.id === publicationIdToEdit);
+    if (!publicationToEdit) return;
+
+    setEditingPublication(publicationToEdit);
+    currentlyEditingPublicationId.current = publicationToEdit.id;
+    setIsPublicationDialogOpen(true);
+    navigate(`/vault/${vaultId}`, { replace: true });
+  }, [location.state, canEdit, publications, navigate, vaultId]);
 
   // Fetch user's vaults and shared vaults separately
   const fetchUserVaults = useCallback(async () => {
@@ -1124,14 +1142,13 @@ export default function VaultDetail() {
     
     setForking(true);
     try {
-      const newVault = await forkVault(currentVault);
-
-      if (newVault) {
+      const newVaultId = await forkVault(currentVault);
+      if (newVaultId) {
         toast({
           title: 'vault_forked 🍴',
-          description: 'Successfully forked vault!',
+          description: 'Successfully forked vault as a public vault.',
         });
-        navigate(`/vault/${newVault.id}`);
+        navigate(`/vault/${newVaultId}`);
       }
     } finally {
       setForking(false);
@@ -1187,6 +1204,15 @@ export default function VaultDetail() {
     setExportPublications(pubs);
     setIsExportDialogOpen(true);
   };
+
+  useEffect(() => {
+    if (!vaultId) {
+      setForkInfo(null);
+      return;
+    }
+
+    getVaultForkInfo(vaultId).then(setForkInfo).catch(() => setForkInfo(null));
+  }, [vaultId]);
 
   // State to track loading state to prevent flickering
   const [hasStartedInitialLoad, setHasStartedInitialLoad] = useState(false);
@@ -1471,6 +1497,14 @@ export default function VaultDetail() {
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2 min-w-0 flex-wrap">
                 {visibilityBadge}
+                {forkInfo?.forkedFrom && (
+                  <Badge variant="outline" className="font-mono text-xs gap-1 shrink-0 text-muted-foreground">
+                    <GitFork className="w-3 h-3" />
+                    <Link to={getForkSourceHref(forkInfo.forkedFrom)} className="hover:text-foreground transition-colors">
+                      {getForkSourceLabel(forkInfo.forkedFrom)}
+                    </Link>
+                  </Badge>
+                )}
                 {userRole === 'owner' && (
                   <Badge variant="outline" className="font-mono text-xs gap-1 shrink-0">
                     <Crown className="w-3 h-3" />
@@ -1559,6 +1593,10 @@ export default function VaultDetail() {
           selectedVault={currentVault}
           isVaultContext={true}
           onAddPublication={canEdit ? () => setIsImportDialogOpen(true) : undefined}
+          onOpenPublication={!canEdit ? (pub) => {
+            setViewingPublication(pub);
+          } : undefined}
+          publicationActionLabel={!canEdit ? 'view' : 'edit'}
           onEditPublication={canEdit ? (pub) => {
             setEditingPublication(pub);
             currentlyEditingPublicationId.current = pub.id;
@@ -1607,6 +1645,18 @@ export default function VaultDetail() {
         onAddToVaults={canEdit ? handleAddToVaults : undefined}
       />
 
+      <PublicationViewDialog
+        open={!!viewingPublication}
+        onOpenChange={(open) => {
+          if (!open) {
+            setViewingPublication(null);
+          }
+        }}
+        publication={viewingPublication}
+        tags={viewingPublication ? tags.filter((tag) => (publicationTagsMap[viewingPublication.id] || []).includes(tag.id)) : []}
+        allTags={tags}
+      />
+
       <VaultAugmentDialog
         open={isAugmentDialogOpen}
         onOpenChange={setIsAugmentDialogOpen}
@@ -1653,8 +1703,13 @@ export default function VaultDetail() {
         tags={tags}
         publicationTags={publicationTags}
         onSelectPublication={(pub) => {
-          setEditingPublication(pub);
-          setIsPublicationDialogOpen(true);
+          if (canEdit) {
+            setEditingPublication(pub);
+            currentlyEditingPublicationId.current = pub.id;
+            setIsPublicationDialogOpen(true);
+            return;
+          }
+          setViewingPublication(pub);
         }}
       />
 

--- a/supabase/migrations/20260327155000_force_forked_vaults_public.sql
+++ b/supabase/migrations/20260327155000_force_forked_vaults_public.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION public.enforce_forked_vaults_public()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.vault_forks vf
+    WHERE vf.forked_vault_id = NEW.id
+  ) AND NEW.visibility <> 'public' THEN
+    RAISE EXCEPTION 'forked vaults must remain public';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_forked_vaults_public ON public.vaults;
+
+CREATE TRIGGER enforce_forked_vaults_public
+BEFORE UPDATE ON public.vaults
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_forked_vaults_public();


### PR DESCRIPTION
## Summary
- add a dedicated read-only publication view dialog for public/read-only vault access
- wire publication clicks in public and viewer contexts to open the view dialog instead of dead-ending on the edit flow
- add an edit handoff from the public dialog for users who can edit the vault, reusing the existing vault edit dialog flow

## Verification
- npx tsc --noEmit
- npm run lint -- --no-cache src/components/publications/PublicationCard.tsx src/components/publications/PublicationList.tsx src/components/publications/PublicationTable.tsx src/components/publications/PublicationViewDialog.tsx src/pages/PublicVaultSimple.tsx src/pages/VaultDetail.tsx  # repo has pre-existing unrelated lint errors