### PR TITLE
chore: bump RefHub to 1.3.8 and add What's New entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.3.7",
+  "version": "1.3.8",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -21,6 +21,37 @@ export interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
+    id: 7,
+    date: '2026-05-08',
+    title: 'smoother publication + vault saves',
+    features: [
+      {
+        tag: 'fix',
+        title: 'publication edits stay in place after save',
+        description:
+          'the add/edit publication form now preserves its current values after saving, so follow-up edits and metadata checks no longer force you to re-enter the same details.',
+      },
+      {
+        tag: 'improvement',
+        title: 'vault settings save flow feels immediate',
+        description:
+          'saving vault settings now keeps the dialog open, supports ctrl/cmd+s, and uses consistent save button styling so quick metadata updates take fewer clicks.',
+      },
+      {
+        tag: 'improvement',
+        title: 'cleaner collaboration and researcher discovery',
+        description:
+          'vault collaborator autocomplete is more reliable, and the researchers directory now focuses on profiles that have completed setup instead of showing incomplete entries.',
+      },
+      {
+        tag: 'fix',
+        title: 'version and extension links now point to the right place',
+        description:
+          'the bug report control now reports the live app version correctly, and the browser extension install flow links directly to the current chrome web store listing.',
+      },
+    ],
+  },
+  {
     id: 6,
     date: '2026-04-19',
     title: 'agentic reference management',


### PR DESCRIPTION
## Summary
- bump the app version from 1.3.7 to 1.3.8 in package.json and package-lock.json
- add a new top-level What's New entry for the PR #86 publication/vault save improvements
- keep the release note copy concise and aligned with the existing changelog style

## Verification
- npm run lint
- npm run build

## Notes
- lint still reports one existing warning in src/components/publications/PublicationDialog.tsx:646 for a missing useCallback dependency