### PR TITLE
fix: refine public vault fork UI

### DIFF
--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -62,7 +62,7 @@ export function PublicationViewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto border-2 bg-card/95 backdrop-blur-xl">
+      <DialogContent className="w-[calc(100vw-2rem)] sm:w-full sm:max-w-3xl max-h-[90vh] overflow-y-auto border-2 bg-card/95 backdrop-blur-xl">
         <DialogHeader className="space-y-3">
           <div className="flex flex-wrap items-center gap-2">
             {publication.publication_type && (

--- a/src/lib/vaultFork.ts
+++ b/src/lib/vaultFork.ts
@@ -51,7 +51,7 @@ export function getForkSourceLabel(forkedFrom: NonNullable<VaultForkInfo['forked
     forkedFrom.owner?.display_name ||
     'unknown';
 
-  return `<${ownerLabel}:${forkedFrom.name}>`;
+  return `${ownerLabel}:${forkedFrom.name}`;
 }
 
 /**

--- a/src/pages/PublicVaultSimple.tsx
+++ b/src/pages/PublicVaultSimple.tsx
@@ -513,7 +513,7 @@ export default function PublicVault() {
                       >
                         <GitFork className="w-4 h-4" />
                         <span className="ml-2 hidden md:inline">
-                          {forking ? 'forking_public_vault...' : 'fork public vault'}
+                          {forking ? 'forking...' : 'fork'}
                         </span>
                       </Button>
                     </>

--- a/src/pages/TheCodex.tsx
+++ b/src/pages/TheCodex.tsx
@@ -46,6 +46,7 @@ interface CodexVault extends Vault {
   stats?: VaultStats;
   favorites_count?: number;
   fork_count?: number;
+  is_fork?: boolean;
   owner?: {
     display_name: string | null;
     email: string | null;
@@ -95,12 +96,21 @@ export default function TheCodex() {
         return;
       }
 
+      const vaultIds = vaultsData.map((vault) => vault.id);
+      const { data: forkedVaultRows } = vaultIds.length === 0
+        ? { data: [] }
+        : await supabase
+            .from('vault_forks')
+            .select('forked_vault_id')
+            .in('forked_vault_id', vaultIds);
+      const forkedVaultIds = new Set((forkedVaultRows || []).map((row) => row.forked_vault_id));
+
       // Fetch additional data for each vault
       const vaultsWithData = await Promise.all(
         vaultsData.map(async (vault) => {
-          // Get publication count via vault_papers
+          // Count directly from vault_publications so originals and forks stay accurate.
           const { count } = await supabase
-            .from('vault_papers')
+            .from('vault_publications')
             .select('*', { count: 'exact', head: true })
             .eq('vault_id', vault.id);
 
@@ -136,6 +146,7 @@ export default function TheCodex() {
             stats: statsData as VaultStats | undefined,
             favorites_count: favoritesCount || 0,
             fork_count: forkCount || 0,
+            is_fork: forkedVaultIds.has(vault.id),
             owner: profileData || undefined,
           } as CodexVault;
         })
@@ -446,7 +457,7 @@ export default function TheCodex() {
                   to={`/public/${vault.public_slug}`}
                   className="group"
                 >
-                  <article className="h-full p-6 rounded-2xl border-2 border-border bg-card/50 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 transition-all duration-300 flex flex-col">
+                  <article className={`h-full p-6 rounded-2xl border-2 bg-card/50 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 transition-all duration-300 flex flex-col ${vault.is_fork ? 'border-amber-500/30 bg-amber-500/[0.03]' : 'border-border'}`}>
                     {/* Header with owner info */}
                     <div className="flex items-start gap-3 mb-4">
                       <Avatar className="w-10 h-10 border-2 border-border ring-2 ring-background group-hover:ring-primary/20 transition-all">
@@ -481,11 +492,18 @@ export default function TheCodex() {
                     </div>
 
                     {/* Category Badge */}
-                    {vault.category && (
-                      <Badge variant="secondary" className="w-fit mb-3 text-xs font-mono">
-                        {vault.category.toLowerCase().replace(/\s+/g, '_')}
-                      </Badge>
-                    )}
+                    <div className="mb-3 flex flex-wrap gap-2">
+                      {vault.is_fork && (
+                        <Badge variant="outline" className="w-fit text-xs font-mono border-amber-500/30 text-amber-600">
+                          forked
+                        </Badge>
+                      )}
+                      {vault.category && (
+                        <Badge variant="secondary" className="w-fit text-xs font-mono">
+                          {vault.category.toLowerCase().replace(/\s+/g, '_')}
+                        </Badge>
+                      )}
+                    </div>
 
                     {/* Description/Abstract */}
                     {(vault.abstract || vault.description) && (

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -14,7 +14,7 @@ import { Loader } from '@/components/ui/loader';
 import { logger } from '@/lib/logger';
 import { Github, Linkedin, ArrowLeft, BookOpen, Vault as VaultIcon, ExternalLink, Globe } from 'lucide-react';
 
-type VaultWithCount = Vault & { vault_publications: { id: string }[] };
+type VaultWithCount = Vault & { vault_publications: { id: string }[]; is_fork?: boolean };
 
 function getInitials(p: Profile): string {
   if (p.display_name) {
@@ -89,7 +89,25 @@ export default function UserProfile() {
         .order('created_at', { ascending: false });
 
       if (vaultsError) throw vaultsError;
-      setPublicVaults((vaultsData ?? []) as VaultWithCount[]);
+
+      const fetchedVaults = (vaultsData ?? []) as VaultWithCount[];
+      const vaultIds = fetchedVaults.map((vault) => vault.id);
+      const { data: forkedVaultRows, error: forkedVaultsError } = vaultIds.length === 0
+        ? { data: [], error: null }
+        : await supabase
+            .from('vault_forks')
+            .select('forked_vault_id')
+            .in('forked_vault_id', vaultIds);
+
+      if (forkedVaultsError) throw forkedVaultsError;
+
+      const forkedVaultIds = new Set((forkedVaultRows ?? []).map((row) => row.forked_vault_id));
+      setPublicVaults(
+        fetchedVaults.map((vault) => ({
+          ...vault,
+          is_fork: forkedVaultIds.has(vault.id),
+        })),
+      );
     } catch (err) {
       logger.error('UserProfile', 'Error fetching profile data:', err);
       setNotFound(true);
@@ -302,7 +320,7 @@ export default function UserProfile() {
                       {publicVaults.map((vault) => (
                         <div
                           key={vault.id}
-                          className="group rounded-xl border-2 border-border bg-card/60 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 transition-all duration-200 overflow-hidden"
+                          className={`group rounded-xl border-2 bg-card/60 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 transition-all duration-200 overflow-hidden ${vault.is_fork ? 'border-amber-500/30 bg-amber-500/[0.03]' : 'border-border'}`}
                         >
                           {/* Color accent bar */}
                           <div
@@ -315,11 +333,18 @@ export default function UserProfile() {
                               <h3 className="font-bold font-mono truncate group-hover:text-primary transition-colors">
                                 {vault.name}
                               </h3>
-                              {vault.category && (
-                                <Badge variant="outline" className="font-mono text-[10px] shrink-0">
-                                  {vault.category}
-                                </Badge>
-                              )}
+                              <div className="flex flex-wrap justify-end gap-2 shrink-0">
+                                {vault.is_fork && (
+                                  <Badge variant="outline" className="font-mono text-[10px] border-amber-500/30 text-amber-600">
+                                    forked
+                                  </Badge>
+                                )}
+                                {vault.category && (
+                                  <Badge variant="outline" className="font-mono text-[10px] shrink-0">
+                                    {vault.category}
+                                  </Badge>
+                                )}
+                              </div>
                             </div>
 
                             {(vault.description ?? vault.abstract) && (


### PR DESCRIPTION
## Summary
- align the read-only publication dialog width with other dialogs so it no longer sits flush to the viewport edge
- rename the public vault fork CTA to just `fork` and simplify fork provenance labels to `userName:vaultName`
- distinguish forked public vault cards from originals and count papers from `vault_publications` so public cards report the correct totals

## Testing
- npm run build
- npm run test
- npx eslint src/components/publications/PublicationViewDialog.tsx src/lib/vaultFork.ts src/pages/PublicVaultSimple.tsx src/pages/TheCodex.tsx src/pages/UserProfile.tsx

## Notes
- `npm run lint` still reports pre-existing repo-wide ESLint issues unrelated to this change set