### PR TITLE
Show duplicate BibTeX import items first

### DIFF
--- a/src/components/publications/AddImportDialog.tsx
+++ b/src/components/publications/AddImportDialog.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { parseBibtex, fetchDOIMetadata, generateBibtexKey } from '@/lib/bibtex';
+import { orderImportPreviewIndices } from '@/lib/importOrdering';
 import { FileText, Link, Upload, Check, X, Library, PenLine, Loader2 } from 'lucide-react';
 import { LoadingSpinner } from '@/components/ui/loading';
 import { useToast } from '@/hooks/use-toast';
@@ -264,6 +265,11 @@ export function AddImportDialog({
 
   const selectAll = () => setSelectedIndices(new Set(parsedPublications.map((_, i) => i)));
   const selectNone = () => setSelectedIndices(new Set());
+
+  const orderedPreviewIndices = orderImportPreviewIndices(
+    parsedPublications.length,
+    duplicateIndices,
+  );
 
   // ─── Manual entry ────────────────────────────────────────────────────────────
 
@@ -694,7 +700,8 @@ export function AddImportDialog({
 
               <div className="border-2 rounded-lg max-h-40 overflow-y-auto">
                 <div className="p-2 space-y-2">
-                  {parsedPublications.map((pub, index) => {
+                  {orderedPreviewIndices.map((index) => {
+                    const pub = parsedPublications[index];
                     const isDuplicate = duplicateIndices.has(index);
                     return (
                       <div key={index}

--- a/src/components/publications/ImportDialog.tsx
+++ b/src/components/publications/ImportDialog.tsx
@@ -21,6 +21,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { parseBibtex, fetchDOIMetadata, generateBibtexKey } from '@/lib/bibtex';
+import { orderImportPreviewIndices } from '@/lib/importOrdering';
 import { FileText, Link, Upload, Check, X, Loader2, Library } from 'lucide-react';
 import { LoadingSpinner } from '@/components/ui/loading';
 import { useToast } from '@/hooks/use-toast';
@@ -296,6 +297,11 @@ export function ImportDialog({
     setSelectedIndices(new Set());
   };
 
+  const orderedPreviewIndices = orderImportPreviewIndices(
+    parsedPublications.length,
+    duplicateIndices,
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent forceMount className="w-full max-w-[100vw] h-full sm:h-auto sm:w-[95vw] sm:max-w-4xl sm:max-h-[90vh] p-0 border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col data-[state=closed]:hidden">
@@ -444,7 +450,8 @@ export function ImportDialog({
 
               <div className="border-2 rounded-lg max-h-40 overflow-y-auto">
                 <div className="p-2 space-y-2">
-                  {parsedPublications.map((pub, index) => {
+                  {orderedPreviewIndices.map((index) => {
+                    const pub = parsedPublications[index];
                     const isDuplicate = duplicateIndices.has(index);
                     return (
                     <div

--- a/src/lib/importOrdering.test.ts
+++ b/src/lib/importOrdering.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { orderImportPreviewIndices } from './importOrdering';
+
+describe('orderImportPreviewIndices', () => {
+  it('moves duplicate-marked items to the top while preserving relative order', () => {
+    expect(orderImportPreviewIndices(6, new Set([1, 4]))).toEqual([1, 4, 0, 2, 3, 5]);
+  });
+
+  it('keeps original order when there are no duplicates', () => {
+    expect(orderImportPreviewIndices(4, new Set())).toEqual([0, 1, 2, 3]);
+  });
+});

--- a/src/lib/importOrdering.ts
+++ b/src/lib/importOrdering.ts
@@ -1,0 +1,15 @@
+export function orderImportPreviewIndices(
+  totalCount: number,
+  duplicateIndices: Set<number>,
+): number[] {
+  return Array.from({ length: totalCount }, (_, index) => index).sort((left, right) => {
+    const leftPriority = duplicateIndices.has(left) ? 0 : 1;
+    const rightPriority = duplicateIndices.has(right) ? 0 : 1;
+
+    if (leftPriority !== rightPriority) {
+      return leftPriority - rightPriority;
+    }
+
+    return left - right;
+  });
+}


### PR DESCRIPTION
## Summary
- move duplicate-marked BibTeX import preview items to the top of the review list
- keep non-duplicates in their original relative order and leave import semantics unchanged
- cover the ordering helper with a focused unit test

## Verification
- npm test -- src/lib/importOrdering.test.ts
- npm run lint -- src/components/publications/ImportDialog.tsx src/components/publications/AddImportDialog.tsx src/lib/importOrdering.ts src/lib/importOrdering.test.ts
- npm run build

Closes #110