### PR TITLE
refactor: split scroll-to-top from bug report control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -6,6 +6,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
 import { BugReportButton } from "@/components/layout/BugReportButton";
+import { ScrollToTopButton } from "@/components/layout/ScrollToTopButton";
 import { queryClient, initQueryPersistence } from "@/lib/queryClient";
 import { KeyboardProvider } from "@/contexts/KeyboardContext";
 import { KeyboardHelpOverlay } from "@/components/ui/KeyboardHelpOverlay";
@@ -55,6 +56,7 @@ const App = () => {
             <TooltipProvider>
               <Toaster />
               <Sonner />
+              <ScrollToTopButton />
               <BugReportButton />
               <KeyboardHelpOverlay />
               <BrowserRouter>

--- a/src/components/layout/BugReportButton.tsx
+++ b/src/components/layout/BugReportButton.tsx
@@ -9,22 +9,25 @@ export function BugReportButton() {
   };
 
   return (
-    <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-2">
-      <Badge 
-        variant="outline" 
-        className="gap-1 font-mono text-xs bg-background/95 backdrop-blur-sm border-primary/30 text-primary animate-pulse"
-      >
-        <span className="text-[10px]">v{version}</span>
-      </Badge>
-      <Button
-        onClick={handleBugReport}
-        size="sm"
-        variant="outline"
-        className="h-10 w-10 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 bg-background/95 backdrop-blur-sm border-primary/30 hover:border-primary/50 hover:bg-primary/5 group"
-        title="Report a bug or request a feature"
-      >
-        <Bug className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
-      </Button>
+    <div className="pointer-events-none fixed bottom-4 right-4 z-40 sm:bottom-6 sm:right-6">
+      <div className="flex flex-col items-end gap-2 pointer-events-auto">
+        <Badge
+          variant="outline"
+          className="gap-1 border-primary/30 bg-background/95 font-mono text-xs text-primary backdrop-blur-sm animate-pulse"
+        >
+          <span className="text-[10px]">v{version}</span>
+        </Badge>
+        <Button
+          onClick={handleBugReport}
+          size="icon"
+          variant="outline"
+          className="group h-11 w-11 rounded-full border-primary/30 bg-background/95 shadow-lg backdrop-blur-sm transition-all duration-200 hover:border-primary/50 hover:bg-primary/5 hover:shadow-xl"
+          title="Report a bug or request a feature"
+          aria-label="Report a bug or request a feature"
+        >
+          <Bug className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-primary" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/ScrollToTopButton.tsx
+++ b/src/components/layout/ScrollToTopButton.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { ArrowUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const updateVisibility = () => {
+      const threshold = Math.max(window.innerHeight * 0.75, 480);
+      setIsVisible(window.scrollY > threshold);
+    };
+
+    updateVisibility();
+    window.addEventListener('scroll', updateVisibility, { passive: true });
+    window.addEventListener('resize', updateVisibility);
+
+    return () => {
+      window.removeEventListener('scroll', updateVisibility);
+      window.removeEventListener('resize', updateVisibility);
+    };
+  }, []);
+
+  const handleScrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <div className="pointer-events-none fixed bottom-[calc(1rem+4.75rem)] right-4 z-40 sm:bottom-[calc(1.5rem+4.75rem)] sm:right-6">
+      <Button
+        onClick={handleScrollToTop}
+        size="icon"
+        variant="outline"
+        className={cn(
+          'pointer-events-auto h-11 w-11 rounded-full border-primary/30 bg-background/95 shadow-lg backdrop-blur-sm transition-all duration-200 hover:border-primary/50 hover:bg-primary/5 hover:shadow-xl',
+          isVisible
+            ? 'translate-y-0 opacity-100'
+            : 'pointer-events-none translate-y-2 opacity-0',
+        )}
+        title="Scroll back to top"
+        aria-label="Scroll back to top"
+      >
+        <ArrowUp className="h-4 w-4 text-muted-foreground" />
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- move scroll-to-top behavior into its own dedicated layout component
- keep the bug report control focused on bug reporting and version display
- mount both floating controls from the app shell so they coexist cleanly

## Verification
- npx eslint src/App.tsx src/components/layout/BugReportButton.tsx src/components/layout/ScrollToTopButton.tsx
- npx tsc --noEmit