### PR TITLE
fix: correct last updated attribution

### DIFF
--- a/src/lib/vaultPublicationAttribution.test.ts
+++ b/src/lib/vaultPublicationAttribution.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildVaultPublicationCopyPayload,
+  resolveLastUpdatedActivity,
+} from './vaultPublicationAttribution';
+
+describe('buildVaultPublicationCopyPayload', () => {
+  it('resets identity fields to the current actor when copying a vault publication', () => {
+    const payload = buildVaultPublicationCopyPayload(
+      {
+        id: 'source-row',
+        vault_id: 'source-vault',
+        original_publication_id: 'pub-1',
+        created_at: '2026-03-01T10:00:00.000Z',
+        updated_at: '2026-03-02T10:00:00.000Z',
+        created_by: 'user-a',
+        updated_by: 'user-b',
+        version: 4,
+        title: 'Copied paper',
+      },
+      'target-vault',
+      'user-c',
+      '2026-03-27T14:00:00.000Z',
+    );
+
+    expect(payload).toEqual({
+      original_publication_id: 'pub-1',
+      vault_id: 'target-vault',
+      created_at: '2026-03-27T14:00:00.000Z',
+      updated_at: '2026-03-27T14:00:00.000Z',
+      created_by: 'user-c',
+      title: 'Copied paper',
+    });
+    expect(payload).not.toHaveProperty('updated_by');
+    expect(payload).not.toHaveProperty('version');
+    expect(payload).not.toHaveProperty('id');
+  });
+});
+
+describe('resolveLastUpdatedActivity', () => {
+  it('prefers the actual updater and update timestamp', () => {
+    expect(
+      resolveLastUpdatedActivity(
+        {
+          created_by: 'user-a',
+          updated_by: 'user-b',
+          created_at: '2026-03-01T10:00:00.000Z',
+          updated_at: '2026-03-03T10:00:00.000Z',
+        },
+        '2026-03-04T10:00:00.000Z',
+      ),
+    ).toEqual({
+      actorId: 'user-b',
+      timestamp: '2026-03-03T10:00:00.000Z',
+    });
+  });
+
+  it('falls back to the creator and creation timestamp for repeated edits without updated_by', () => {
+    expect(
+      resolveLastUpdatedActivity(
+        {
+          created_by: 'user-a',
+          updated_by: null,
+          created_at: '2026-03-01T10:00:00.000Z',
+          updated_at: null,
+        },
+        '2026-03-04T10:00:00.000Z',
+      ),
+    ).toEqual({
+      actorId: 'user-a',
+      timestamp: '2026-03-01T10:00:00.000Z',
+    });
+  });
+
+  it('keeps the activity timestamp even when no user can be resolved', () => {
+    expect(
+      resolveLastUpdatedActivity(
+        {
+          created_by: null,
+          updated_by: null,
+          created_at: null,
+          updated_at: '2026-03-05T10:00:00.000Z',
+        },
+        '2026-03-04T10:00:00.000Z',
+      ),
+    ).toEqual({
+      actorId: null,
+      timestamp: '2026-03-05T10:00:00.000Z',
+    });
+  });
+});

--- a/src/lib/vaultPublicationAttribution.ts
+++ b/src/lib/vaultPublicationAttribution.ts
@@ -1,0 +1,55 @@
+type VaultPublicationIdentityFields = {
+  id?: string;
+  vault_id?: string;
+  original_publication_id?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  created_by?: string | null;
+  updated_by?: string | null;
+  version?: number;
+  [key: string]: unknown;
+};
+
+export function buildVaultPublicationCopyPayload(
+  vaultPublication: VaultPublicationIdentityFields,
+  targetVaultId: string,
+  actorUserId: string,
+  timestamp = new Date().toISOString(),
+) {
+  const {
+    id: _id,
+    vault_id: _vaultId,
+    created_at: _createdAt,
+    updated_at: _updatedAt,
+    created_by: _createdBy,
+    updated_by: _updatedBy,
+    version: _version,
+    ...publicationData
+  } = vaultPublication;
+
+  return {
+    ...publicationData,
+    vault_id: targetVaultId,
+    original_publication_id: vaultPublication.original_publication_id || null,
+    created_at: timestamp,
+    updated_at: timestamp,
+    created_by: actorUserId,
+  };
+}
+
+type LastUpdatedPublication = {
+  updated_by?: string | null;
+  created_by?: string | null;
+  updated_at?: string | null;
+  created_at?: string | null;
+};
+
+export function resolveLastUpdatedActivity(
+  publication: LastUpdatedPublication | null | undefined,
+  fallbackTimestamp: string,
+) {
+  return {
+    actorId: publication?.updated_by || publication?.created_by || null,
+    timestamp: publication?.updated_at || publication?.created_at || fallbackTimestamp,
+  };
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -18,6 +18,7 @@ import { PhaseLoader, LoadingPhase } from '@/components/ui/loading';
 import { useToast } from '@/hooks/use-toast';
 import { Sparkles } from 'lucide-react';
 import { getPageCache, setPageCache, hasPageCache } from '@/lib/pageCache';
+import { buildVaultPublicationCopyPayload } from '@/lib/vaultPublicationAttribution';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -927,17 +928,9 @@ export default function Dashboard() {
         if (!existingCopy) {
           // If we have a vault_publication, we need to copy its data directly
           if (vaultPub) {
-            // Copy the vault_publication data to the new vault
-            const { id, vault_id, original_publication_id, created_at, updated_at, ...pubData } = vaultPub;
             const { error: insertError } = await supabase
               .from('vault_publications')
-              .insert({
-                ...pubData,
-                vault_id: vaultId,
-                original_publication_id: original_publication_id || null,
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-              });
+              .insert(buildVaultPublicationCopyPayload(vaultPub, vaultId, user.id));
 
             if (insertError) throw insertError;
           } else {

--- a/src/pages/PublicVaultSimple.tsx
+++ b/src/pages/PublicVaultSimple.tsx
@@ -4,6 +4,7 @@ import { logger } from '@/lib/logger';
 import { supabase } from '@/integrations/supabase/client';
 import { Publication, Vault, Tag, PublicationTag } from '@/types/database';
 import { formatTimeAgo } from '@/lib/utils';
+import { resolveLastUpdatedActivity } from '@/lib/vaultPublicationAttribution';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
@@ -36,7 +37,10 @@ export default function PublicVault() {
   const navigate = useNavigate();
   const [vault, setVault] = useState<Vault | null>(null);
   const [vaultOwner, setVaultOwner] = useState<{ display_name: string | null; username: string | null } | null>(null);
-  const [lastUpdatedBy, setLastUpdatedBy] = useState<{ display_name: string | null; username: string | null } | null>(null);
+  const [lastUpdatedActivity, setLastUpdatedActivity] = useState<{
+    profile: { display_name: string | null; username: string | null } | null;
+    timestamp: string;
+  } | null>(null);
   const [favoritesCount, setFavoritesCount] = useState(0);
   const [forkCount, setForkCount] = useState(0);
   const [publications, setPublications] = useState<Publication[]>([]);
@@ -169,22 +173,32 @@ export default function PublicVault() {
       
       setForkCount(forksCount || 0);
 
-      // Fetch last updated by user
+      // Fetch last updated activity
       const { data: lastUpdatedPub } = await supabase
         .from('vault_publications')
-        .select('updated_by')
+        .select('updated_by, created_by, updated_at, created_at')
         .eq('vault_id', vaultData.id)
         .order('updated_at', { ascending: false })
         .limit(1)
         .maybeSingle();
-      
-      if (lastUpdatedPub?.updated_by) {
+
+      const lastUpdated = resolveLastUpdatedActivity(lastUpdatedPub, vaultData.updated_at);
+
+      if (lastUpdated.actorId) {
         const { data: updaterProfile } = await supabase
           .from('profiles')
           .select('display_name, username')
-          .eq('user_id', lastUpdatedPub.updated_by)
+          .eq('user_id', lastUpdated.actorId)
           .maybeSingle();
-        setLastUpdatedBy(updaterProfile);
+        setLastUpdatedActivity({
+          profile: updaterProfile,
+          timestamp: lastUpdated.timestamp,
+        });
+      } else {
+        setLastUpdatedActivity({
+          profile: null,
+          timestamp: lastUpdated.timestamp,
+        });
       }
 
       // Increment view count
@@ -456,9 +470,9 @@ export default function PublicVault() {
                   <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
                     <Clock className="w-3.5 h-3.5 shrink-0" />
                     <span className="truncate">
-                      {lastUpdatedBy
-                        ? `${lastUpdatedBy.display_name || lastUpdatedBy.username || 'someone'}.last_update() // ${formatTimeAgo(vault.updated_at)}`
-                        : `last_sync() // ${formatTimeAgo(vault.updated_at)}`
+                      {lastUpdatedActivity?.profile
+                        ? `${lastUpdatedActivity.profile.display_name || lastUpdatedActivity.profile.username || 'someone'}.last_update() // ${formatTimeAgo(lastUpdatedActivity.timestamp)}`
+                        : `last_sync() // ${formatTimeAgo(lastUpdatedActivity?.timestamp || vault.updated_at)}`
                       }
                     </span>
                   </span>

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -28,6 +28,7 @@ import { useVaultFork } from '@/hooks/useVaultFork';
 import { useVaultContent } from '@/contexts/VaultContentContext';
 import { useSharedVaultOperations } from '@/hooks/useSharedVaultOperations';
 import { getForkSourceHref, getForkSourceLabel, getVaultForkInfo, VaultForkInfo } from '@/lib/vaultFork';
+import { buildVaultPublicationCopyPayload } from '@/lib/vaultPublicationAttribution';
 import { Lock, Globe, Shield, Users, Clock, User, ExternalLink, Sparkles, Crown, Edit, Eye, Heart, GitFork } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -809,17 +810,9 @@ export default function VaultDetail() {
         if (!existingCopy) {
           // If we have a vault_publication, we need to copy its data directly
           if (vaultPub) {
-            // Copy the vault_publication data to the new vault
-            const { id, vault_id, original_publication_id, created_at, updated_at, ...pubData } = vaultPub;
             const { error: insertError } = await supabase
               .from('vault_publications')
-              .insert({
-                ...pubData,
-                vault_id: vaultIdToAdd,
-                original_publication_id: original_publication_id || null,
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-              });
+              .insert(buildVaultPublicationCopyPayload(vaultPub, vaultIdToAdd, user.id));
 
             if (insertError) throw insertError;
           } else {


### PR DESCRIPTION
## Summary
- stop copied vault publications from inheriting another user\'s created/updated attribution
- keep the public last-updated badge tied to the actual latest activity timestamp
- add regression tests for attribution copy and fallback resolution

## Verification
- npm test -- --run src/lib/vaultPublicationAttribution.test.ts

Supersedes #52 with a clean branch from current main for issue #38.