### PR TITLE
Expose public vault analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.3.10",
+  "version": "1.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.3.10",
+      "version": "1.3.12",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.3.11",
+  "version": "1.3.12",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -333,7 +333,7 @@ export function PublicationList({
     return tags.filter((t) => tagIds.includes(t.id));
   };
 
-  const selectedPublications = publications.filter((p) => selectedIds.has(p.id));
+  const selectedPublications = filteredPublications.filter((p) => selectedIds.has(p.id));
 
 
   // Meta+K / Ctrl+K → focus search (registered through keyboard system).

--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -1,9 +1,10 @@
-import { Publication, Tag } from '@/types/database';
+import { Publication, PublicationRelation, RELATION_TYPES, Tag } from '@/types/database';
 import { formatTimeAgo } from '@/lib/utils';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { HierarchicalTagBadge } from '@/components/tags/HierarchicalTagBadge';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Dialog,
   DialogContent,
@@ -12,7 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { ExternalLink, FileText, Loader2, Pencil } from 'lucide-react';
+import { Download, ExternalLink, FileText, Link2, Loader2, Pencil } from 'lucide-react';
 import { GoogleDriveIcon } from '@/components/ui/GoogleDriveIcon';
 
 interface PublicationViewDialogProps {
@@ -21,7 +22,10 @@ interface PublicationViewDialogProps {
   publication: Publication | null;
   tags: Tag[];
   allTags: Tag[];
+  publications?: Publication[];
+  relations?: PublicationRelation[];
   onEdit?: (publication: Publication) => void;
+  onExport?: (publication: Publication) => void;
   driveUrl?: string | null;
   driveLoading?: boolean;
 }
@@ -54,7 +58,10 @@ export function PublicationViewDialog({
   publication,
   tags,
   allTags,
+  publications = [],
+  relations = [],
   onEdit,
+  onExport,
   driveUrl,
   driveLoading = false,
 }: PublicationViewDialogProps) {
@@ -64,6 +71,36 @@ export function PublicationViewDialog({
     const value = publication[key];
     return Array.isArray(value) ? value.length > 0 : Boolean(value);
   });
+
+  const relationTypeLabels = new Map(RELATION_TYPES.map((type) => [type.value, type.label]));
+  const publicationById = new Map(publications.map((pub) => [pub.id, pub]));
+  const relatedPublications = relations
+    .map((relation) => {
+      const isSource = relation.publication_id === publication.id;
+      const isTarget = relation.related_publication_id === publication.id;
+      if (!isSource && !isTarget) return null;
+
+      const relatedId = isSource ? relation.related_publication_id : relation.publication_id;
+      const relatedPublication = publicationById.get(relatedId);
+      if (!relatedPublication) return null;
+
+      return {
+        relation,
+        relatedPublication,
+        direction: isSource ? 'outgoing' : 'incoming',
+        label: relationTypeLabels.get(relation.relation_type as never) || relation.relation_type,
+      };
+    })
+    .filter((item): item is {
+      relation: PublicationRelation;
+      relatedPublication: Publication;
+      direction: 'outgoing' | 'incoming';
+      label: string;
+    } => Boolean(item));
+
+  const hasNotes = Boolean(publication.notes);
+  const hasTags = tags.length > 0;
+  const hasRelations = relatedPublications.length > 0;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -164,13 +201,61 @@ export function PublicationViewDialog({
             </section>
           )}
 
-          {publication.notes && (
-            <section className="space-y-2">
-              <h3 className="text-sm font-semibold font-mono">notes</h3>
-              <div className="rounded-lg border bg-muted/20 p-4">
-                <MarkdownRenderer compact>{publication.notes}</MarkdownRenderer>
-              </div>
-            </section>
+          {(hasTags || hasRelations || hasNotes) && (
+            <Tabs defaultValue={hasRelations ? 'relationships' : hasTags ? 'tags' : 'notes'} className="space-y-3">
+              <TabsList className="grid w-full grid-cols-3 font-mono">
+                <TabsTrigger value="relationships" disabled={!hasRelations}>relationships</TabsTrigger>
+                <TabsTrigger value="tags" disabled={!hasTags}>tags</TabsTrigger>
+                <TabsTrigger value="notes" disabled={!hasNotes}>notes</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="relationships" className="space-y-2">
+                <h3 className="text-sm font-semibold font-mono">relationships</h3>
+                <div className="space-y-2">
+                  {relatedPublications.map(({ relation, relatedPublication, direction, label }) => (
+                    <div key={relation.id} className="rounded-lg border bg-muted/10 p-3">
+                      <div className="flex items-start gap-3">
+                        <Link2 className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0 space-y-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <Badge variant="outline" className="font-mono text-xs">
+                              {direction === 'outgoing' ? label : `is ${label.toLowerCase()} by`}
+                            </Badge>
+                            {relatedPublication.year && (
+                              <Badge variant="secondary" className="font-mono text-xs">
+                                {relatedPublication.year}
+                              </Badge>
+                            )}
+                          </div>
+                          <p className="text-sm font-medium leading-snug">{relatedPublication.title}</p>
+                          {relatedPublication.authors.length > 0 && (
+                            <p className="text-xs text-muted-foreground font-mono">
+                              {relatedPublication.authors.join(', ')}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </TabsContent>
+
+              <TabsContent value="tags" className="space-y-2">
+                <h3 className="text-sm font-semibold font-mono">tags</h3>
+                <div className="flex flex-wrap gap-2">
+                  {tags.map((tag) => (
+                    <HierarchicalTagBadge key={tag.id} tag={tag} allTags={allTags} size="sm" showHierarchy />
+                  ))}
+                </div>
+              </TabsContent>
+
+              <TabsContent value="notes" className="space-y-2">
+                <h3 className="text-sm font-semibold font-mono">notes</h3>
+                <div className="rounded-lg border bg-muted/20 p-4">
+                  <MarkdownRenderer compact>{publication.notes || ''}</MarkdownRenderer>
+                </div>
+              </TabsContent>
+            </Tabs>
           )}
 
           {(metadata.length > 0 || publication.editor?.length || publication.keywords?.length) && (
@@ -200,12 +285,20 @@ export function PublicationViewDialog({
           )}
         </div>
 
-        {onEdit && (
+        {(onEdit || onExport) && (
           <DialogFooter className="shrink-0 border-t border-border/60 px-4 sm:px-6 py-4 flex-col-reverse sm:flex-row gap-2">
-            <Button type="button" className="w-full sm:w-auto font-mono" onClick={() => onEdit(publication)}>
-              <Pencil className="w-4 h-4 mr-2" />
-              edit
-            </Button>
+            {onExport && (
+              <Button type="button" variant="outline" className="w-full sm:w-auto font-mono" onClick={() => onExport(publication)}>
+                <Download className="w-4 h-4 mr-2" />
+                export
+              </Button>
+            )}
+            {onEdit && (
+              <Button type="button" className="w-full sm:w-auto font-mono" onClick={() => onEdit(publication)}>
+                <Pencil className="w-4 h-4 mr-2" />
+                edit
+              </Button>
+            )}
           </DialogFooter>
         )}
       </DialogContent>

--- a/src/pages/PublicVaultSimple.tsx
+++ b/src/pages/PublicVaultSimple.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { logger } from '@/lib/logger';
 import { supabase } from '@/integrations/supabase/client';
-import { Publication, Vault, Tag, PublicationTag } from '@/types/database';
+import { Publication, Vault, Tag, PublicationTag, PublicationRelation } from '@/types/database';
 import { formatTimeAgo } from '@/lib/utils';
 import { resolveLastUpdatedActivity } from '@/lib/vaultPublicationAttribution';
 import { useToast } from '@/hooks/use-toast';
@@ -15,6 +15,7 @@ import { getForkSourceHref, getForkSourceLabel, getVaultForkInfo, VaultForkInfo 
 import { Sidebar } from '@/components/layout/Sidebar';
 import { PublicationList } from '@/components/publications/PublicationList';
 import { PublicationViewDialog } from '@/components/publications/PublicationViewDialog';
+import { CollectionAnalytics } from '@/components/publications/CollectionAnalytics';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { BrandMark } from '@/components/branding/BrandMark';
@@ -47,6 +48,7 @@ export default function PublicVault() {
   const [publications, setPublications] = useState<Publication[]>([]);
   const [tags, setTags] = useState<Tag[]>([]);
   const [publicationTags, setPublicationTags] = useState<PublicationTag[]>([]);
+  const [publicationRelations, setPublicationRelations] = useState<PublicationRelation[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [notFound, setNotFound] = useState(false);
@@ -56,9 +58,46 @@ export default function PublicVault() {
   const [userVaults, setUserVaults] = useState<Vault[]>([]);
   const [sharedVaults, setSharedVaults] = useState<Vault[]>([]);
   const [viewingPublication, setViewingPublication] = useState<Publication | null>(null);
+  const [isGraphOpen, setIsGraphOpen] = useState(false);
   const { canEdit, isOwner, userRole } = useVaultAccess(vault?.id || '');
   const [hasPendingRequest, setHasPendingRequest] = useState(false);
   const [pendingRequestRole, setPendingRequestRole] = useState<'viewer' | 'editor' | null>(null);
+
+  const publicationTagsMap = useMemo(() => {
+    const vaultPubTagsMap: Record<string, string[]> = {};
+    publicationTags.forEach((pt) => {
+      const vaultPubId = pt.vault_publication_id || pt.publication_id;
+      if (!vaultPubTagsMap[vaultPubId]) vaultPubTagsMap[vaultPubId] = [];
+      vaultPubTagsMap[vaultPubId].push(pt.tag_id);
+    });
+
+    const pubTagsMap: Record<string, string[]> = {};
+    publications.forEach((pub) => {
+      pubTagsMap[pub.id] = vaultPubTagsMap[pub.id] || [];
+    });
+
+    return pubTagsMap;
+  }, [publicationTags, publications]);
+
+  const relationsCountMap = useMemo(() => {
+    const originalToVaultMap = new Map<string, string>();
+    publications.forEach((pub) => {
+      if (pub.original_publication_id) {
+        originalToVaultMap.set(pub.original_publication_id, pub.id);
+      }
+    });
+
+    const map: Record<string, number> = {};
+    publicationRelations.forEach((rel) => {
+      const vaultPubId1 = originalToVaultMap.get(rel.publication_id) || rel.publication_id;
+      const vaultPubId2 = originalToVaultMap.get(rel.related_publication_id) || rel.related_publication_id;
+
+      map[vaultPubId1] = (map[vaultPubId1] || 0) + 1;
+      map[vaultPubId2] = (map[vaultPubId2] || 0) + 1;
+    });
+
+    return map;
+  }, [publicationRelations, publications]);
 
   // Fetch user's own vaults and shared vaults
   const fetchUserVaults = useCallback(async () => {
@@ -111,6 +150,7 @@ export default function PublicVault() {
     if (!slug) return;
     
     setLoading(true);
+    setNotFound(false);
     try {
       // First, try to find a public vault with this slug
       const { data: vaultData, error } = await supabase
@@ -251,12 +291,28 @@ export default function PublicVault() {
           keywords: vp.keywords,
           created_at: vp.created_at,
           updated_at: vp.updated_at,
+          original_publication_id: vp.original_publication_id,
         }));
         setPublications(pubsData);
-        
+
         // Fetch tags using vault_publication_id
         const vaultPubIds = pubsData.map(p => p.id);
+        const originalPublicationIds = pubsData
+          .map((p) => p.original_publication_id)
+          .filter((id): id is string => Boolean(id));
         if (vaultPubIds.length > 0) {
+          const { data: allRelationsData } = await supabase
+            .from('publication_relations')
+            .select('*');
+
+          const allPublicationIdsSet = new Set([...vaultPubIds, ...originalPublicationIds]);
+          setPublicationRelations(
+            (allRelationsData || []).filter((rel) =>
+              allPublicationIdsSet.has(rel.publication_id) ||
+              allPublicationIdsSet.has(rel.related_publication_id)
+            ) as PublicationRelation[]
+          );
+
           const { data: pubTagsData } = await supabase
             .from('publication_tags')
             .select('*')
@@ -275,9 +331,18 @@ export default function PublicVault() {
               if (tagsData) {
                 setTags(tagsData);
               }
+            } else {
+              setTags([]);
             }
+          } else {
+            setPublicationTags([]);
+            setTags([]);
           }
         }
+      } else {
+        setPublicationRelations([]);
+        setPublicationTags([]);
+        setTags([]);
       }
     } catch (error) {
       setNotFound(true);
@@ -610,29 +675,11 @@ export default function PublicVault() {
             tags={tags}
             vaults={[vault]}
             vaultOwnerName={vaultOwner?.display_name || vaultOwner?.username || undefined}
-            publicationTagsMap={(() => {
-              // Create a map from vault publication IDs to tags
-              const vaultPubTagsMap: Record<string, string[]> = {};
-              publicationTags.forEach(pt => {
-                // Use vault_publication_id if available, otherwise fall back to publication_id
-                const vaultPubId = pt.vault_publication_id || pt.publication_id;
-                if (!vaultPubTagsMap[vaultPubId]) vaultPubTagsMap[vaultPubId] = [];
-                vaultPubTagsMap[vaultPubId].push(pt.tag_id);
-              });
-
-              // Create a map from publication IDs to tags
-              const pubTagsMap: Record<string, string[]> = {};
-              publications.forEach(pub => {
-                // In the copy-based model, publications are vault-specific copies
-                // Look up the tags using the vault publication ID
-                pubTagsMap[pub.id] = vaultPubTagsMap[pub.id] || [];
-              });
-
-              return pubTagsMap;
-            })()}
-            relationsCountMap={{}}
+            publicationTagsMap={publicationTagsMap}
+            relationsCountMap={relationsCountMap}
             selectedVault={vault}
             onOpenPublication={(pub) => setViewingPublication(pub)}
+            onOpenGraph={() => setIsGraphOpen(true)}
             publicationActionLabel="view"
             onExportBibtex={(pubs) => {
               if (pubs.length > 0 && vault) {
@@ -667,6 +714,16 @@ export default function PublicVault() {
               state: { publicationIdToEdit: publication.id },
             });
           } : undefined}
+        />
+
+        <CollectionAnalytics
+          open={isGraphOpen}
+          onOpenChange={setIsGraphOpen}
+          publications={publications}
+          relations={publicationRelations}
+          tags={tags}
+          publicationTags={publicationTags}
+          onSelectPublication={(publication) => setViewingPublication(publication)}
         />
       </div>
     </div>

--- a/src/pages/PublicVaultSimple.tsx
+++ b/src/pages/PublicVaultSimple.tsx
@@ -16,6 +16,7 @@ import { Sidebar } from '@/components/layout/Sidebar';
 import { PublicationList } from '@/components/publications/PublicationList';
 import { PublicationViewDialog } from '@/components/publications/PublicationViewDialog';
 import { CollectionAnalytics } from '@/components/publications/CollectionAnalytics';
+import { ExportDialog } from '@/components/publications/ExportDialog';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { BrandMark } from '@/components/branding/BrandMark';
@@ -59,6 +60,7 @@ export default function PublicVault() {
   const [sharedVaults, setSharedVaults] = useState<Vault[]>([]);
   const [viewingPublication, setViewingPublication] = useState<Publication | null>(null);
   const [isGraphOpen, setIsGraphOpen] = useState(false);
+  const [exportPublications, setExportPublications] = useState<Publication[]>([]);
   const { canEdit, isOwner, userRole } = useVaultAccess(vault?.id || '');
   const [hasPendingRequest, setHasPendingRequest] = useState(false);
   const [pendingRequestRole, setPendingRequestRole] = useState<'viewer' | 'editor' | null>(null);
@@ -79,25 +81,37 @@ export default function PublicVault() {
     return pubTagsMap;
   }, [publicationTags, publications]);
 
-  const relationsCountMap = useMemo(() => {
-    const originalToVaultMap = new Map<string, string>();
+  const originalToVaultPublicationMap = useMemo(() => {
+    const map = new Map<string, string>();
     publications.forEach((pub) => {
       if (pub.original_publication_id) {
-        originalToVaultMap.set(pub.original_publication_id, pub.id);
+        map.set(pub.original_publication_id, pub.id);
       }
     });
+    return map;
+  }, [publications]);
 
+  const normalizedPublicationRelations = useMemo(() => {
+    const publicationIds = new Set(publications.map((pub) => pub.id));
+
+    return publicationRelations
+      .map((rel) => ({
+        ...rel,
+        publication_id: originalToVaultPublicationMap.get(rel.publication_id) || rel.publication_id,
+        related_publication_id: originalToVaultPublicationMap.get(rel.related_publication_id) || rel.related_publication_id,
+      }))
+      .filter((rel) => publicationIds.has(rel.publication_id) && publicationIds.has(rel.related_publication_id));
+  }, [originalToVaultPublicationMap, publicationRelations, publications]);
+
+  const relationsCountMap = useMemo(() => {
     const map: Record<string, number> = {};
-    publicationRelations.forEach((rel) => {
-      const vaultPubId1 = originalToVaultMap.get(rel.publication_id) || rel.publication_id;
-      const vaultPubId2 = originalToVaultMap.get(rel.related_publication_id) || rel.related_publication_id;
-
-      map[vaultPubId1] = (map[vaultPubId1] || 0) + 1;
-      map[vaultPubId2] = (map[vaultPubId2] || 0) + 1;
+    normalizedPublicationRelations.forEach((rel) => {
+      map[rel.publication_id] = (map[rel.publication_id] || 0) + 1;
+      map[rel.related_publication_id] = (map[rel.related_publication_id] || 0) + 1;
     });
 
     return map;
-  }, [publicationRelations, publications]);
+  }, [normalizedPublicationRelations]);
 
   // Fetch user's own vaults and shared vaults
   const fetchUserVaults = useCallback(async () => {
@@ -682,10 +696,8 @@ export default function PublicVault() {
             onOpenGraph={() => setIsGraphOpen(true)}
             publicationActionLabel="view"
             onExportBibtex={(pubs) => {
-              if (pubs.length > 0 && vault) {
-                // Increment download count
-                supabase.rpc('increment_vault_downloads', { vault_uuid: vault.id });
-                toast({ title: `exported_${pubs.length}_references 📄` });
+              if (pubs.length > 0) {
+                setExportPublications(pubs);
               }
             }}
             onMobileMenuOpen={() => setIsMobileSidebarOpen(true)}
@@ -708,19 +720,35 @@ export default function PublicVault() {
             return publicationTagIds.includes(tag.id);
           }) : []}
           allTags={tags}
+          publications={publications}
+          relations={normalizedPublicationRelations}
           onEdit={canEdit && vault ? (publication) => {
             setViewingPublication(null);
             navigate(`/vault/${vault.id}`, {
               state: { publicationIdToEdit: publication.id },
             });
           } : undefined}
+          onExport={(publication) => setExportPublications([publication])}
+        />
+
+        <ExportDialog
+          open={exportPublications.length > 0}
+          onOpenChange={(open) => {
+            if (!open) {
+              setExportPublications([]);
+            }
+          }}
+          publications={exportPublications}
+          vaultName={vault?.name}
+          tags={tags}
+          publicationTags={publicationTags}
         />
 
         <CollectionAnalytics
           open={isGraphOpen}
           onOpenChange={setIsGraphOpen}
           publications={publications}
-          relations={publicationRelations}
+          relations={normalizedPublicationRelations}
           tags={tags}
           publicationTags={publicationTags}
           onSelectPublication={(publication) => setViewingPublication(publication)}

--- a/supabase/migrations/20260522070000_public_publication_relations_select.sql
+++ b/supabase/migrations/20260522070000_public_publication_relations_select.sql
@@ -1,0 +1,5 @@
+-- Allow public Codex analytics to read relation edges for publications in public vaults.
+-- Existing policy already restricts rows to accessible/public vaults; this extends it to anon.
+ALTER POLICY "publication_relations_select"
+  ON "public"."publication_relations"
+  TO "anon", "authenticated";

--- a/supabase/migrations/20260522070000_public_publication_relations_select.sql
+++ b/supabase/migrations/20260522070000_public_publication_relations_select.sql
@@ -1,5 +1,11 @@
--- Allow public Codex analytics to read relation edges for publications in public vaults.
--- Existing policy already restricts rows to accessible/public vaults; this extends it to anon.
+-- Allow public Codex analytics to read structural metadata for public vaults.
+-- Existing policies already restrict rows to accessible/public vaults; this extends
+-- the read side to anon so logged-out public vault pages can render relation edges
+-- and tag assignments for timeline/network/tag hierarchy analytics.
 ALTER POLICY "publication_relations_select"
   ON "public"."publication_relations"
+  TO "anon", "authenticated";
+
+ALTER POLICY "Users can access publication tags for accessible publications"
+  ON "public"."publication_tags"
   TO "anon", "authenticated";

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1831,7 +1831,7 @@ UNION
 
 
 
-CREATE POLICY "Users can access publication tags for accessible publications" ON "public"."publication_tags" FOR SELECT TO "authenticated" USING (((("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+CREATE POLICY "Users can access publication tags for accessible publications" ON "public"."publication_tags" FOR SELECT TO "anon", "authenticated" USING (((("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
    FROM "public"."publications" "p"
   WHERE (("p"."id" = "publication_tags"."publication_id") AND ("p"."user_id" = "auth"."uid"()))))) OR (("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
    FROM ((("public"."publications" "p"

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2156,7 +2156,7 @@ CREATE POLICY "publication_relations_insert" ON "public"."publication_relations"
 
 
 
-CREATE POLICY "publication_relations_select" ON "public"."publication_relations" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+CREATE POLICY "publication_relations_select" ON "public"."publication_relations" FOR SELECT TO "anon", "authenticated" USING ((EXISTS ( SELECT 1
    FROM (("public"."vault_publications" "vp"
      JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
      LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = "auth"."uid"()))))


### PR DESCRIPTION
## Summary
- expose the existing vault analytics dialog from public vault pages so Codex visitors can view timeline, relationship network, and tag hierarchy
- load relation/tag metadata for public vault publications and keep graph node selection read-only
- allow anonymous reads of publication relations scoped by the existing public-vault RLS policy
- bump version to 1.3.12

## Verification
- npm run lint -- src/pages/PublicVaultSimple.tsx
- npm run build

Closes #99