### PR TITLE
fix: enrich related paper metadata rendering

### DIFF
--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -102,18 +102,40 @@ function PaperRow({
         </div>
       </div>
 
-      {/* Authors + year */}
-      <p className="text-sm text-muted-foreground font-mono">
-        {formatAuthors(paper.authors)}
-        {paper.year && <span className="text-neon-green"> • {paper.year}</span>}
-      </p>
-
-      {/* Abstract snippet */}
-      {paper.abstract && (
-        <p className="text-sm text-muted-foreground/70 leading-relaxed line-clamp-2">
-          {paper.abstract}
+      {/* Authors + year + venue */}
+      <div className="space-y-1">
+        <p className="text-sm text-muted-foreground font-mono">
+          {formatAuthors(paper.authors)}
+          {paper.year && <span className="text-neon-green"> • {paper.year}</span>}
         </p>
-      )}
+        {paper.venue && (
+          <p className="text-xs text-muted-foreground/80 font-mono line-clamp-1">
+            {paper.venue}
+          </p>
+        )}
+      </div>
+
+      {/* DOI + abstract snippet */}
+      <div className="space-y-1.5">
+        {paper.externalIds?.DOI && (
+          <a
+            href={`https://doi.org/${paper.externalIds.DOI}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="inline-flex max-w-full items-center gap-1 text-xs font-mono text-cyber-blue hover:text-cyber-blue/80 transition-colors"
+          >
+            <ExternalLink className="w-3 h-3 shrink-0" />
+            <span className="truncate">{paper.externalIds.DOI}</span>
+          </a>
+        )}
+
+        {paper.abstract && (
+          <p className="text-sm text-muted-foreground/70 leading-relaxed line-clamp-2">
+            {paper.abstract}
+          </p>
+        )}
+      </div>
 
       {/* Footer: citations + source link */}
       <div className="flex items-center gap-3 pt-1">

--- a/src/lib/semanticScholar.ts
+++ b/src/lib/semanticScholar.ts
@@ -6,10 +6,12 @@ export interface SSPaper {
   title: string;
   authors: { name: string }[];
   year: number | null;
+  venue: string | null;
   citationCount: number | null;
   externalIds: { DOI?: string } | null;
   abstract: string | null;
   url: string | null;
+  openAccessPdfUrl: string | null;
 }
 
 interface BackendPaperAuthor {
@@ -24,12 +26,15 @@ interface BackendPaper {
   title?: string | null;
   authors?: BackendPaperAuthor[] | null;
   year?: number | null;
+  venue?: string | null;
   citation_count?: number | null;
   citationCount?: number | null;
   external_ids?: { DOI?: string | null } | null;
   externalIds?: { DOI?: string | null } | null;
   abstract?: string | null;
   url?: string | null;
+  open_access_pdf_url?: string | null;
+  openAccessPdfUrl?: string | null;
 }
 
 // In-memory cache keyed by cache key
@@ -54,6 +59,7 @@ function normalizePaper(record: BackendPaper): SSPaper | null {
           .filter((author) => author.name.length > 0)
       : [],
     year: typeof record.year === 'number' ? record.year : null,
+    venue: record.venue?.trim() || null,
     citationCount:
       typeof record.citation_count === 'number'
         ? record.citation_count
@@ -68,6 +74,7 @@ function normalizePaper(record: BackendPaper): SSPaper | null {
         : null,
     abstract: record.abstract ?? null,
     url: record.url ?? null,
+    openAccessPdfUrl: record.open_access_pdf_url ?? record.openAccessPdfUrl ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary\n- normalize additional backend recommendation fields in the frontend client\n- show venue and DOI when available in the related papers list\n- keep related results visually aligned with the richer references/citations presentation\n\n## Testing\n- not run here\n- checked diffs and normalization path manually