### PR TITLE
Fix global publication keyboard shortcuts

### DIFF
--- a/src/components/publications/FilterBuilder.tsx
+++ b/src/components/publications/FilterBuilder.tsx
@@ -60,6 +60,7 @@ interface FilterBuilderProps {
   vaults: Vault[];
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  onCloseAutoFocus?: (event: Event) => void;
 }
 
 const FIELD_OPTIONS: { value: FilterField; label: string }[] = [
@@ -116,7 +117,7 @@ const needsValueInput = (operator: FilterOperator): boolean => {
   return !['is_empty', 'is_not_empty'].includes(operator);
 };
 
-export function FilterBuilder({ filters, onFiltersChange, tags, vaults, open: controlledOpen, onOpenChange }: FilterBuilderProps) {
+export function FilterBuilder({ filters, onFiltersChange, tags, vaults, open: controlledOpen, onOpenChange, onCloseAutoFocus }: FilterBuilderProps) {
   const [internalOpen, setInternalOpen] = useState(false);
   const isOpen = controlledOpen ?? internalOpen;
   const setIsOpen = (v: boolean) => { setInternalOpen(v); onOpenChange?.(v); };
@@ -358,7 +359,7 @@ export function FilterBuilder({ filters, onFiltersChange, tags, vaults, open: co
         <SheetTrigger asChild>
           {filterTrigger}
         </SheetTrigger>
-        <SheetContent side="bottom" className="px-4 pb-8 pt-4 max-h-[80vh] overflow-y-auto">
+        <SheetContent side="bottom" className="px-4 pb-8 pt-4 max-h-[80vh] overflow-y-auto" onCloseAutoFocus={onCloseAutoFocus}>
           <SheetHeader className="mb-4">
             <SheetTitle className="font-mono text-left">filter_papers</SheetTitle>
           </SheetHeader>
@@ -378,6 +379,7 @@ export function FilterBuilder({ filters, onFiltersChange, tags, vaults, open: co
         side="bottom"
         sideOffset={8}
         className="w-auto min-w-[400px] p-3 bg-popover border-2"
+        onCloseAutoFocus={onCloseAutoFocus}
       >
         {filterContent}
       </PopoverContent>

--- a/src/components/publications/PersistentFilterBuilder.tsx
+++ b/src/components/publications/PersistentFilterBuilder.tsx
@@ -9,9 +9,10 @@ interface PersistentFilterBuilderProps {
   onFiltersChange?: (filters: PublicationFilter[]) => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  onCloseAutoFocus?: (event: Event) => void;
 }
 
-export function PersistentFilterBuilder({ tags, vaults, onFiltersChange, open, onOpenChange }: PersistentFilterBuilderProps) {
+export function PersistentFilterBuilder({ tags, vaults, onFiltersChange, open, onOpenChange, onCloseAutoFocus }: PersistentFilterBuilderProps) {
   const {
     filters: persistedFilters,
     updateFilters
@@ -32,6 +33,7 @@ export function PersistentFilterBuilder({ tags, vaults, onFiltersChange, open, o
       vaults={vaults}
       open={open}
       onOpenChange={onOpenChange}
+      onCloseAutoFocus={onCloseAutoFocus}
     />
   );
 }

--- a/src/components/publications/PublicationDialog.tsx
+++ b/src/components/publications/PublicationDialog.tsx
@@ -32,6 +32,7 @@ import { HierarchicalTagSelector } from '@/components/tags/HierarchicalTagSelect
 import { usePublicationRelations } from '@/hooks/usePublicationRelations';
 import { useAuth } from '@/hooks/useAuth';
 import { uploadPublicationDrivePdf, uploadVaultPublicationDrivePdf } from '@/lib/pdfUpload';
+import { fetchGoogleDriveStatus, GoogleDriveStatus } from '@/lib/googleDrive';
 
 interface PublicationDialogProps {
   open: boolean;
@@ -75,7 +76,7 @@ export function PublicationDialog({
   closeOnSave = false,
   driveUrl,
 }: PublicationDialogProps) {
-  const { user } = useAuth();
+  const { user, session } = useAuth();
   const {
     relations,
     loading: relationsLoading,
@@ -132,6 +133,9 @@ export function PublicationDialog({
   const [drivePdfInput, setDrivePdfInput] = useState<string>(driveUrl ?? '');
   const [driveUploadStatus, setDriveUploadStatus] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle');
   const [driveUploadError, setDriveUploadError] = useState('');
+  const [driveStatus, setDriveStatus] = useState<GoogleDriveStatus | null>(null);
+  const [driveStatusLoading, setDriveStatusLoading] = useState(false);
+  const [driveStatusError, setDriveStatusError] = useState('');
   const drivePdfFileInputRef = useRef<HTMLInputElement | null>(null);
   const driveUploadResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fullscreenCleanNotesRef = useRef<string>(''); // snapshot of notes when entering fullscreen
@@ -215,8 +219,53 @@ export function PublicationDialog({
   useEffect(() => { formDataRef.current = formData; }, [formData]);
   useEffect(() => { selectedTagsRef.current = selectedTags; }, [selectedTags]);
   useEffect(() => { setDrivePdfInput(driveUrl ?? ''); }, [driveUrl]);
+
+  useEffect(() => {
+    if (!open || !session?.access_token) {
+      setDriveStatus(null);
+      setDriveStatusError('');
+      setDriveStatusLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const loadDriveStatus = async () => {
+      setDriveStatusLoading(true);
+      setDriveStatusError('');
+      try {
+        const nextStatus = await fetchGoogleDriveStatus(session.access_token);
+        if (!cancelled) setDriveStatus(nextStatus);
+      } catch (err) {
+        if (!cancelled) {
+          setDriveStatus(null);
+          setDriveStatusError((err as Error).message);
+        }
+      } finally {
+        if (!cancelled) setDriveStatusLoading(false);
+      }
+    };
+
+    void loadDriveStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, session?.access_token]);
+
+  const isDriveUploadReady = Boolean(driveStatus?.linked && driveStatus.folderStatus === 'ready');
+  const driveUploadSetupHint = !session?.access_token
+    ? 'sign in again before uploading PDFs to Google Drive.'
+    : driveStatusLoading
+      ? 'checking Google Drive setup...'
+      : driveStatusError
+        ? 'could not verify Google Drive setup. Open settings > storage and reconnect Google Drive.'
+        : !driveStatus?.linked
+          ? 'connect Google Drive in profile settings > storage to upload PDFs.'
+          : driveStatus.folderStatus !== 'ready'
+            ? 'prepare the RefHub Drive folder in profile settings > storage before uploading PDFs.'
+            : '';
+
   const handleDrivePdfFileSelected = useCallback(async (file: File | null) => {
-    if (!file || !publication?.id) return;
+    if (!file || !publication?.id || !isDriveUploadReady) return;
 
     if (driveUploadResetRef.current) clearTimeout(driveUploadResetRef.current);
     setDriveUploadStatus('uploading');
@@ -235,7 +284,7 @@ export function PublicationDialog({
     } finally {
       if (drivePdfFileInputRef.current) drivePdfFileInputRef.current.value = '';
     }
-  }, [currentVaultId, driveUploadContext, publication?.id]);
+  }, [currentVaultId, driveUploadContext, isDriveUploadReady, publication?.id]);
 
 
   // ─── Last-save indicator timer (fullscreen notes) ──────────────────────────
@@ -1070,8 +1119,10 @@ export function PublicationDialog({
                   type="button"
                   variant="outline"
                   size="sm"
-                  disabled={!publication?.id || driveUploadStatus === 'uploading'}
+                  disabled={!publication?.id || !isDriveUploadReady || driveUploadStatus === 'uploading'}
+                  aria-describedby={!isDriveUploadReady ? 'drive_pdf_setup_hint' : undefined}
                   onClick={() => {
+                    if (!isDriveUploadReady) return;
                     setDriveUploadStatus('idle');
                     setDriveUploadError('');
                     drivePdfFileInputRef.current?.click();
@@ -1085,12 +1136,18 @@ export function PublicationDialog({
                   {driveUploadStatus === 'uploading' && <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />}
                   {driveUploadStatus === 'success' && <CheckCircle2 className="w-3.5 h-3.5 mr-1.5" />}
                   {driveUploadStatus === 'error' && <AlertCircle className="w-3.5 h-3.5 mr-1.5" />}
-                  {driveUploadStatus === 'idle' && <Upload className="w-3.5 h-3.5 mr-1.5" />}
+                  {driveUploadStatus === 'idle' && (driveStatusLoading ? <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" /> : <Upload className="w-3.5 h-3.5 mr-1.5" />)}
                   {driveUploadStatus === 'uploading' ? 'uploading…' :
                    driveUploadStatus === 'success' ? 'uploaded!' :
                    driveUploadStatus === 'error' ? 'retry' : 'upload_pdf'}
                 </Button>
               </div>
+              {!isDriveUploadReady && driveUploadSetupHint && (
+                <p id="drive_pdf_setup_hint" className="text-xs font-mono text-muted-foreground flex items-start gap-1.5 pt-0.5">
+                  <AlertCircle className="w-3 h-3 shrink-0 mt-0.5 text-fuchsia-300" />
+                  {driveUploadSetupHint}
+                </p>
+              )}
               {driveUploadStatus === 'error' && driveUploadError && (
                 <p className="text-xs font-mono text-destructive flex items-start gap-1.5 pt-0.5">
                   <AlertCircle className="w-3 h-3 shrink-0 mt-0.5" />

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -122,11 +122,19 @@ export function PublicationList({
   const { setActiveContext } = useKeyboardContext();
 
   const releaseToolbarFocus = useCallback(() => {
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
-    }
-    setActiveContext('publication-list');
+    requestAnimationFrame(() => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+      listContainerRef.current?.focus();
+      setActiveContext('publication-list');
+    });
   }, [setActiveContext]);
+
+  const handleToolbarCloseAutoFocus = useCallback((event: Event) => {
+    event.preventDefault();
+    releaseToolbarFocus();
+  }, [releaseToolbarFocus]);
 
   // Calculate tag usage counts
   const tagUsageCounts = useMemo(() => {
@@ -616,6 +624,7 @@ export function PublicationList({
                 onFiltersChange={setFilters}
                 open={filterOpen}
                 onOpenChange={setFilterOpen}
+                onCloseAutoFocus={handleToolbarCloseAutoFocus}
               />
               {persistedFilters.length > 0 && (
                 <span className="absolute -top-1 -right-1 w-2 h-2 bg-primary rounded-full z-10"></span>
@@ -644,7 +653,7 @@ export function PublicationList({
                     )}
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="font-mono">
+                <DropdownMenuContent align="end" className="font-mono" onCloseAutoFocus={handleToolbarCloseAutoFocus}>
                   <DropdownMenuItem onClick={() => { setSortBy('created'); setSortDirection('desc'); }}>
                     recently_added
                   </DropdownMenuItem>
@@ -671,6 +680,7 @@ export function PublicationList({
             propertiesHint={<KbdHint shortcut="p" size="xs" className="hidden md:inline-flex !px-1 !py-0.5 !text-[10px] !leading-none !h-4" />}
             propertiesOpen={propertiesOpen}
             onPropertiesOpenChange={setPropertiesOpen}
+            onPropertiesCloseAutoFocus={handleToolbarCloseAutoFocus}
           />
 
           {selectedIds.size > 0 && onDiscoverRelated && (

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -290,6 +290,7 @@ export function PublicationList({
     onExport: handleKbExport,
     activateOnMount: true,
     bootstrapOnNav: true,
+    appWideShortcuts: true,
     containerRef: listContainerRef as React.RefObject<HTMLElement>,
     resetKey: selectedVault?.id ?? 'all_papers',
   });
@@ -328,7 +329,9 @@ export function PublicationList({
   const selectedPublications = publications.filter((p) => selectedIds.has(p.id));
 
 
-  // Meta+K / Ctrl+K → focus search (registered through keyboard system)
+  // Meta+K / Ctrl+K → focus search (registered through keyboard system).
+  // Escape from the focused search clears/blurs so single-letter shortcuts
+  // resume without requiring a click elsewhere.
   useHotkeys(
     'global',
     [
@@ -342,17 +345,32 @@ export function PublicationList({
         },
         allowInInput: true,
       },
+      {
+        combo: 'Escape',
+        description: 'Clear search',
+        handler: () => {
+          if (document.activeElement !== searchInputRef.current) return false;
+          if (searchQuery) setSearchQuery('');
+          searchInputRef.current?.blur();
+          return true;
+        },
+        allowInInput: true,
+      },
     ],
-    [],
+    [searchQuery],
   );
 
-  // publication-list context: p, f, s shortcuts
+  // Publication page shortcuts are unique app-wide; register them as appWide so
+  // stale activeContext never forces a click before f/s/p/r work. The keyboard
+  // provider still blocks them while typing in editable fields and while modal
+  // contexts are active.
   useHotkeys(
     kbContext,
     [
       {
         combo: 'p',
         description: 'Show properties popup',
+        appWide: true,
         handler: (e) => {
           e.preventDefault();
           setPropertiesOpen((prev) => !prev);
@@ -364,6 +382,7 @@ export function PublicationList({
       {
         combo: 'f',
         description: 'Show filter popup',
+        appWide: true,
         handler: (e) => {
           e.preventDefault();
           setFilterOpen((prev) => !prev);
@@ -375,6 +394,7 @@ export function PublicationList({
       {
         combo: 's',
         description: 'Show sort popup',
+        appWide: true,
         handler: (e) => {
           e.preventDefault();
           setSortDropdownOpen((prev) => !prev);
@@ -386,6 +406,7 @@ export function PublicationList({
       {
         combo: 'r',
         description: 'Discover related papers',
+        appWide: true,
         handler: (e) => {
           if (!onDiscoverRelated || selectedPublications.length === 0) return false;
           e.preventDefault();

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -330,8 +330,8 @@ export function PublicationList({
 
 
   // Meta+K / Ctrl+K → focus search (registered through keyboard system).
-  // Escape from the focused search clears/blurs so single-letter shortcuts
-  // resume without requiring a click elsewhere.
+  // Escape always closes the currently active toolbar/search affordance first,
+  // without disturbing the other shortcuts that now work app-wide.
   useHotkeys(
     'global',
     [
@@ -347,17 +347,35 @@ export function PublicationList({
       },
       {
         combo: 'Escape',
-        description: 'Clear search',
+        description: 'Close active search or popup',
         handler: () => {
-          if (document.activeElement !== searchInputRef.current) return false;
-          if (searchQuery) setSearchQuery('');
-          searchInputRef.current?.blur();
-          return true;
+          if (document.activeElement === searchInputRef.current) {
+            if (searchQuery) setSearchQuery('');
+            searchInputRef.current?.blur();
+            return true;
+          }
+
+          if (propertiesOpen) {
+            setPropertiesOpen(false);
+            return true;
+          }
+
+          if (sortDropdownOpen) {
+            setSortDropdownOpen(false);
+            return true;
+          }
+
+          if (filterOpen) {
+            setFilterOpen(false);
+            return true;
+          }
+
+          return false;
         },
         allowInInput: true,
       },
     ],
-    [searchQuery],
+    [filterOpen, propertiesOpen, searchQuery, sortDropdownOpen],
   );
 
   // Publication page shortcuts are unique app-wide; register them as appWide so

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -119,18 +119,14 @@ export function PublicationList({
   const [propertiesOpen, setPropertiesOpen] = useState(false);
   const listContainerRef = useRef<HTMLDivElement>(null);
 
-  const { pushContext, popContext } = useKeyboardContext();
+  const { setActiveContext } = useKeyboardContext();
 
-  // While any toolbar popup is open, push 'dialog' context so publication-list
-  // shortcuts (j/k/up/down/space/enter) don't fire inside them. Radix handles
-  // arrow key / Escape navigation natively. When all popups close, context pops
-  // back to publication-list automatically.
-  useEffect(() => {
-    if (filterOpen || sortDropdownOpen || propertiesOpen) {
-      pushContext('dialog');
-      return () => popContext();
+  const releaseToolbarFocus = useCallback(() => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
     }
-  }, [filterOpen, sortDropdownOpen, propertiesOpen, pushContext, popContext]);
+    setActiveContext('publication-list');
+  }, [setActiveContext]);
 
   // Calculate tag usage counts
   const tagUsageCounts = useMemo(() => {
@@ -271,7 +267,8 @@ export function PublicationList({
     setFilterOpen(false);
     setSortDropdownOpen(false);
     setPropertiesOpen(false);
-  }, []);
+    releaseToolbarFocus();
+  }, [releaseToolbarFocus]);
 
   const handleKbExport = useCallback(
     (ids: string[]) => {
@@ -351,22 +348,25 @@ export function PublicationList({
         handler: () => {
           if (document.activeElement === searchInputRef.current) {
             if (searchQuery) setSearchQuery('');
-            searchInputRef.current?.blur();
+            releaseToolbarFocus();
             return true;
           }
 
           if (propertiesOpen) {
             setPropertiesOpen(false);
+            releaseToolbarFocus();
             return true;
           }
 
           if (sortDropdownOpen) {
             setSortDropdownOpen(false);
+            releaseToolbarFocus();
             return true;
           }
 
           if (filterOpen) {
             setFilterOpen(false);
+            releaseToolbarFocus();
             return true;
           }
 
@@ -391,6 +391,7 @@ export function PublicationList({
         appWide: true,
         handler: (e) => {
           e.preventDefault();
+          releaseToolbarFocus();
           setPropertiesOpen((prev) => !prev);
           setFilterOpen(false);
           setSortDropdownOpen(false);
@@ -403,6 +404,7 @@ export function PublicationList({
         appWide: true,
         handler: (e) => {
           e.preventDefault();
+          releaseToolbarFocus();
           setFilterOpen((prev) => !prev);
           setSortDropdownOpen(false);
           setPropertiesOpen(false);
@@ -415,6 +417,7 @@ export function PublicationList({
         appWide: true,
         handler: (e) => {
           e.preventDefault();
+          releaseToolbarFocus();
           setSortDropdownOpen((prev) => !prev);
           setFilterOpen(false);
           setPropertiesOpen(false);
@@ -433,7 +436,7 @@ export function PublicationList({
         },
       },
     ],
-    [kbContext, onDiscoverRelated, selectedPublications],
+    [kbContext, onDiscoverRelated, releaseToolbarFocus, selectedPublications],
   );
 
   return (

--- a/src/components/publications/ViewSettings.tsx
+++ b/src/components/publications/ViewSettings.tsx
@@ -39,6 +39,7 @@ interface ViewSettingsProps {
   propertiesHint?: ReactNode;
   propertiesOpen?: boolean;
   onPropertiesOpenChange?: (open: boolean) => void;
+  onPropertiesCloseAutoFocus?: (event: Event) => void;
 }
 
 const COLUMN_OPTIONS: { key: keyof VisibleColumns; label: string }[] = [
@@ -83,6 +84,7 @@ export function ViewSettings({
   propertiesHint,
   propertiesOpen,
   onPropertiesOpenChange,
+  onPropertiesCloseAutoFocus,
 }: ViewSettingsProps) {
   const {
     viewMode: persistedViewMode,
@@ -186,7 +188,7 @@ export function ViewSettings({
             {/* p shortcut hint now outside in PublicationList */}
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="end" className="w-56 p-3 bg-popover border-2">
+        <PopoverContent align="end" className="w-56 p-3 bg-popover border-2" onCloseAutoFocus={onPropertiesCloseAutoFocus}>
           <div className="space-y-3">
             <h4 className="text-sm font-semibold">Visible Properties</h4>
             <p className="text-xs text-muted-foreground font-mono">

--- a/src/contexts/KeyboardContext.tsx
+++ b/src/contexts/KeyboardContext.tsx
@@ -14,10 +14,24 @@ import {
   parseCombo,
   matchesCombo,
   isEditableTarget,
+  isNativeInteractiveTarget,
   ChordMachine,
   ChordDef,
 } from '@/lib/keyboard';
 import { debug } from '@/lib/logger';
+
+const MODAL_CONTEXTS = new Set<KeyboardContextName>(['dialog', 'editor', 'export', 'search']);
+
+function isContextActive(def: ShortcutDef, currentContext: KeyboardContextName): boolean {
+  if (def.context === currentContext || def.context === 'global') return true;
+
+  // RefHub shortcuts are intentionally unique app-wide. Let normal page-level
+  // shortcuts fire even if activeContext is stale after a route/view change,
+  // but never steal keys from modal/editor/search/export contexts.
+  if (def.appWide && !MODAL_CONTEXTS.has(currentContext)) return true;
+
+  return false;
+}
 
 // ─── Feature flag ────────────────────────────────────────────────────────────
 
@@ -226,15 +240,17 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
       const currentContext = contextStackRef.current[contextStackRef.current.length - 1];
       const inInput = isEditableTarget(e);
 
-      // Sort shortcuts by context priority (highest first)
+      // Sort shortcuts by context priority (highest first). For equal priority,
+      // the most recently registered shortcut wins; this keeps the active
+      // PublicationList instance authoritative when toggling card/table views.
       const sorted = [...allShortcuts].sort(
         (a, b) =>
-          (CONTEXT_PRIORITY[b.context] ?? 0) - (CONTEXT_PRIORITY[a.context] ?? 0),
+          (CONTEXT_PRIORITY[b.context] ?? 0) - (CONTEXT_PRIORITY[a.context] ?? 0) ||
+          allShortcuts.lastIndexOf(b) - allShortcuts.lastIndexOf(a),
       );
 
       for (const def of sorted) {
-        // Only fire shortcuts from the active context or from 'global'
-        if (def.context !== currentContext && def.context !== 'global') continue;
+        if (!isContextActive(def, currentContext)) continue;
 
         const parsed = parseCombo(def.combo);
 
@@ -243,6 +259,11 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
         // allowInInput.  This ensures browser defaults (Ctrl+A to select text,
         // Ctrl+C to copy, etc.) work normally inside inputs / textareas.
         if (inInput && !def.allowInInput) continue;
+
+        // App-wide shortcuts are for normal page chrome/list contexts only.
+        // Do not let them hijack focused buttons, links, dropdown/menu items,
+        // checkboxes, radios, selects, or other native/ARIA controls.
+        if (def.appWide && isNativeInteractiveTarget(e)) continue;
 
         if (matchesCombo(e, parsed)) {
           e.preventDefault();

--- a/src/contexts/KeyboardContext.tsx
+++ b/src/contexts/KeyboardContext.tsx
@@ -266,11 +266,13 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
         if (def.appWide && isNativeInteractiveTarget(e)) continue;
 
         if (matchesCombo(e, parsed)) {
-          e.preventDefault();
           const handled = def.handler(e);
-          emitAnalytics(def.combo, def.context);
-          debug('KeyboardContext', `shortcut matched: ${def.combo} in ${def.context}`);
-          if (handled !== false) return; // stop propagation to lower-priority shortcuts
+          if (handled !== false) {
+            e.preventDefault();
+            emitAnalytics(def.combo, def.context);
+            debug('KeyboardContext', `shortcut matched: ${def.combo} in ${def.context}`);
+            return; // stop propagation to lower-priority shortcuts
+          }
         }
       }
 

--- a/src/hooks/useKeyboardNavigation.tsx
+++ b/src/hooks/useKeyboardNavigation.tsx
@@ -15,6 +15,7 @@ export interface HotkeyDef {
   description: string;
   handler: (e: KeyboardEvent) => boolean | void;
   allowInInput?: boolean;
+  appWide?: boolean;
 }
 
 /**
@@ -37,6 +38,7 @@ export function useHotkeys(
       context,
       handler: d.handler,
       allowInInput: d.allowInInput,
+      appWide: d.appWide,
     }));
 
     return registerShortcuts(shortcutDefs);
@@ -72,6 +74,8 @@ export interface UseKeyboardNavigationOptions {
    * do NOT enable for sidebar / secondary lists to avoid context conflicts.
    */
   bootstrapOnNav?: boolean;
+  /** Make this list's shortcuts available across normal app contexts. */
+  appWideShortcuts?: boolean;
 }
 
 export interface UseKeyboardNavigationReturn {
@@ -128,6 +132,7 @@ export function useKeyboardNavigation(
     containerRef,
     resetKey,
     bootstrapOnNav = false,
+    appWideShortcuts = false,
   } = options;
 
   const kb = useKeyboardContext();
@@ -364,6 +369,7 @@ export function useKeyboardNavigation(
       {
         combo: 'j',
         description: 'Move focus down',
+        appWide: appWideShortcuts,
         handler: () => { moveFocus(1); return true; },
       },
       {
@@ -374,6 +380,7 @@ export function useKeyboardNavigation(
       {
         combo: 'k',
         description: 'Move focus up',
+        appWide: appWideShortcuts,
         handler: () => { moveFocus(-1); return true; },
       },
       {
@@ -396,6 +403,7 @@ export function useKeyboardNavigation(
       {
         combo: 'Shift+g',
         description: 'Jump to last item',
+        appWide: appWideShortcuts,
         handler: () => { jumpTo(itemIdsRef.current.length - 1); return true; },
       },
       // Enter: open
@@ -426,6 +434,7 @@ export function useKeyboardNavigation(
       {
         combo: 'v',
         description: 'Toggle view mode',
+        appWide: appWideShortcuts,
         handler: () => {
           onToggleView?.();
           return true;
@@ -486,6 +495,7 @@ export function useKeyboardNavigation(
       {
         combo: 'Shift+j',
         description: 'Range select down',
+        appWide: appWideShortcuts,
         handler: () => {
           if (rangeAnchorRef.current == null) rangeAnchorRef.current = focusedIndexRef.current;
           moveFocus(1);
@@ -497,6 +507,7 @@ export function useKeyboardNavigation(
       {
         combo: 'Shift+k',
         description: 'Range select up',
+        appWide: appWideShortcuts,
         handler: () => {
           if (rangeAnchorRef.current == null) rangeAnchorRef.current = focusedIndexRef.current;
           moveFocus(-1);
@@ -519,20 +530,22 @@ export function useKeyboardNavigation(
     [moveFocus, jumpTo, toggleSelection, doRangeSelect, selectAll, clearSelection, onOpen, onDelete, onToggleView, onExport],
   );
 
-  // Feed single non-modifier keys into chord machine
+  // Feed single non-modifier keys into chord machine. App-wide primary lists
+  // keep gg working even when activeContext is stale; scoped lists keep the old
+  // context gate so sidebar/vault-list chords cannot accidentally compete.
   useEffect(() => {
     if (!kb.enabled) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (shouldSuppressSingleKey()) return;
       if (e.ctrlKey || e.metaKey || e.altKey) return;
-      if (kb.activeContext !== context) return;
+      if (!appWideShortcuts && kb.activeContext !== context) return;
       chordRef.current?.feed(e.key);
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [kb.enabled, kb.activeContext, context]);
+  }, [kb.enabled, kb.activeContext, context, appWideShortcuts]);
 
   // Item props generator
   const itemProps = useCallback(

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -198,6 +198,75 @@ export function isEditableTarget(e: KeyboardEvent): boolean {
   return false;
 }
 
+const NATIVE_INTERACTIVE_SELECTOR = [
+  'button',
+  'a[href]',
+  'select',
+  'summary',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="menuitem"]',
+  '[role="menuitemcheckbox"]',
+  '[role="menuitemradio"]',
+  '[role="option"]',
+  '[role="tab"]',
+  '[role="checkbox"]',
+  '[role="radio"]',
+  '[role="switch"]',
+  '[role="combobox"]',
+  '[role="slider"]',
+  '[role="spinbutton"]',
+  '[contenteditable="false"][tabindex]',
+].join(',');
+
+function isNativeInteractiveElement(el?: Element | null): boolean {
+  if (!el) return false;
+
+  const htmlEl = el as HTMLElement;
+  if (htmlEl.dataset?.keyboardIgnore !== undefined) return true;
+
+  if (el instanceof HTMLInputElement) {
+    // Text-like inputs are already covered by isEditableTarget; keep the native
+    // guard focused on controls whose Enter/Space/arrows/Delete behavior belongs
+    // to the browser or component library.
+    return [
+      'button',
+      'checkbox',
+      'color',
+      'file',
+      'image',
+      'radio',
+      'range',
+      'reset',
+      'submit',
+    ].includes(el.type);
+  }
+
+  return el.matches?.(NATIVE_INTERACTIVE_SELECTOR) ?? false;
+}
+
+/**
+ * Returns true when an event originates from, or focus is currently inside, a
+ * native/ARIA interactive control. App-wide shortcuts should not steal these
+ * controls' Enter/Space/arrows/Delete handling just because a page-level list
+ * registered global key listeners.
+ */
+export function isNativeInteractiveTarget(e: KeyboardEvent): boolean {
+  const candidates = [e.target as Element | null, document.activeElement].filter(
+    Boolean,
+  ) as Element[];
+
+  for (const candidate of candidates) {
+    let el: Element | null = candidate;
+    while (el) {
+      if (isNativeInteractiveElement(el)) return true;
+      el = el.parentElement;
+    }
+  }
+
+  return false;
+}
+
 // ─── Chorded key state machine ───────────────────────────────────────────────
 
 export type ChordCallback = () => void;
@@ -303,6 +372,12 @@ export interface ShortcutDef {
   handler: (e: KeyboardEvent) => boolean | void;
   /** If true, this shortcut works even when text input is focused. Default: false. */
   allowInInput?: boolean;
+  /**
+   * If true, this shortcut is available across normal app pages even when the
+   * active keyboard context is stale. Modal/editor contexts still take
+   * priority and editable targets are still protected unless allowInInput is set.
+   */
+  appWide?: boolean;
 }
 
 // ─── Shortcut map for help overlay ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make primary publication list/table shortcuts app-wide across normal app contexts
- preserve modal/editor/export/search and editable-field guards
- let Escape clear/blur focused publication search so letter shortcuts recover cleanly
- prefer most recently registered equal-priority shortcuts for card/table consistency

## Verification
- npm run build
- npm run lint *(fails on pre-existing src/components/publications/PublicationSyncDialog.tsx:46 no-unused-expressions; existing warnings in Dashboard/VaultDetail exhaustive-deps)*
- git diff --check