### PR TITLE
fix: wrap /profile-edit in AuthWrapper to prevent unauthenticated access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import OpenGraphPreview from "./pages/OpenGraphPreview";
 import Users from "./pages/Users";
 import UserProfile from "./pages/UserProfile";
 import ProfileEdit from "./pages/ProfileEdit";
+import AuthWrapper from "@/components/layout/AuthWrapper";
 import SignupNextSteps from "./pages/SignupNextSteps";
 import ResetPassword from "./pages/ResetPassword";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
@@ -69,7 +70,7 @@ const App = () => {
                   <Route path="/public/:slug" element={<PublicVault />} />
                   <Route path="/vault/:id" element={<VaultDetail />} />
                   <Route path="/opengraphpreview" element={<OpenGraphPreview />} />
-                  <Route path="/profile-edit" element={<ProfileEdit />} />
+                  <Route path="/profile-edit" element={<AuthWrapper><ProfileEdit /></AuthWrapper>} />
                   <Route path="/signup-next-steps" element={<SignupNextSteps />} />
                   <Route path="/reset-password" element={<ResetPassword />} />
                   <Route path="/privacy" element={<PrivacyPolicy />} />

--- a/src/components/layout/AuthWrapper.tsx
+++ b/src/components/layout/AuthWrapper.tsx
@@ -1,4 +1,3 @@
-import { Navigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 import { Link } from 'react-router-dom';
@@ -7,8 +6,16 @@ import { LoadingSpinner } from '@/components/ui/loading';
 // Simple auth wrapper component that redirects to auth if not authenticated
 // This ensures unauthenticated users can't access protected routes
 const AuthWrapper = ({ children }: { children: React.ReactNode }) => {
-  const { user } = useAuth();
-  
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <LoadingSpinner size="md" />
+      </div>
+    );
+  }
+
   if (!user) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">


### PR DESCRIPTION
## Summary
- `/profile-edit` was accessible without authentication
- Added `AuthWrapper` component wrapping in `App.tsx`
- `AuthWrapper` shows a loading spinner while auth resolves, then redirects unauthenticated visitors to sign-in
- No other exposed routes found in the audit

## What was checked
All routes audited for auth protection:
- `/dashboard`, `/users`, `/profile/:username` — already protected
- `/codex`, `/vault/:id` — intentionally public (mutations check auth at action time, backend RLS enforces access)
- `/profile-edit` — **fixed here**

🤖 Generated with [Claude Code](https://claude.ai/claude-code)