### PR TITLE
fix: align publication dialog spacing and table open behavior

### DIFF
--- a/src/components/publications/PublicationTable.tsx
+++ b/src/components/publications/PublicationTable.tsx
@@ -179,6 +179,11 @@ export function PublicationTable({
             const isFocused = focusedIndex === index;
             const relCount = relationsCountMap[pub.id] || 0;
             const kbProps = kbItemProps ? kbItemProps(index, pub.id) : {};
+            const {
+              onClick: kbOnClick,
+              onDoubleClick: kbOnDoubleClick,
+              ...rowKbProps
+            } = kbProps;
 
             return (
               <TableRow
@@ -189,8 +194,16 @@ export function PublicationTable({
                   isSelected && 'bg-primary/5',
                   isFocused && 'ring-2 ring-inset ring-[hsl(var(--cyber-blue))]/50'
                 )}
-                onClick={() => onOpen?.(pub)}
-                {...kbProps}
+                onClick={(e) => {
+                  kbOnClick?.(e);
+                  if (!e.defaultPrevented && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
+                    onOpen?.(pub);
+                  }
+                }}
+                onDoubleClick={(e) => {
+                  kbOnDoubleClick?.(e);
+                }}
+                {...rowKbProps}
               >
                 <TableCell onClick={(e) => e.stopPropagation()}>
                   <Checkbox

--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -62,7 +62,7 @@ export function PublicationViewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[calc(100vw-2rem)] sm:w-full sm:max-w-3xl max-h-[90vh] overflow-y-auto border-2 bg-card/95 backdrop-blur-xl">
+      <DialogContent className="publication-view-dialog w-[min(calc(100vw-2rem),48rem)] max-w-[calc(100vw-2rem)] rounded-2xl border-2 bg-card/95 backdrop-blur-xl max-h-[min(90vh,56rem)] overflow-y-auto shadow-2xl sm:max-w-3xl">
         <DialogHeader className="space-y-3">
           <div className="flex flex-wrap items-center gap-2">
             {publication.publication_type && (

--- a/src/index.css
+++ b/src/index.css
@@ -306,6 +306,20 @@
       border-radius: 0 !important;
       transform: none !important;
     }
+
+    .publication-view-dialog[role="dialog"] {
+      top: 50% !important;
+      left: 50% !important;
+      right: auto !important;
+      bottom: auto !important;
+      width: calc(100vw - 1.5rem) !important;
+      height: auto !important;
+      max-width: calc(100vw - 1.5rem) !important;
+      max-height: calc(100vh - 1.5rem) !important;
+      margin: 0 !important;
+      border-radius: 1rem !important;
+      transform: translate(-50%, -50%) !important;
+    }
     
     /* Force inputs to fit and break text */
     [role="dialog"] input,


### PR DESCRIPTION
## Summary\n- keep the publication view dialog inset from the viewport instead of flush to the window edge\n- restore modal-style spacing for that dialog on small screens\n- make publication table rows open on single click like publication cards\n\n## Testing\n- not run here\n- checked diffs and handler wiring manually