### PR TITLE
fix: constrain mobile add/import dialog width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/AddImportDialog.tsx
+++ b/src/components/publications/AddImportDialog.tsx
@@ -297,7 +297,7 @@ export function AddImportDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent forceMount className="w-full max-w-[100vw] h-full sm:h-auto sm:w-[95vw] sm:max-w-4xl sm:max-h-[90vh] p-0 border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col data-[state=closed]:hidden">
+      <DialogContent forceMount className="h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-h-[calc(100dvh-1rem)] max-w-[calc(100vw-1rem)] p-0 border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col rounded-lg sm:h-auto sm:w-[95vw] sm:max-w-4xl sm:max-h-[90vh] data-[state=closed]:hidden">
         <DialogHeader className="p-4 sm:p-6 pb-0">
           <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">
             // add_<span className="text-gradient">papers</span>


### PR DESCRIPTION
## Summary
- add a small mobile viewport inset to the add/import dialog so it no longer clips horizontally on small screens
- keep the desktop sizing behavior unchanged
- bump the app version to 1.3.1

## Verification
- 
- 
/opt/openclaw/projects/r2d2/refhub/src/components/publications/AddImportDialog.tsx
  235:59  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 1 problem (1 error, 0 warnings) *(fails on a pre-existing  at line 235, outside this change)*