### PR TITLE
Fix publication form clearing after save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6506,15 +6506,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -8838,9 +8838,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -10781,9 +10781,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.3.5",
+      "version": "1.3.7",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.3.6",
+  "version": "1.3.7",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/layout/BugReportButton.tsx
+++ b/src/components/layout/BugReportButton.tsx
@@ -1,11 +1,23 @@
 import { Bug } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { version } from '../../../package.json';
 
 export function BugReportButton() {
   const handleBugReport = () => {
-    window.open('https://github.com/velitchko/refhub.io/issues/new?template=bug_report.md', '_blank', 'noopener,noreferrer');
+    const issueUrl = new URL('https://github.com/velitchko/refhub.io/issues/new');
+    issueUrl.searchParams.set('template', 'bug_report.md');
+    issueUrl.searchParams.set(
+      'body',
+      [
+        '**App version**',
+        `v${__APP_VERSION__}`,
+        '',
+        '**Describe the bug**',
+        'A clear and concise description of what the bug is.',
+      ].join('\n'),
+    );
+
+    window.open(issueUrl.toString(), '_blank', 'noopener,noreferrer');
   };
 
   return (
@@ -15,7 +27,7 @@ export function BugReportButton() {
           variant="outline"
           className="gap-1 border-primary/30 bg-background/95 font-mono text-xs text-primary backdrop-blur-sm animate-pulse"
         >
-          <span className="text-[10px]">v{version}</span>
+          <span className="text-[10px]">v{__APP_VERSION__}</span>
         </Badge>
         <Button
           onClick={handleBugReport}

--- a/src/components/publications/BrowserExtensionInstallCard.tsx
+++ b/src/components/publications/BrowserExtensionInstallCard.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Download, Puzzle, ExternalLink } from 'lucide-react';
 
 const EXTENSION_LINKS = {
-  chrome: 'https://chromewebstore.google.com/detail/refhub-ext/ggoophlbadcgkmcpnbnfjacknccpkmgc',
+  chrome: 'https://chromewebstore.google.com/detail/refhub/ggoophlbadcgkmcpnbnfjacknccpkmgc?authuser=0&hl=en',
   firefox: 'https://addons.mozilla.org/en-US/firefox/addon/refhub/',
   repo: 'https://github.com/refhub-io/refhub-extensions',
 } as const;

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -1234,42 +1234,39 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
             </p>
           )}
 
-          <div className="flex flex-col sm:flex-row justify-between gap-3 pt-6 mt-6 border-t-2 border-border">
-            {vault && onDelete ? (
+          <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3 pt-3 sm:pt-4 border-t border-border w-full box-border">
+            {vault && onDelete && (
               <Button
                 type="button"
                 variant="ghost"
                 onClick={() => onDelete(vault)}
-                className="text-destructive hover:text-destructive hover:bg-destructive/10 w-full sm:w-auto font-mono"
+                className="text-destructive hover:text-destructive hover:bg-destructive/10 font-mono w-full sm:w-auto text-xs sm:text-sm h-9 sm:h-10"
               >
-                <Trash2 className="w-4 h-4 mr-2" />
+                <Trash2 className="w-3 h-3 mr-1.5" />
                 delete_vault
               </Button>
-            ) : (
-              <div className="hidden sm:block" />
             )}
-            <div className="flex flex-col-reverse sm:flex-row gap-3 w-full sm:w-auto">
-              <Button type="button" variant="outline" onClick={() => handleDialogClose(false)} className="w-full sm:w-auto font-mono">
-                cancel
-              </Button>
-              <Button
-                type="submit"
-                variant="glow"
-                disabled={saving || !name.trim()}
-                className="w-full sm:w-auto font-mono text-xs sm:text-sm h-9 sm:h-10"
-              >
-                {saving ? (
-                  'saving...'
-                ) : vault ? (
-                  <><Save className="w-3 h-3 mr-1.5" />save_changes</>
-                ) : (
-                  <><Plus className="w-3 h-3 mr-1.5" />create_vault</>
-                )}
-                {vault && (
-                  <KbdHint shortcut="Ctrl+S" className="ml-1.5 hidden sm:inline-flex [&_kbd]:bg-white/20 [&_kbd]:border-white/30 [&_kbd]:text-primary-foreground [&_kbd]:shadow-none" size="sm" />
-                )}
-              </Button>
-            </div>
+            <Button type="button" variant="outline" onClick={() => handleDialogClose(false)} className="font-mono w-full sm:w-auto text-xs sm:text-sm h-9 sm:h-10">
+              <X className="w-3 h-3 mr-1.5" />
+              cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="glow"
+              disabled={saving || !name.trim()}
+              className="font-mono w-full sm:w-auto text-xs sm:text-sm h-9 sm:h-10"
+            >
+              {saving ? (
+                'saving...'
+              ) : vault ? (
+                <><Save className="w-3 h-3 mr-1.5" />save_changes</>
+              ) : (
+                <><Plus className="w-3 h-3 mr-1.5" />create_vault</>
+              )}
+              {vault && (
+                <KbdHint shortcut="Ctrl+S" className="ml-1.5 hidden sm:inline-flex [&_kbd]:bg-white/20 [&_kbd]:border-white/30 [&_kbd]:text-primary-foreground [&_kbd]:shadow-none" size="sm" />
+              )}
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -16,6 +16,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
+import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
@@ -54,6 +56,13 @@ interface AccessRequest {
   requester_profile: null;
 }
 
+interface UserSuggestion {
+  user_id: string;
+  display_name: string | null;
+  username: string | null;
+  email: string | null;
+}
+
 interface VaultDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -82,7 +91,11 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
   const [requestPermissions, setRequestPermissions] = useState<Record<string, 'viewer' | 'editor'>>({});
   const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
   const [email, setEmail] = useState('');
-const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('viewer');
+  const [userSuggestions, setUserSuggestions] = useState<UserSuggestion[]>([]);
+  const [suggestionsOpen, setSuggestionsOpen] = useState(false);
+  const [loadingSuggestions, setLoadingSuggestions] = useState(false);
+  const [selectedProfile, setSelectedProfile] = useState<UserSuggestion | null>(null);
+  const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('viewer');
   const [publicSlug, setPublicSlug] = useState('');
   const [slugAvailable, setSlugAvailable] = useState<boolean | null>(null);
   const [checkingSlug, setCheckingSlug] = useState(false);
@@ -247,6 +260,83 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
       setShares(enrichedShares as VaultShare[]);
     }
   }, []);
+
+  const handleSelectUserSuggestion = useCallback((profile: UserSuggestion) => {
+    setSelectedProfile(profile);
+    setEmail(profile.email || '');
+    setSuggestionsOpen(false);
+  }, []);
+
+  const handleShareEmailChange = useCallback((value: string) => {
+    setEmail(value);
+    setSelectedProfile(null);
+  }, []);
+
+  useEffect(() => {
+    if (!open || visibility !== 'protected' || !vault || email.trim().length < 2) {
+      setUserSuggestions([]);
+      setLoadingSuggestions(false);
+      return;
+    }
+
+    let cancelled = false;
+    const search = email.trim().replace(/[%_]/g, '');
+
+    setLoadingSuggestions(true);
+    const timeoutId = window.setTimeout(async () => {
+      try {
+        const existingUserIds = shares
+          .map((share) => share.shared_with_user_id)
+          .filter(Boolean);
+        const existingEmails = shares
+          .map((share) => share.shared_with_email?.toLowerCase())
+          .filter(Boolean);
+
+        const { data, error } = await supabase
+          .from('profiles')
+          .select('user_id, display_name, username, email')
+          .or(`email.ilike.%${search}%,display_name.ilike.%${search}%,username.ilike.%${search}%`)
+          .limit(8);
+
+        if (error) throw error;
+        if (cancelled) return;
+
+        const filtered = (data || []).filter((profile) => {
+          const profileEmail = profile.email?.toLowerCase();
+          return profile.user_id !== user?.id &&
+            !existingUserIds.includes(profile.user_id) &&
+            (!profileEmail || !existingEmails.includes(profileEmail));
+        });
+
+        setUserSuggestions(filtered as UserSuggestion[]);
+        setSuggestionsOpen(filtered.length > 0);
+      } catch (error) {
+        logger.error('VaultDialog', 'Error fetching user suggestions:', error);
+        if (!cancelled) setUserSuggestions([]);
+      } finally {
+        if (!cancelled) setLoadingSuggestions(false);
+      }
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [email, open, shares, user?.id, vault, visibility]);
+
+  useEffect(() => {
+    if (!open) {
+      setUserSuggestions([]);
+      setSuggestionsOpen(false);
+      setSelectedProfile(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (selectedProfile && email !== (selectedProfile.email || '')) {
+      setSelectedProfile(null);
+    }
+  }, [email, selectedProfile]);
 
   useEffect(() => {
     isInitialLoadRef.current = true; // Reset on dialog open
@@ -488,12 +578,16 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
 
     setSaving(true);
     try {
-      // Look up the user's profile by email to get their user_id and display name
-      const { data: profile, error: profileError } = await supabase
-        .from('profiles')
-        .select('user_id, display_name, username, email')
-        .eq('email', email.trim().toLowerCase())
-        .single();
+      // Use the selected autocomplete profile when available; otherwise fall back to email lookup.
+      let profile = selectedProfile;
+      if (!profile) {
+        const { data: profileData } = await supabase
+          .from('profiles')
+          .select('user_id, display_name, username, email')
+          .eq('email', email.trim().toLowerCase())
+          .maybeSingle();
+        profile = profileData as UserSuggestion | null;
+      }
 
       const shareData: {
         vault_id: string;
@@ -521,6 +615,9 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
 
       toast({ title: 'user_added ✨' });
       setEmail('');
+      setSelectedProfile(null);
+      setUserSuggestions([]);
+      setSuggestionsOpen(false);
       setSharePermission('viewer');
       if (vault) fetchShares(vault.id);
       onUpdate?.();
@@ -850,16 +947,56 @@ const [sharePermission, setSharePermission] = useState<'viewer' | 'editor'>('vie
 
               <div className="space-y-3">
                 <div className="flex gap-2">
-                  <div className="relative flex-1">
-                    <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                    <Input
-                      type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      placeholder="user@example.com"
-                      className="pl-10 font-mono text-sm"
-                    />
-                  </div>
+                  <Popover open={suggestionsOpen} onOpenChange={setSuggestionsOpen}>
+                    <PopoverTrigger asChild>
+                      <div className="relative flex-1">
+                        <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                        <Input
+                          type="email"
+                          value={email}
+                          onChange={(e) => handleShareEmailChange(e.target.value)}
+                          onFocus={() => {
+                            if (userSuggestions.length > 0) setSuggestionsOpen(true);
+                          }}
+                          placeholder="user@example.com"
+                          className="pl-10 font-mono text-sm"
+                        />
+                      </div>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+                      <Command shouldFilter={false}>
+                        <CommandList>
+                          {loadingSuggestions ? (
+                            <CommandEmpty>loading_users…</CommandEmpty>
+                          ) : userSuggestions.length === 0 ? (
+                            <CommandEmpty>no_matching_users</CommandEmpty>
+                          ) : (
+                            <CommandGroup heading="matching_users">
+                              {userSuggestions.map((profile) => (
+                                <CommandItem
+                                  key={profile.user_id}
+                                  value={`${profile.email || ''} ${profile.display_name || ''} ${profile.username || ''}`}
+                                  onSelect={() => handleSelectUserSuggestion(profile)}
+                                  className="font-mono text-sm"
+                                >
+                                  <div className="flex flex-col min-w-0">
+                                    <span className="truncate">
+                                      {profile.display_name || profile.username || profile.email}
+                                    </span>
+                                    {profile.email && (
+                                      <span className="text-xs text-muted-foreground truncate">
+                                        {profile.email}
+                                      </span>
+                                    )}
+                                  </div>
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          )}
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
                   <Select value={sharePermission} onValueChange={(value: 'viewer' | 'editor') => setSharePermission(value)}>
                     <SelectTrigger className="w-[130px] font-mono text-sm">
                       <SelectValue />

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -63,6 +63,12 @@ interface UserSuggestion {
   email: string | null;
 }
 
+const sanitizeProfileSearch = (value: string) =>
+  value
+    .trim()
+    .replace(/[%_,()]/g, '')
+    .replace(/\s+/g, ' ');
+
 interface VaultDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -276,13 +282,22 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
     if (!open || visibility !== 'protected' || !vault || email.trim().length < 2) {
       setUserSuggestions([]);
       setLoadingSuggestions(false);
+      setSuggestionsOpen(false);
       return;
     }
 
     let cancelled = false;
-    const search = email.trim().replace(/[%_]/g, '');
+    const search = sanitizeProfileSearch(email);
+
+    if (search.length < 2) {
+      setUserSuggestions([]);
+      setLoadingSuggestions(false);
+      setSuggestionsOpen(false);
+      return;
+    }
 
     setLoadingSuggestions(true);
+    setSuggestionsOpen(true);
     const timeoutId = window.setTimeout(async () => {
       try {
         const existingUserIds = shares
@@ -296,6 +311,9 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
           .from('profiles')
           .select('user_id, display_name, username, email')
           .or(`email.ilike.%${search}%,display_name.ilike.%${search}%,username.ilike.%${search}%`)
+          .order('display_name', { ascending: true })
+          .order('username', { ascending: true })
+          .order('email', { ascending: true })
           .limit(8);
 
         if (error) throw error;
@@ -309,10 +327,11 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
         });
 
         setUserSuggestions(filtered as UserSuggestion[]);
-        setSuggestionsOpen(filtered.length > 0);
       } catch (error) {
         logger.error('VaultDialog', 'Error fetching user suggestions:', error);
-        if (!cancelled) setUserSuggestions([]);
+        if (!cancelled) {
+          setUserSuggestions([]);
+        }
       } finally {
         if (!cancelled) setLoadingSuggestions(false);
       }
@@ -952,14 +971,17 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
                       <div className="relative flex-1">
                         <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                         <Input
-                          type="email"
+                          type="text"
                           value={email}
                           onChange={(e) => handleShareEmailChange(e.target.value)}
                           onFocus={() => {
-                            if (userSuggestions.length > 0) setSuggestionsOpen(true);
+                            if (email.trim().length >= 2) setSuggestionsOpen(true);
                           }}
-                          placeholder="user@example.com"
+                          placeholder="name, username, or email"
                           className="pl-10 font-mono text-sm"
+                          autoComplete="off"
+                          autoCapitalize="none"
+                          spellCheck={false}
                         />
                       </div>
                     </PopoverTrigger>

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -18,6 +18,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { KbdHint } from '@/components/ui/KbdHint';
 import {
   Select,
   SelectContent,
@@ -25,7 +26,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Lock, Users, Globe, Mail, Trash2, Copy, Check, Link2, X } from 'lucide-react';
+import { useKeyboardContext } from '@/contexts/KeyboardContext';
+import { useHotkeys } from '@/hooks/useKeyboardNavigation';
+import { Lock, Users, Globe, Mail, Trash2, Copy, Check, Link2, X, Save, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 type VaultVisibility = 'private' | 'protected' | 'public';
@@ -82,6 +85,7 @@ interface VaultDialogProps {
 export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSave, onUpdate, onDelete }: VaultDialogProps) {
   const { user } = useAuth();
   const { toast } = useToast();
+  const kbCtx = useKeyboardContext();
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -125,6 +129,17 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
     };
     setHasUnsavedChanges(false);
   }, [name, description, color, category, abstract, visibility, publicSlug, isForkedVault]);
+
+  useEffect(() => {
+    if (open) {
+      kbCtx.saveFocus();
+      kbCtx.pushContext('dialog');
+    } else {
+      kbCtx.popContext();
+      kbCtx.restoreFocus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   // Fetch access requests for owners and enrich with display names when possible
   async function fetchAccessRequests() {
@@ -574,8 +589,9 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
     }
   }, [name, description, color, category, abstract, visibility, publicSlug, isForkedVault, onSave, onOpenChange, syncSavedValues]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = useCallback(async () => {
+    if (!open || saving || !name.trim()) return;
+
     setSaving(true);
     try {
       await onSave({
@@ -595,7 +611,30 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
     } finally {
       setSaving(false);
     }
-  };
+  }, [open, saving, name, description, color, category, abstract, visibility, publicSlug, isForkedVault, onSave, syncSavedValues, vault, onOpenChange]);
+
+  useHotkeys(
+    'dialog',
+    [
+      {
+        combo: 'Ctrl+s',
+        description: 'Save changes',
+        handler: (e) => {
+          if (!open || !vault || saving || !name.trim()) return false;
+          e.preventDefault();
+          void handleSubmit();
+          return true;
+        },
+        allowInInput: true,
+      },
+    ],
+    [open, vault, saving, name, handleSubmit],
+  );
+
+  const handleFormSubmit = useCallback((e: React.FormEvent) => {
+    e.preventDefault();
+    void handleSubmit();
+  }, [handleSubmit]);
 
   const handleShareWithUser = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -805,7 +844,7 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto space-y-5 px-6 pb-6">
+        <form onSubmit={handleFormSubmit} className="flex-1 overflow-y-auto space-y-5 px-6 pb-6">
           <div className="space-y-2">
             <Label htmlFor="name" className="font-semibold font-mono">name</Label>
             <Input
@@ -1213,8 +1252,22 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
               <Button type="button" variant="outline" onClick={() => handleDialogClose(false)} className="w-full sm:w-auto font-mono">
                 cancel
               </Button>
-              <Button type="submit" variant="glow" disabled={saving || !name.trim()} className="w-full sm:w-auto font-mono">
-                {saving ? 'saving...' : vault ? 'save_changes' : 'create_vault'}
+              <Button
+                type="submit"
+                variant="glow"
+                disabled={saving || !name.trim()}
+                className="w-full sm:w-auto font-mono text-xs sm:text-sm h-9 sm:h-10"
+              >
+                {saving ? (
+                  'saving...'
+                ) : vault ? (
+                  <><Save className="w-3 h-3 mr-1.5" />save_changes</>
+                ) : (
+                  <><Plus className="w-3 h-3 mr-1.5" />create_vault</>
+                )}
+                {vault && (
+                  <KbdHint shortcut="Ctrl+S" className="ml-1.5 hidden sm:inline-flex [&_kbd]:bg-white/20 [&_kbd]:border-white/30 [&_kbd]:text-primary-foreground [&_kbd]:shadow-none" size="sm" />
+                )}
               </Button>
             </div>
           </div>

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -74,7 +74,7 @@ interface VaultDialogProps {
   onOpenChange: (open: boolean) => void;
   vault?: Vault | null;
   initialRequestId?: string;
-  onSave: (data: Partial<Vault>) => Promise<void>;
+  onSave: (data: Partial<Vault>) => Promise<Vault | void>;
   onUpdate?: () => void;
   onDelete?: (vault: Vault) => void;
 }
@@ -112,6 +112,19 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
   const slugCheckTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isInitialLoadRef = useRef(true);
   const initialValuesRef = useRef<{ name: string; description: string; color: string; category: string; abstract: string; visibility: VaultVisibility; publicSlug: string } | null>(null);
+
+  const syncSavedValues = useCallback(() => {
+    initialValuesRef.current = {
+      name,
+      description,
+      color,
+      category,
+      abstract,
+      visibility: isForkedVault ? 'public' : visibility,
+      publicSlug: (isForkedVault || visibility === 'public') ? (publicSlug || generateSlug(name)) : '',
+    };
+    setHasUnsavedChanges(false);
+  }, [name, description, color, category, abstract, visibility, publicSlug, isForkedVault]);
 
   // Fetch access requests for owners and enrich with display names when possible
   async function fetchAccessRequests() {
@@ -551,7 +564,7 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
         visibility: isForkedVault ? 'public' : visibility,
         public_slug: (isForkedVault || visibility === 'public') ? (publicSlug || generateSlug(name)) : null,
       });
-      setHasUnsavedChanges(false);
+      syncSavedValues();
       setShowUnsavedDialog(false);
       onOpenChange(false);
     } catch (error) {
@@ -559,7 +572,7 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
     } finally {
       setSaving(false);
     }
-  }, [name, description, color, category, abstract, visibility, publicSlug, isForkedVault, onSave, onOpenChange]);
+  }, [name, description, color, category, abstract, visibility, publicSlug, isForkedVault, onSave, onOpenChange, syncSavedValues]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -574,8 +587,11 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
         visibility: isForkedVault ? 'public' : visibility,
         public_slug: (isForkedVault || visibility === 'public') ? (publicSlug || generateSlug(name)) : null,
       });
-      setHasUnsavedChanges(false);
-      onOpenChange(false);
+      syncSavedValues();
+
+      if (!vault) {
+        onOpenChange(false);
+      }
     } finally {
       setSaving(false);
     }

--- a/src/contexts/VaultContentContext.tsx
+++ b/src/contexts/VaultContentContext.tsx
@@ -42,6 +42,7 @@ interface VaultContentContextType {
   setPublicationTags: React.Dispatch<React.SetStateAction<PublicationTag[]>>;
   setPublicationRelations: React.Dispatch<React.SetStateAction<PublicationRelation[]>>;
   setVaultShares: React.Dispatch<React.SetStateAction<VaultShare[]>>;
+  updateCurrentVault: (vault: Vault) => void;
   // New methods for optimistic updates
   refreshVaultContent: () => Promise<void>;
   isRealtimeConnected: boolean;
@@ -96,6 +97,23 @@ export function VaultContentProvider({ children }: VaultContentProviderProps) {
   const hasCachedContentRef = useRef(false);
 
   const { canView, refresh } = useVaultAccess(currentVaultId || '', { enableRealtime: false });
+
+  const updateCurrentVault = useCallback((vault: Vault) => {
+    setCurrentVault(vault);
+
+    if (!currentVaultId) return;
+
+    const cacheKey = `vault-content-${currentVaultId}` as const;
+    const cached = getPageCache<VaultContentCache>(cacheKey);
+    setPageCache<VaultContentCache>(cacheKey, {
+      currentVault: vault,
+      publications: cached?.publications || publications,
+      tags: cached?.tags || tags,
+      publicationTags: cached?.publicationTags || publicationTags,
+      publicationRelations: cached?.publicationRelations || publicationRelations,
+      vaultShares: cached?.vaultShares || vaultShares,
+    });
+  }, [currentVaultId, publications, tags, publicationTags, publicationRelations, vaultShares]);
   
   // Helper to get user display name (with caching)
   const getUserDisplayName = useCallback(async (userId: string): Promise<string | null> => {
@@ -799,6 +817,7 @@ export function VaultContentProvider({ children }: VaultContentProviderProps) {
         setPublicationTags,
         setPublicationRelations,
         setVaultShares,
+        updateCurrentVault,
         refreshVaultContent,
         isRealtimeConnected,
         lastActivity,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -753,10 +753,9 @@ export default function Dashboard() {
           ...newTagRecords
         ]);
 
-        // Update editingPublication with new data so dialog stays in sync
-        if (isAutoSave) {
-          setEditingPublication({ ...editingPublication, ...updatedPub } as Publication);
-        }
+        // Update editingPublication with persisted data so the still-open dialog
+        // stays in sync after manual saves as well as auto-saves.
+        setEditingPublication({ ...editingPublication, ...updatedPub } as Publication);
 
         if (!isAutoSave) {
           toast({ title: 'paper_updated ✨' });
@@ -809,10 +808,9 @@ export default function Dashboard() {
         toast({ title: 'paper_added ✨' });
       }
 
-      // Only clear editing publication on manual save, not auto-save
-      if (!isAutoSave) {
-        setEditingPublication(null);
-      }
+      // Keep the current publication selected after manual save so the dialog can
+      // continue showing the persisted values instead of reopening in empty
+      // create mode. The dialog close handler clears editingPublication.
     } catch (error) {
       toast({
         title: 'error_saving_paper',

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1252,8 +1252,10 @@ export default function Dashboard() {
         setVaults(prev => prev.map(v => 
           v.id === editingVault.id ? { ...v, ...updatedVault } as Vault : v
         ));
+        setEditingVault(updatedVault as Vault);
         
         toast({ title: 'vault_updated ✨' });
+        return updatedVault as Vault;
       } else {
         // Create optimistic vault with temporary ID
         const tempId = `temp_${Date.now()}`;
@@ -1289,14 +1291,14 @@ export default function Dashboard() {
           }
           
           toast({ title: 'vault_created ✨' });
+          setEditingVault(null);
+          return newVault as Vault;
         } catch (error) {
           // Rollback optimistic update on error
           setVaults(prev => prev.filter(v => v.id !== tempId));
           throw error;
         }
       }
-
-      setEditingVault(null);
     } catch (error) {
       toast({
         title: 'error_adding_to_vaults',

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -142,10 +142,11 @@ export default function Users() {
   const fetchUsers = async (silent = false) => {
     if (!silent) setLoading(true);
     try {
-      // Fetch all profiles — requires the "Authenticated users can view all profiles" RLS policy
+      // Only show researchers with completed profiles in the directory.
       const { data: profilesData, error: profilesError } = await supabase
         .from('profiles')
         .select('*')
+        .eq('is_setup', true)
         .order('created_at', { ascending: false });
 
       if (profilesError) throw profilesError;

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -603,10 +603,12 @@ export default function VaultDetail() {
           }
         }
 
-        // Update editingPublication with new data so dialog stays in sync
-        if (isAutoSave) {
-          setEditingPublication({ ...editingPublication, ...data } as Publication);
-        } else {
+        // Update editingPublication with new data so dialog stays in sync after
+        // manual saves as well as auto-saves. Otherwise the still-open dialog can
+        // fall back to empty create state when editingPublication is cleared.
+        setEditingPublication({ ...editingPublication, ...data } as Publication);
+
+        if (!isAutoSave) {
           // Update last activity for the updated publication
           updateLastActivity('publication_updated', user.id);
         }
@@ -667,10 +669,9 @@ export default function VaultDetail() {
         updateLastActivity('publication_added', user.id);
       }
 
-      // Only clear editing publication on manual save, not auto-save
-      if (!isAutoSave) {
-        setEditingPublication(null);
-      }
+      // Keep the current publication selected after manual save so the dialog can
+      // continue showing the persisted values instead of reopening in empty
+      // create mode. The dialog close handler clears editingPublication.
     } catch (error) {
       toast({
         title: 'error_saving_paper',

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -78,6 +78,7 @@ export default function VaultDetail() {
     setPublicationTags,
     setPublicationRelations,
     setVaultShares,
+    updateCurrentVault,
     refreshVaultContent,
     isRealtimeConnected,
     lastActivity,
@@ -1268,10 +1269,18 @@ export default function VaultDetail() {
 
         // Update the editingVault state with the fresh data from the database
         setEditingVault(updatedVault as Vault);
+        updateCurrentVault(updatedVault as Vault);
+        setVaults(prev => prev.map(v =>
+          v.id === editingVault.id ? updatedVault as Vault : v
+        ));
+        setSharedVaults(prev => prev.map(v =>
+          v.id === editingVault.id ? updatedVault as Vault : v
+        ));
         
         // Update the vault in the hook's state (silent - toast provides feedback)
         silentRefresh();
         toast({ title: 'vault_updated ✨' });
+        return updatedVault as Vault;
       } else {
         const { data: newVault, error } = await supabase
           .from('vaults')
@@ -1284,6 +1293,7 @@ export default function VaultDetail() {
         // Update the vault in the hook's state (silent - toast provides feedback)
         silentRefresh();
         toast({ title: 'vault_created ✨' });
+        return newVault as Vault;
       }
 
       // Note: Don't set editingVault to null here, let the dialog stay open with updated data

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import { readFileSync } from "node:fs";
 import { componentTagger } from "lovable-tagger";
+
+const { version } = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
+) as { version: string };
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -14,6 +19,9 @@ export default defineConfig(({ mode }) => ({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
- keep the edited publication selected after manual saves in Dashboard and Vault views
- sync editing state with persisted values after save so the open dialog does not reset to empty create mode
- update the Chrome extension install button to the approved Chrome Web Store URL
- add profile autocomplete suggestions when sharing protected vaults with collaborators
- bump app version to 1.3.7

Fixes #82
Fixes #84
Refs #85

## Verification
- npm run lint (passes with existing PublicationDialog exhaustive-deps warning)
- npm run build (passes; existing large chunk warning)
