### PR TITLE
feat: request edit access on public vaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.3.7",
+  "version": "1.3.8",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -52,6 +52,7 @@ interface AccessRequest {
   requester_id: string | null;
   requester_email: string | null;
   requester_name: string | null;
+  requested_role?: 'viewer' | 'editor' | null;
   status: 'pending' | 'approved' | 'rejected';
   note: string | null;
   created_at: string;
@@ -176,9 +177,9 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
 
       setAccessRequests(processed);
 
-      // Initialize per-request permission selections (default viewer)
+      // Initialize per-request permission selections from the requested role when present.
       const perms: Record<string, 'viewer' | 'editor'> = {};
-      processed.forEach((r) => { perms[r.id] = 'viewer'; });
+      processed.forEach((r) => { perms[r.id] = r.requested_role === 'editor' ? 'editor' : 'viewer'; });
       setRequestPermissions(perms);
 
       if (initialRequestId) {
@@ -1192,6 +1193,7 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
                           <div className="text-sm">
                             <div className="font-semibold">{r.display_name}</div>
                             <div className="text-xs text-muted-foreground">{r.requester_email || r.requester_profile?.email || r.requester_profile?.username || ''}</div>
+                            <div className="text-xs text-muted-foreground font-mono">requested: {r.requested_role === 'editor' ? 'write (editor)' : 'read (viewer)'}</div>
                             <div className="text-xs text-muted-foreground">{new Date(r.created_at).toLocaleString()}</div>
                             {r.note && <div className="text-xs mt-1">{r.note}</div>}
                           </div>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -21,6 +21,37 @@ export interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
+    id: 7,
+    date: '2026-05-08',
+    title: 'smoother publication + vault saves',
+    features: [
+      {
+        tag: 'fix',
+        title: 'publication edits stay in place after save',
+        description:
+          'the add/edit publication form now preserves its current values after saving, so follow-up edits and metadata checks no longer force you to re-enter the same details.',
+      },
+      {
+        tag: 'improvement',
+        title: 'vault settings save flow feels immediate',
+        description:
+          'saving vault settings now keeps the dialog open, supports ctrl/cmd+s, and uses consistent save button styling so quick metadata updates take fewer clicks.',
+      },
+      {
+        tag: 'improvement',
+        title: 'cleaner collaboration and researcher discovery',
+        description:
+          'vault collaborator autocomplete is more reliable, and the researchers directory now focuses on profiles that have completed setup instead of showing incomplete entries.',
+      },
+      {
+        tag: 'fix',
+        title: 'version and extension links now point to the right place',
+        description:
+          'the bug report control now reports the live app version correctly, and the browser extension install flow links directly to the current chrome web store listing.',
+      },
+    ],
+  },
+  {
     id: 6,
     date: '2026-04-19',
     title: 'agentic reference management',

--- a/src/hooks/useVaultAccess.ts
+++ b/src/hooks/useVaultAccess.ts
@@ -417,7 +417,8 @@ export const useVaultAccess = (
 export const requestVaultAccess = async (
   vaultId: string,
   requesterId: string,
-  note?: string
+  note?: string,
+  requestedRole: 'viewer' | 'editor' = 'viewer'
 ) => {
   // First, get the user's profile information to include in the request
   const { data: profile } = await supabase
@@ -434,6 +435,7 @@ export const requestVaultAccess = async (
       requester_name: profile?.display_name || profile?.username,
       requester_email: profile?.email,
       note,
+      requested_role: requestedRole,
       status: 'pending',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -29,7 +29,7 @@ import { useVaultContent } from '@/contexts/VaultContentContext';
 import { useSharedVaultOperations } from '@/hooks/useSharedVaultOperations';
 import { getForkSourceHref, getForkSourceLabel, getVaultForkInfo, VaultForkInfo } from '@/lib/vaultFork';
 import { buildVaultPublicationCopyPayload } from '@/lib/vaultPublicationAttribution';
-import { Lock, Globe, Shield, Users, Clock, User, ExternalLink, Sparkles, Crown, Edit, Eye, Heart, GitFork } from 'lucide-react';
+import { Lock, Globe, Shield, Users, Clock, User, ExternalLink, Sparkles, Crown, Edit, Eye, Heart, GitFork, PencilLine } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -416,6 +416,7 @@ export default function VaultDetail() {
 
   // Check for pending access requests
   const [hasPendingRequest, setHasPendingRequest] = useState(false);
+  const [pendingRequestRole, setPendingRequestRole] = useState<'viewer' | 'editor' | null>(null);
   const processedApprovedRequestRef = useRef<string | null>(null);
   const lastCheckedVaultIdRef = useRef<string | null>(null);
 
@@ -430,7 +431,7 @@ export default function VaultDetail() {
           if (vault) {
             const { data: existingRequest } = await supabase
               .from('vault_access_requests')
-              .select('id, status')
+              .select('id, status, requested_role')
               .eq('vault_id', vault.id)
               .eq('requester_id', user.id)
               .in('status', ['pending', 'approved'])
@@ -445,8 +446,10 @@ export default function VaultDetail() {
               refresh();
             } else if (existingRequest && existingRequest.status === 'pending') {
               setHasPendingRequest(true);
+              setPendingRequestRole(existingRequest.requested_role === 'editor' ? 'editor' : 'viewer');
             } else {
               setHasPendingRequest(false);
+              setPendingRequestRole(null);
             }
           }
         };
@@ -1510,7 +1513,7 @@ export default function VaultDetail() {
                     }
 
                     // Submit new request
-                    const result = await requestVaultAccess(vault.id, user.id, '');
+                    const result = await requestVaultAccess(vault.id, user.id, '', 'viewer');
                     if (result.error) throw result.error;
 
                     toast({
@@ -1630,6 +1633,12 @@ export default function VaultDetail() {
                     viewer
                   </Badge>
                 )}
+                {!isOwner && vault.visibility === 'public' && userRole === 'viewer' && hasPendingRequest && pendingRequestRole === 'editor' && (
+                  <Badge variant="outline" className="font-mono text-xs gap-1 shrink-0 text-yellow-600 border-yellow-500/30">
+                    <Clock className="w-3 h-3" />
+                    edit_request_pending
+                  </Badge>
+                )}
                 <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
                   <Clock className="w-3.5 h-3.5 shrink-0" />
                   <span className="truncate">
@@ -1682,6 +1691,71 @@ export default function VaultDetail() {
                       <GitFork className="w-4 h-4" />
                       <span className="ml-2 hidden md:inline">fork</span>
                     </Button>
+                    {vault.visibility === 'public' && userRole === 'viewer' && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={async () => {
+                          if (!user) {
+                            localStorage.setItem('redirectAfterLogin', `/vault/${vaultId}`);
+                            navigate('/auth');
+                            return;
+                          }
+
+                          try {
+                            const { data: existingRequest } = await supabase
+                              .from('vault_access_requests')
+                              .select('id, status, requested_role')
+                              .eq('vault_id', vault.id)
+                              .eq('requester_id', user.id)
+                              .in('status', ['pending', 'approved'])
+                              .maybeSingle();
+
+                            if (existingRequest?.status === 'pending') {
+                              setHasPendingRequest(true);
+                              setPendingRequestRole(existingRequest.requested_role === 'editor' ? 'editor' : 'viewer');
+                              toast({
+                                title: 'Request Already Pending',
+                                description: existingRequest.requested_role === 'editor'
+                                  ? 'Your edit access request is pending approval.'
+                                  : 'You already have an access request pending approval.',
+                              });
+                              return;
+                            }
+
+                            if (existingRequest?.status === 'approved') {
+                              toast({ title: 'Access Approved', description: 'Refreshing...' });
+                              refresh();
+                              return;
+                            }
+
+                            const result = await requestVaultAccess(vault.id, user.id, 'Requesting edit access to this public vault.', 'editor');
+                            if (result.error) throw result.error;
+
+                            setHasPendingRequest(true);
+                            setPendingRequestRole('editor');
+                            toast({
+                              title: 'Edit Access Requested',
+                              description: 'The vault owner has been notified.',
+                            });
+                            refresh();
+                          } catch (error) {
+                            logger.error('VaultDetail', 'Error requesting edit access:', error);
+                            toast({
+                              title: 'Error',
+                              description: (error as Error).message,
+                              variant: 'destructive',
+                            });
+                          }
+                        }}
+                        disabled={hasPendingRequest && pendingRequestRole === 'editor'}
+                        className="font-mono h-8"
+                        title="Request edit access"
+                      >
+                        <PencilLine className="w-4 h-4" />
+                        <span className="ml-2 hidden md:inline">{hasPendingRequest && pendingRequestRole === 'editor' ? 'edit requested' : 'request edit'}</span>
+                      </Button>
+                    )}
                   </>
                 )}
               </div>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -232,6 +232,7 @@ export interface VaultAccessRequest {
   requester_id: string | null;
   requester_email: string | null;
   requester_name: string | null;
+  requested_role: 'viewer' | 'editor';
   note: string | null;
   status: 'pending' | 'approved' | 'rejected';
   created_at: string;

--- a/src/types/vault-extensions.ts
+++ b/src/types/vault-extensions.ts
@@ -59,10 +59,12 @@ export const vaultHelpers = {
   createAccessRequest: (
     vaultId: string,
     requesterId: string,
-    note?: string
+    note?: string,
+    requestedRole: 'viewer' | 'editor' = 'viewer'
   ) => ({
     vault_id: vaultId,
     requester_id: requesterId,
+    requested_role: requestedRole,
     note: note || null,
     status: 'pending' as const,
   } as const),

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -979,6 +979,7 @@ CREATE TABLE IF NOT EXISTS "public"."vault_access_requests" (
     "updated_at" timestamp with time zone DEFAULT "timezone"('utc'::"text", "now"()),
     "requester_email" "text",
     "requester_name" "text",
+    "requested_role" "public"."vault_permission" DEFAULT 'viewer'::"public"."vault_permission" NOT NULL,
     "note" "text",
     "requester_id" "uuid" NOT NULL
 );


### PR DESCRIPTION
## Summary
- implement #83 so public vault viewers can request editor access
- add requested_role to vault access requests and default owner approval selection from the requested role
- bump RefHub to 1.3.8 and add a What's New entry

## Verification
- npm run lint
- npm run build
- git diff --check

## Notes
- lint still reports the existing PublicationDialog.tsx:646 hook dependency warning
- build passes with the existing large chunk warning
- Supabase needs the tracked schema change applied: vault_access_requests.requested_role public.vault_permission DEFAULT viewer NOT NULL

Closes #83