### PR TITLE
fix: polish mobile publication layouts

### DIFF
--- a/src/components/layout/BugReportButton.tsx
+++ b/src/components/layout/BugReportButton.tsx
@@ -21,7 +21,7 @@ export function BugReportButton() {
   };
 
   return (
-    <div className="pointer-events-none fixed bottom-4 right-4 z-40 sm:bottom-6 sm:right-6">
+    <div className="pointer-events-none fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] right-4 z-40 sm:bottom-6 sm:right-6">
       <div className="flex flex-col items-end gap-2 pointer-events-auto">
         <Badge
           variant="outline"

--- a/src/components/layout/ScrollToTopButton.tsx
+++ b/src/components/layout/ScrollToTopButton.tsx
@@ -27,7 +27,7 @@ export function ScrollToTopButton() {
   };
 
   return (
-    <div className="pointer-events-none fixed bottom-[calc(1rem+4.75rem)] right-4 z-40 sm:bottom-[calc(1.5rem+4.75rem)] sm:right-6">
+    <div className="pointer-events-none fixed bottom-[calc(1rem+4.75rem+env(safe-area-inset-bottom))] right-4 z-40 sm:bottom-[calc(1.5rem+4.75rem)] sm:right-6">
       <Button
         onClick={handleScrollToTop}
         size="icon"

--- a/src/components/profile/ProfileDialog.tsx
+++ b/src/components/profile/ProfileDialog.tsx
@@ -282,7 +282,7 @@ export function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
         description="You have unsaved changes to your profile. Would you like to save them before closing?"
       />
       <Dialog open={open} onOpenChange={handleDialogClose}>
-        <DialogContent className="dialog-mobile rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-3xl sm:max-h-[90vh] border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col gap-0 p-0">
+        <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-3xl sm:max-h-[90vh] border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col gap-0 p-0">
         <DialogHeader className="px-6 pt-6 pb-4">
           <DialogTitle className="text-2xl font-bold font-mono">edit_profile</DialogTitle>
         </DialogHeader>

--- a/src/components/profile/ProfileDialog.tsx
+++ b/src/components/profile/ProfileDialog.tsx
@@ -284,7 +284,7 @@ export function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
       <Dialog open={open} onOpenChange={handleDialogClose}>
         <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-3xl sm:max-h-[90vh] border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col gap-0 p-0">
         <DialogHeader className="px-6 pt-6 pb-4">
-          <DialogTitle className="text-2xl font-bold font-mono">edit_profile</DialogTitle>
+          <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">// edit_profile</DialogTitle>
         </DialogHeader>
 
         <Form {...form}>

--- a/src/components/publications/AddImportDialog.tsx
+++ b/src/components/publications/AddImportDialog.tsx
@@ -422,7 +422,7 @@ export function AddImportDialog({
                     placeholder="Author 1, Author 2, ..." className="font-mono text-sm" />
                 </div>
                 {/* Year + Type */}
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label className="font-semibold font-mono">year</Label>
                     <Input type="number" value={manualForm.year ?? ''} onChange={(e) => setManualForm(f => ({ ...f, year: e.target.value ? parseInt(e.target.value) : null }))}
@@ -445,7 +445,7 @@ export function AddImportDialog({
                     placeholder="Journal name" className="font-mono text-sm" />
                 </div>
                 {/* Volume / Issue / Pages */}
-                <div className="grid grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                   <div className="space-y-2">
                     <Label className="font-semibold font-mono">volume</Label>
                     <Input value={manualForm.volume || ''} onChange={(e) => setManualForm(f => ({ ...f, volume: e.target.value }))}
@@ -463,7 +463,7 @@ export function AddImportDialog({
                   </div>
                 </div>
                 {/* DOI + URL */}
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label className="font-semibold font-mono">doi</Label>
                     <Input value={manualForm.doi || ''} onChange={(e) => setManualForm(f => ({ ...f, doi: e.target.value }))}
@@ -614,7 +614,7 @@ export function AddImportDialog({
 
                 {/* ISSN + EID (articles) */}
                 {manualForm.publication_type === 'article' && (
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <Label className="font-semibold font-mono">issn</Label>
                       <Input value={manualForm.issn || ''} onChange={(e) => setManualForm(f => ({ ...f, issn: e.target.value }))}

--- a/src/components/publications/AddImportDialog.tsx
+++ b/src/components/publications/AddImportDialog.tsx
@@ -308,7 +308,7 @@ export function AddImportDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent forceMount className="dialog-mobile rounded-2xl p-0 border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col gap-0 min-h-0 sm:h-auto sm:w-[95vw] sm:max-w-4xl sm:max-h-[90vh] data-[state=closed]:hidden">
+      <DialogContent forceMount className="dialog-mobile max-w-[100vw] p-0 border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col gap-0 min-h-0 sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-4xl sm:max-h-[90vh] data-[state=closed]:hidden">
         <DialogHeader className="p-4 sm:p-6 pb-0">
           <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">
             // add_<span className="text-gradient">papers</span>

--- a/src/components/publications/ExportDialog.tsx
+++ b/src/components/publications/ExportDialog.tsx
@@ -162,9 +162,8 @@ export function ExportDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-lg sm:max-h-[90vh] flex flex-col overflow-hidden border-2 bg-card/95 backdrop-blur-xl p-0">
         <DialogHeader className="px-4 sm:px-6 pt-4 sm:pt-6 pb-4">
-          <DialogTitle className="flex items-center gap-2 font-mono text-lg sm:text-xl">
-            <FileText className="w-5 h-5 text-primary" />
-            export_references
+          <DialogTitle className="flex items-center gap-2 font-mono text-xl sm:text-2xl font-bold">
+            // export_references
             <KbdHint shortcut="Ctrl+E" className="ml-auto" size="sm" />
           </DialogTitle>
         </DialogHeader>

--- a/src/components/publications/ExportDialog.tsx
+++ b/src/components/publications/ExportDialog.tsx
@@ -160,7 +160,7 @@ export function ExportDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="dialog-mobile rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-lg sm:max-h-[90vh] flex flex-col overflow-hidden border-2 bg-card/95 backdrop-blur-xl p-0">
+      <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-lg sm:max-h-[90vh] flex flex-col overflow-hidden border-2 bg-card/95 backdrop-blur-xl p-0">
         <DialogHeader className="px-4 sm:px-6 pt-4 sm:pt-6 pb-4">
           <DialogTitle className="flex items-center gap-2 font-mono text-lg sm:text-xl">
             <FileText className="w-5 h-5 text-primary" />

--- a/src/components/publications/PublicationCard.tsx
+++ b/src/components/publications/PublicationCard.tsx
@@ -110,8 +110,8 @@ export function PublicationCard({
       )}
       onClick={onOpen}
     >
-      <CardContent className="p-5">
-        <div className="flex items-start gap-4">
+      <CardContent className="p-3 sm:p-5">
+        <div className="flex items-start gap-3 sm:gap-4">
           <div 
             className="pt-1"
             onClick={(e) => {
@@ -126,13 +126,13 @@ export function PublicationCard({
           </div>
 
           <div className="flex-1 min-w-0">
-            <div className="flex items-start justify-between gap-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex-1 min-w-0">
-                <h3 className="font-bold text-lg text-foreground leading-tight line-clamp-2 group-hover:text-primary transition-colors">
+                <h3 className="font-bold text-base sm:text-lg text-foreground leading-tight line-clamp-3 sm:line-clamp-2 group-hover:text-primary transition-colors">
                   {publication.title}
                 </h3>
                 {(show.authors || show.year || show.type) && (
-                  <p className="text-sm text-muted-foreground mt-1.5 font-mono">
+                  <p className="text-xs sm:text-sm text-muted-foreground mt-1.5 font-mono">
                     {show.authors && formatAuthors(publication.authors)}
                     {show.year && publication.year && (
                       <span className="text-neon-green">{show.authors ? ' • ' : ''}{publication.year}</span>
@@ -155,7 +155,7 @@ export function PublicationCard({
                 )}
               </div>
 
-              <div className="flex items-center gap-1 shrink-0">
+              <div className="flex flex-wrap items-center gap-1 shrink-0 sm:justify-end">
                 {show.pdf && publication.pdf_url && (
                   <a
                     href={publication.pdf_url}
@@ -195,7 +195,7 @@ export function PublicationCard({
                     <Button 
                       variant="ghost" 
                       size="icon" 
-                      className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity h-9 w-9"
+                      className="shrink-0 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity h-9 w-9"
                     >
                       <MoreVertical className="w-4 h-4" />
                     </Button>

--- a/src/components/publications/PublicationDialog.tsx
+++ b/src/components/publications/PublicationDialog.tsx
@@ -827,11 +827,11 @@ export function PublicationDialog({
           className="w-screen max-w-none box-border h-screen sm:w-[95vw] sm:max-w-3xl sm:h-auto sm:max-h-[90vh] m-0 p-0 border-0 sm:border-2 bg-card/95 backdrop-blur-xl overflow-x-hidden overflow-y-auto flex flex-col"
         >
         <DialogHeader className="px-2 py-3 sm:p-6 pb-2 sm:pb-0">
-          <DialogTitle className="text-lg sm:text-2xl font-bold font-mono pr-8 sm:pr-10">
+          <DialogTitle className="text-xl sm:text-2xl font-bold font-mono pr-8 sm:pr-10">
             {publication ? (
-              <span>edit_<span className="text-gradient">paper</span></span>
+              <span>// edit_<span className="text-gradient">paper</span></span>
             ) : (
-              <span>add_<span className="text-gradient">paper</span></span>
+              <span>// add_<span className="text-gradient">paper</span></span>
             )}
           </DialogTitle>
           {publication && onCheckSync && (

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -400,8 +400,8 @@ export function PublicationList({
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-x-hidden">
       {/* Header */}
-      <header className="bg-card/50 backdrop-blur-xl border-b-2 border-border px-4 lg:px-8 py-4 shrink-0 sticky top-0 z-10">
-        <div className="flex items-center gap-3">
+      <header className="bg-card/50 backdrop-blur-xl border-b-2 border-border px-3 sm:px-4 lg:px-8 py-3 sm:py-4 shrink-0 sticky top-0 z-10">
+        <div className="flex items-center gap-2 sm:gap-3">
           <MobileMenuButton 
             onClick={onMobileMenuOpen}
             className="shrink-0"
@@ -440,7 +440,7 @@ export function PublicationList({
             </p>
           </div>
 
-          <div className="flex items-center gap-2 shrink-0">
+          <div className="flex items-center gap-1 sm:gap-2 shrink-0">
             <NotificationDropdown />
 
             {/* Visible buttons on larger screens */}
@@ -531,7 +531,7 @@ export function PublicationList({
             )}
 
             {onAddPublication && (
-              <Button onClick={onAddPublication} variant="glow" className="h-9 font-mono">
+              <Button onClick={onAddPublication} variant="glow" className="h-9 w-9 sm:w-auto sm:px-3 font-mono">
                 <Plus className="w-4 h-4 sm:mr-2" />
                 <span className="hidden sm:inline">add_paper</span>
               </Button>
@@ -540,9 +540,9 @@ export function PublicationList({
         </div>
 
         {/* Search, filters and view settings */}
-        <div className="flex items-center gap-3 mt-5 flex-wrap">
+        <div className="mt-4 sm:mt-5 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
           {/* Search input — left side, grows to fill available space */}
-          <div className="relative flex-1 min-w-[160px]">
+          <div className="relative w-full sm:flex-1 sm:min-w-[220px]">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
             <Input
               ref={searchInputRef}
@@ -692,7 +692,7 @@ export function PublicationList({
       {/* Publication list */}
       <div
         ref={listContainerRef}
-        className="flex-1 overflow-y-auto scrollbar-thin overflow-x-hidden p-4 lg:p-8 outline-none"
+        className="flex-1 overflow-y-auto scrollbar-thin overflow-x-hidden p-3 sm:p-4 lg:p-8 pb-[calc(1rem+env(safe-area-inset-bottom))] outline-none"
         {...kbNav.containerProps}
       >
         {filteredPublications.length === 0 ? (
@@ -743,7 +743,7 @@ export function PublicationList({
             onCheckSync={onCheckPublicationSync}
           />
         ) : (
-          <div className="space-y-4 max-w-4xl mx-auto">
+          <div className="space-y-3 sm:space-y-4 max-w-4xl mx-auto">
             {filteredPublications.map((pub, index) => (
               <div
                 key={pub.id}

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -540,7 +540,7 @@ export function PublicationList({
         </div>
 
         {/* Search, filters and view settings */}
-        <div className="mt-4 sm:mt-5 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+        <div className="mt-4 sm:mt-5 flex flex-row flex-wrap gap-2 sm:gap-3 items-center">
           {/* Search input — left side, grows to fill available space */}
           <div className="relative w-full sm:flex-1 sm:min-w-[220px]">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />

--- a/src/components/publications/PublicationSyncDialog.tsx
+++ b/src/components/publications/PublicationSyncDialog.tsx
@@ -56,9 +56,8 @@ export function PublicationSyncDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl bg-card border-2 backdrop-blur-xl">
         <DialogHeader>
-          <DialogTitle className="font-mono flex items-center gap-2 text-base">
-            <RefreshCw className="w-4 h-4" />
-            semantic_scholar_sync()
+          <DialogTitle className="font-mono text-xl sm:text-2xl font-bold">
+            // semantic_scholar_sync()
           </DialogTitle>
           <DialogDescription className="font-mono text-xs">
             Review incoming metadata. Notes and tags are not affected.

--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -67,7 +67,7 @@ export function PublicationViewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="dialog-mobile publication-view-dialog rounded-2xl border-2 bg-card/95 backdrop-blur-xl overflow-hidden shadow-2xl sm:h-auto sm:w-[95vw] sm:max-w-3xl sm:max-h-[90vh] p-0 gap-0">
+      <DialogContent className="dialog-mobile publication-view-dialog max-w-[100vw] border-2 bg-card/95 backdrop-blur-xl overflow-hidden shadow-2xl sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-3xl sm:max-h-[90vh] p-0 gap-0">
         <DialogHeader className="shrink-0 space-y-3 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 border-b border-border/60">
           <div className="flex flex-wrap items-center gap-2">
             {publication.publication_type && (

--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -81,8 +81,8 @@ export function PublicationViewDialog({
               </Badge>
             )}
           </div>
-          <DialogTitle className="pr-8 text-lg sm:text-2xl font-bold leading-tight">
-            {publication.title}
+          <DialogTitle className="pr-8 text-xl sm:text-2xl font-bold font-mono leading-tight">
+            // {publication.title}
           </DialogTitle>
           <DialogDescription className="text-sm font-mono">
             {publication.authors.length > 0 ? publication.authors.join(', ') : 'unknown author'}

--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -67,8 +67,8 @@ export function PublicationViewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="publication-view-dialog w-[min(calc(100vw-2rem),48rem)] max-w-[calc(100vw-2rem)] rounded-2xl border-2 bg-card/95 backdrop-blur-xl max-h-[min(90vh,56rem)] overflow-y-auto shadow-2xl sm:max-w-3xl">
-        <DialogHeader className="space-y-3">
+      <DialogContent className="dialog-mobile publication-view-dialog rounded-2xl border-2 bg-card/95 backdrop-blur-xl overflow-hidden shadow-2xl sm:h-auto sm:w-[95vw] sm:max-w-3xl sm:max-h-[90vh] p-0 gap-0">
+        <DialogHeader className="shrink-0 space-y-3 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 border-b border-border/60">
           <div className="flex flex-wrap items-center gap-2">
             {publication.publication_type && (
               <Badge variant="outline" className="font-mono text-xs">
@@ -81,7 +81,7 @@ export function PublicationViewDialog({
               </Badge>
             )}
           </div>
-          <DialogTitle className="text-xl sm:text-2xl font-bold leading-tight">
+          <DialogTitle className="pr-8 text-lg sm:text-2xl font-bold leading-tight">
             {publication.title}
           </DialogTitle>
           <DialogDescription className="text-sm font-mono">
@@ -90,11 +90,11 @@ export function PublicationViewDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-6">
+        <div className="flex-1 min-h-0 overflow-y-auto space-y-5 sm:space-y-6 px-4 sm:px-6 py-4 sm:py-6">
           {(publication.doi || publication.url || publication.pdf_url || driveLoading || driveUrl) && (
-            <div className="flex flex-wrap gap-2">
+            <div className="grid grid-cols-1 sm:flex sm:flex-wrap gap-2">
               {publication.doi && (
-                <Button asChild variant="outline" size="sm" className="font-mono">
+                <Button asChild variant="outline" size="sm" className="w-full justify-start sm:w-auto font-mono">
                   <a
                     href={`https://doi.org/${encodeURIComponent(publication.doi)}`}
                     target="_blank"
@@ -106,7 +106,7 @@ export function PublicationViewDialog({
                 </Button>
               )}
               {publication.url && (
-                <Button asChild variant="outline" size="sm" className="font-mono">
+                <Button asChild variant="outline" size="sm" className="w-full justify-start sm:w-auto font-mono">
                   <a href={publication.url} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="w-4 h-4 mr-2" />
                     link
@@ -114,7 +114,7 @@ export function PublicationViewDialog({
                 </Button>
               )}
               {publication.pdf_url && (
-                <Button asChild variant="outline" size="sm" className="font-mono">
+                <Button asChild variant="outline" size="sm" className="w-full justify-start sm:w-auto font-mono">
                   <a href={publication.pdf_url} target="_blank" rel="noopener noreferrer">
                     <FileText className="w-4 h-4 mr-2" />
                     publisher_pdf
@@ -122,13 +122,13 @@ export function PublicationViewDialog({
                 </Button>
               )}
               {driveLoading && (
-                <Button variant="outline" size="sm" className="font-mono" disabled>
+                <Button variant="outline" size="sm" className="w-full justify-start sm:w-auto font-mono" disabled>
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                   drive_pdf
                 </Button>
               )}
               {!driveLoading && driveUrl && (
-                <Button asChild variant="outline" size="sm" className="font-mono">
+                <Button asChild variant="outline" size="sm" className="w-full justify-start sm:w-auto font-mono">
                   <a href={driveUrl} target="_blank" rel="noopener noreferrer">
                     <GoogleDriveIcon className="w-4 h-4 mr-2" />
                     drive_pdf
@@ -201,8 +201,8 @@ export function PublicationViewDialog({
         </div>
 
         {onEdit && (
-          <DialogFooter>
-            <Button type="button" className="font-mono" onClick={() => onEdit(publication)}>
+          <DialogFooter className="shrink-0 border-t border-border/60 px-4 sm:px-6 py-4 flex-col-reverse sm:flex-row gap-2">
+            <Button type="button" className="w-full sm:w-auto font-mono" onClick={() => onEdit(publication)}>
               <Pencil className="w-4 h-4 mr-2" />
               edit
             </Button>

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -304,7 +304,7 @@ export function VaultAugmentDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="dialog-mobile rounded-2xl sm:w-[95vw] sm:max-w-4xl sm:h-auto sm:min-h-[400px] sm:max-h-[90vh] flex flex-col bg-card/95 backdrop-blur-xl border-2 p-0 overflow-hidden">
+      <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:w-[95vw] sm:max-w-4xl sm:h-auto sm:min-h-[400px] sm:max-h-[90vh] flex flex-col bg-card/95 backdrop-blur-xl border-2 p-0 overflow-hidden">
         <DialogHeader className="shrink-0 px-6 pt-5 pb-3 border-b border-border/50">
           <DialogTitle className="text-xl font-bold font-mono">
             // vault_augmentation

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -306,7 +306,7 @@ export function VaultAugmentDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:w-[95vw] sm:max-w-4xl sm:h-auto sm:min-h-[400px] sm:max-h-[90vh] flex flex-col bg-card/95 backdrop-blur-xl border-2 p-0 overflow-hidden">
         <DialogHeader className="shrink-0 px-6 pt-5 pb-3 border-b border-border/50">
-          <DialogTitle className="text-xl font-bold font-mono">
+          <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">
             // vault_augmentation
           </DialogTitle>
           <DialogDescription className="font-mono text-sm text-muted-foreground">

--- a/src/components/ui/KeyboardHelpOverlay.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.tsx
@@ -67,14 +67,8 @@ export function KeyboardHelpOverlay() {
         {/* ── Header ────────────────────────────────────────────── */}
         <DialogHeader className="shrink-0 px-6 pt-6 pb-4 border-b border-border/60">
           <div className="flex items-center justify-between">
-            <DialogTitle className="font-mono flex items-center gap-2.5 text-base">
-              <div className="w-8 h-8 rounded-lg bg-gradient-primary flex items-center justify-center shadow-md glow-purple">
-                <Terminal className="w-4 h-4 text-white" />
-              </div>
-              <span>
-                <span className="text-gradient">keyboard</span>
-                <span className="text-muted-foreground">_shortcuts()</span>
-              </span>
+            <DialogTitle className="font-mono flex items-center gap-2.5 text-xl sm:text-2xl font-bold">
+              <span>// <span className="text-gradient">keyboard</span><span className="text-muted-foreground">_shortcuts()</span></span>
             </DialogTitle>
             <div className="flex items-center gap-2">
               <Button

--- a/src/components/ui/KeyboardHelpOverlay.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.tsx
@@ -63,9 +63,9 @@ export function KeyboardHelpOverlay() {
 
   return (
     <Dialog open={helpOverlayOpen} onOpenChange={setHelpOverlayOpen}>
-      <DialogContent className="max-w-3xl max-h-[85vh] p-0 gap-0 border-primary/20 shadow-2xl shadow-primary/10">
+      <DialogContent className="dialog-mobile max-w-[100vw] flex flex-col p-0 gap-0 border-primary/20 shadow-2xl shadow-primary/10 sm:rounded-2xl sm:max-w-3xl sm:h-auto sm:max-h-[85vh]">
         {/* ── Header ────────────────────────────────────────────── */}
-        <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/60">
+        <DialogHeader className="shrink-0 px-6 pt-6 pb-4 border-b border-border/60">
           <div className="flex items-center justify-between">
             <DialogTitle className="font-mono flex items-center gap-2.5 text-base">
               <div className="w-8 h-8 rounded-lg bg-gradient-primary flex items-center justify-center shadow-md glow-purple">
@@ -95,7 +95,7 @@ export function KeyboardHelpOverlay() {
         </DialogHeader>
 
         {/* ── Shortcut grid ─────────────────────────────────────── */}
-        <ScrollArea className="max-h-[60vh]">
+        <ScrollArea className="flex-1 min-h-0">
           <div className="p-6 grid grid-cols-1 md:grid-cols-2 gap-5">
             {SHORTCUT_HELP.map((group) => (
               <div
@@ -153,7 +153,7 @@ export function KeyboardHelpOverlay() {
         </ScrollArea>
 
         {/* ── Footer ────────────────────────────────────────────── */}
-        <div className="px-6 py-4 border-t border-border/60 bg-muted/20">
+        <div className="shrink-0 px-6 py-4 border-t border-border/60 bg-muted/20">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <Label htmlFor="kbd-toggle" className="text-xs text-muted-foreground font-mono cursor-pointer">

--- a/src/components/ui/WhatsNewDialog.tsx
+++ b/src/components/ui/WhatsNewDialog.tsx
@@ -70,8 +70,7 @@ export function WhatsNewDialog({ open, onOpenChange }: WhatsNewDialogProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="w-[95vw] max-w-lg flex flex-col bg-card/95 backdrop-blur-xl border-2 p-0 overflow-hidden max-h-[80vh]">
         <DialogHeader className="shrink-0 px-6 pt-5 pb-4 border-b border-border/50">
-          <DialogTitle className="text-xl font-bold font-mono flex items-center gap-2">
-            <Sparkles className="w-5 h-5 text-primary" />
+          <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">
             // whats_new
           </DialogTitle>
           <DialogDescription className="font-mono text-sm text-muted-foreground">

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100vw-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-lg max-h-[calc(100dvh-2rem)] overflow-y-auto duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
@@ -49,7 +49,7 @@ const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDiv
 AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+  <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2", className)} {...props} />
 );
 AlertDialogFooter.displayName = "AlertDialogFooter";
 
@@ -73,7 +73,7 @@ const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), "w-full sm:w-auto", className)} {...props} />
 ));
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
@@ -83,7 +83,7 @@ const AlertDialogCancel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Cancel
     ref={ref}
-    className={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+    className={cn(buttonVariants({ variant: "outline" }), "mt-2 w-full sm:mt-0 sm:w-auto", className)}
     {...props}
   />
 ));

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -52,7 +52,7 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+  <div className={cn("flex flex-col space-y-1.5 text-left", className)} {...props} />
 );
 DialogHeader.displayName = "DialogHeader";
 

--- a/src/components/ui/loader.tsx
+++ b/src/components/ui/loader.tsx
@@ -84,7 +84,7 @@ export function Loader({ message, className }: LoaderProps) {
         {/* Terminal content */}
         <div className="p-4 sm:p-6 font-mono text-sm space-y-4">
           {/* ASCII art logo */}
-          <pre className="text-gradient text-[10px] sm:text-xs leading-tight select-none overflow-x-auto">
+          <pre className="text-gradient text-[8px] sm:text-xs leading-tight select-none">
 {`
  *******   ******** ******** **      ** **     ** ******  
 /**////** /**///// /**///// /**     /**/**    /**/*////** 

--- a/src/components/ui/loading.tsx
+++ b/src/components/ui/loading.tsx
@@ -254,7 +254,7 @@ export function FullScreenLoader({ message, variant = 'terminal', progress = fal
         {/* Terminal content */}
         <div className="p-4 sm:p-6 font-mono text-sm space-y-4">
           {/* ASCII art logo */}
-          <pre className="text-gradient text-[10px] sm:text-xs leading-tight select-none overflow-x-auto">
+          <pre className="text-gradient text-[8px] sm:text-xs leading-tight select-none">
 {`
  *******   ******** ******** **      ** **     ** ******  
 /**////** /**///// /**///// /**     /**/**    /**/*////** 
@@ -365,7 +365,7 @@ export function PhaseLoader({ phases, title = 'initializing_refhub', subtitle, c
 
   return (
     <div className={cn("min-h-screen bg-background flex items-center justify-center", className)}>
-      <div className="w-full max-w-lg px-6">
+      <div className="w-full max-w-lg px-3 sm:px-6">
         {/* Terminal window */}
         <div className="bg-card border-2 border-border rounded-lg overflow-hidden shadow-2xl">
           {/* Terminal header */}
@@ -379,7 +379,7 @@ export function PhaseLoader({ phases, title = 'initializing_refhub', subtitle, c
           </div>
 
           {/* Terminal content */}
-          <div className="p-6 font-mono text-sm space-y-6">
+          <div className="p-4 sm:p-6 font-mono text-sm space-y-4 sm:space-y-6">
             {/* Title with glitch effect */}
             <div className="space-y-1">
               <h1 className={cn(

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -137,8 +137,8 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
         {canShare && (
           <DialogContent className="sm:max-w-sm">
             <DialogHeader>
-              <DialogTitle className="text-center font-mono">
-                share "{vault.name}"
+              <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">
+                // share "{vault.name}"
               </DialogTitle>
             </DialogHeader>
             <div className="flex flex-col items-center gap-4 sm:gap-6 py-2 sm:py-4">

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -835,7 +835,7 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
         description="You have unsaved changes to this vault. Would you like to save them before closing?"
       />
       <Dialog open={open} onOpenChange={handleDialogClose}>
-        <DialogContent className="dialog-mobile rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-2xl border-2 bg-card/95 backdrop-blur-xl sm:max-h-[90vh] overflow-hidden flex flex-col p-0">
+        <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-2xl border-2 bg-card/95 backdrop-blur-xl sm:max-h-[90vh] overflow-hidden flex flex-col p-0">
         <DialogHeader className="px-6 pt-6 pb-4">
           <div className="flex items-center justify-between gap-3">
             <DialogTitle className="text-2xl font-bold font-mono">

--- a/src/components/vaults/VaultDialog.tsx
+++ b/src/components/vaults/VaultDialog.tsx
@@ -838,11 +838,11 @@ export function VaultDialog({ open, onOpenChange, vault, initialRequestId, onSav
         <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-2xl border-2 bg-card/95 backdrop-blur-xl sm:max-h-[90vh] overflow-hidden flex flex-col p-0">
         <DialogHeader className="px-6 pt-6 pb-4">
           <div className="flex items-center justify-between gap-3">
-            <DialogTitle className="text-2xl font-bold font-mono">
+            <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">
               {vault ? (
-                <span>vault_<span className="text-gradient">settings</span></span>
+                <span>// vault_<span className="text-gradient">settings</span></span>
               ) : (
-                <span>create_<span className="text-gradient">vault</span></span>
+                <span>// create_<span className="text-gradient">vault</span></span>
               )}
             </DialogTitle>
             {accessRequests.length > 0 && (

--- a/src/index.css
+++ b/src/index.css
@@ -272,23 +272,12 @@
   padding-right: env(safe-area-inset-right);
 }
 
-/* Near-fullscreen dialog sizing on mobile — 1rem min inset each side, safe-area aware.
-   Use as `dialog-mobile sm:h-auto sm:w-[95vw] sm:max-w-[...]` on DialogContent.
-   At >=640px (sm), Tailwind's sm: utilities (in @layer utilities) override this component style. */
+/* Fullscreen dialog on mobile — use sm: variants on DialogContent for desktop sizing.
+   Height applies because dialogs only set sm:h-auto (no mobile height Tailwind class).
+   Width is full via w-full on the base. Desktop: sm: classes restore normal sizing. */
 @layer components {
   .dialog-mobile {
-    width: calc(100vw - 2rem);
-    max-width: calc(100vw - 2rem);
-    height: calc(100dvh - 2rem);
-    max-height: calc(100dvh - 2rem);
-  }
-
-  @supports (padding-top: env(safe-area-inset-top)) {
-    .dialog-mobile {
-      width: calc(100vw - max(1rem, env(safe-area-inset-left)) - max(1rem, env(safe-area-inset-right)));
-      max-width: calc(100vw - max(1rem, env(safe-area-inset-left)) - max(1rem, env(safe-area-inset-right)));
-      height: calc(100dvh - max(1rem, env(safe-area-inset-top)) - max(1rem, env(safe-area-inset-bottom)));
-      max-height: calc(100dvh - max(1rem, env(safe-area-inset-top)) - max(1rem, env(safe-area-inset-bottom)));
-    }
+    height: 100dvh;
+    max-height: 100dvh;
   }
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1592,7 +1592,7 @@ export default function Dashboard() {
         onEditProfile={() => setIsProfileDialogOpen(true)}
       />
 
-      <div className="flex-1 lg:pl-72 min-w-0">
+      <div className="flex-1 lg:pl-72 min-w-0 flex flex-col min-h-screen">
         <PublicationList
         publications={publications}
         tags={tags}

--- a/src/pages/ProfileEdit.tsx
+++ b/src/pages/ProfileEdit.tsx
@@ -222,7 +222,7 @@ export default function ProfileEdit() {
             <ArrowLeft className="w-5 h-5" />
           </Button>
           <div className="min-w-0 flex-1">
-            <h1 className="text-xl font-bold font-mono sm:text-2xl">account_<span className="text-gradient">settings</span></h1>
+            <h1 className="text-xl font-bold font-mono sm:text-2xl">// account_<span className="text-gradient">settings</span></h1>
             <p className="text-xs text-muted-foreground font-mono sm:text-sm">// manage your profile, security, API access, and linked storage</p>
           </div>
         </div>

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1664,11 +1664,11 @@ export default function VaultDetail() {
         onEditProfile={() => setIsProfileDialogOpen(true)}
       />
 
-      <div className="flex-1 lg:pl-72 min-w-0">
+      <div className="flex-1 lg:pl-72 min-w-0 flex flex-col min-h-screen">
         {/* Vault Header */}
-        <div className="border-b border-border bg-card/50 backdrop-blur-xl sticky top-0 z-30">
-          <div className="px-4 py-3">
-            <div className="flex items-center justify-between gap-2">
+        <div className="border-b border-border bg-card/50 backdrop-blur-xl sticky top-0 z-30 shrink-0">
+          <div className="px-3 sm:px-4 py-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-2 min-w-0 flex-wrap">
                 {visibilityBadge}
                 {forkInfo?.forkedFrom && (
@@ -1716,7 +1716,7 @@ export default function VaultDetail() {
                 </span>
               </div>
 
-              <div className="flex items-center gap-2 shrink-0">
+              <div className="flex items-center gap-2 shrink-0 overflow-x-auto pb-1 sm:overflow-visible sm:pb-0">
                 {/* Stats for owners */}
                 {isOwner && currentVault && (
                   <>

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1666,7 +1666,7 @@ export default function VaultDetail() {
 
       <div className="flex-1 lg:pl-72 min-w-0 flex flex-col min-h-screen">
         {/* Vault Header */}
-        <div className="border-b border-border bg-card/50 backdrop-blur-xl sticky top-0 z-30 shrink-0">
+        <div className="border-b border-border bg-card/50 backdrop-blur-xl sm:sticky sm:top-0 sm:z-30 shrink-0">
           <div className="px-3 sm:px-4 py-3">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-2 min-w-0 flex-wrap">


### PR DESCRIPTION
## Summary
- tighten mobile dashboard/vault publication list headers and controls
- make publication cards, publication view dialog, and import grids more mobile-friendly
- improve alert dialog sizing/actions and safe-area spacing for floating buttons

## Verification
- npm run build ✅
- npm run lint ⚠️ fails on pre-existing src/components/publications/PublicationSyncDialog.tsx:46 no-unused-expressions; warnings in Dashboard/VaultDetail pre-existing hook deps
- manual code inspection of affected mobile classes/layouts