### PR TITLE
Use custom RefHub QR generator for vault shares

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.3.12",
+  "version": "1.3.13",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils';
 
 const CUSTOM_QR_ENDPOINT = 'https://refhub-qr.netlify.app/api/generate-qr';
 const CUSTOM_QR_FREEDOM = 0;
+const QR_DOWNLOAD_BACKGROUND = '#0d0d0f';
 
 interface QRCodeDialogProps {
   vault: Vault;
@@ -174,11 +175,19 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
     }
   };
 
+  const getDownloadableSvg = (svg: string) => {
+    const viewBoxMatch = svg.match(/<svg[^>]*viewBox="([^"]+)"/);
+    const [, , width = '1024', height = '1024'] = viewBoxMatch?.[1]?.split(/\s+/) ?? [];
+    const background = `<rect width="${width}" height="${height}" fill="${QR_DOWNLOAD_BACKGROUND}"/>`;
+    return svg.replace(/(<svg\b[^>]*>)/, `$1${background}`);
+  };
+
   const downloadQR = () => {
     const link = document.createElement('a');
 
     if (customQrSvg) {
-      const blobUrl = URL.createObjectURL(new Blob([customQrSvg], { type: 'image/svg+xml' }));
+      const svgForDownload = getDownloadableSvg(customQrSvg);
+      const blobUrl = URL.createObjectURL(new Blob([svgForDownload], { type: 'image/svg+xml' }));
       link.download = `${vault.name || 'vault'}-qr.svg`;
       link.href = blobUrl;
       link.click();

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -44,6 +44,7 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
   const [customQrLoading, setCustomQrLoading] = useState(false);
   const [customQrError, setCustomQrError] = useState<string | null>(null);
   const qrRef = useRef<HTMLDivElement>(null);
+  const fallbackQrSize = typeof window !== 'undefined' && window.innerWidth < 640 ? 240 : 360;
   const { toast } = useToast();
 
   const isPrivate = vault.visibility === 'private';
@@ -212,15 +213,15 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
           </Button>
         </DialogTrigger>
         {canShare && (
-          <DialogContent className="sm:max-w-xl">
-            <DialogHeader>
-              <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">
+          <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:w-[95vw] sm:max-w-xl sm:max-h-[90vh] overflow-y-auto">
+            <DialogHeader className="px-1 sm:px-0">
+              <DialogTitle className="text-lg sm:text-2xl font-bold font-mono break-words">
                 // share "{vault.name}"
               </DialogTitle>
             </DialogHeader>
             <div className="flex flex-col items-center gap-4 sm:gap-6 py-2 sm:py-5">
-              <div className="p-4 sm:p-7 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-3xl shadow-xl border-2 border-border/50 glow-purple">
-                <div className="p-3 sm:p-5 bg-white rounded-2xl relative">
+              <div className="w-full max-w-[312px] sm:max-w-[456px] p-4 sm:p-7 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-2xl sm:rounded-3xl shadow-xl border-2 border-border/50 glow-purple">
+                <div className="p-3 sm:p-5 bg-white rounded-xl sm:rounded-2xl relative">
                   <div 
                     ref={qrRef}
                     className="relative flex items-center justify-center"
@@ -232,12 +233,12 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
                       <img
                         src={customQrUrl}
                         alt={`QR code for ${vault.name || 'vault'}`}
-                        className="h-[240px] w-[240px] sm:h-[360px] sm:w-[360px]"
+                        className="h-[min(70vw,240px)] w-[min(70vw,240px)] sm:h-[360px] sm:w-[360px]"
                       />
                     ) : (
                       <QRCodeCanvas
                         value={shareUrl}
-                        size={window.innerWidth < 640 ? 240 : 360}
+                        size={fallbackQrSize}
                         level="H"
                         marginSize={2}
                         bgColor="#ffffff"

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -44,7 +44,7 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
   const [customQrLoading, setCustomQrLoading] = useState(false);
   const [customQrError, setCustomQrError] = useState<string | null>(null);
   const qrRef = useRef<HTMLDivElement>(null);
-  const fallbackQrSize = typeof window !== 'undefined' && window.innerWidth < 640 ? 240 : 360;
+  const fallbackQrSize = typeof window !== 'undefined' && window.innerWidth < 640 ? 220 : 360;
   const { toast } = useToast();
 
   const isPrivate = vault.visibility === 'private';
@@ -213,15 +213,15 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
           </Button>
         </DialogTrigger>
         {canShare && (
-          <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:w-[95vw] sm:max-w-xl sm:max-h-[90vh] overflow-y-auto">
+          <DialogContent className="dialog-mobile w-[100vw] max-w-[100vw] gap-3 overflow-y-auto p-4 sm:rounded-2xl sm:w-[95vw] sm:max-w-xl sm:max-h-[90vh] sm:gap-4 sm:p-6">
             <DialogHeader className="px-1 sm:px-0">
               <DialogTitle className="text-lg sm:text-2xl font-bold font-mono break-words">
                 // share "{vault.name}"
               </DialogTitle>
             </DialogHeader>
-            <div className="flex flex-col items-center gap-4 sm:gap-6 py-2 sm:py-5">
-              <div className="w-full max-w-[312px] sm:max-w-[456px] p-4 sm:p-7 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-2xl sm:rounded-3xl shadow-xl border-2 border-border/50 glow-purple">
-                <div className="p-3 sm:p-5 bg-white rounded-xl sm:rounded-2xl relative">
+            <div className="flex flex-col items-center gap-3 sm:gap-6 py-2 sm:py-5">
+              <div className="w-full max-w-[276px] sm:max-w-[456px] p-3 sm:p-7 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-2xl sm:rounded-3xl shadow-xl border-2 border-border/50 glow-purple">
+                <div className="p-2 sm:p-5 bg-white rounded-xl sm:rounded-2xl relative">
                   <div 
                     ref={qrRef}
                     className="relative flex items-center justify-center"
@@ -233,7 +233,7 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
                       <img
                         src={customQrUrl}
                         alt={`QR code for ${vault.name || 'vault'}`}
-                        className="h-[min(70vw,240px)] w-[min(70vw,240px)] sm:h-[360px] sm:w-[360px]"
+                        className="block h-auto w-full max-w-[220px] object-contain sm:max-w-[360px]"
                       />
                     ) : (
                       <QRCodeCanvas

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -19,7 +19,6 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { QrCode, Download, Copy, Check, Lock, Globe, Users, AlertTriangle } from 'lucide-react';
-import { LoadingSpinner } from '@/components/ui/loading';
 import { useToast } from '@/hooks/use-toast';
 import { Vault } from '@/types/database';
 import { supabase } from '@/integrations/supabase/client';
@@ -67,9 +66,11 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
     if (!open || !canShare) {
       setCustomQrSvg(null);
       setCustomQrError(null);
+      setCustomQrLoading(false);
       return;
     }
 
+    let isCurrent = true;
     const controller = new AbortController();
 
     const generateCustomQr = async () => {
@@ -95,12 +96,14 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
           throw new Error('custom QR generator returned non-SVG content');
         }
 
-        setCustomQrSvg(svg);
+        if (isCurrent) {
+          setCustomQrSvg(svg);
+        }
       } catch (error) {
-        if ((error as DOMException).name === 'AbortError') return;
+        if ((error as DOMException).name === 'AbortError' || !isCurrent) return;
         setCustomQrError((error as Error).message);
       } finally {
-        if (!controller.signal.aborted) {
+        if (!controller.signal.aborted && isCurrent) {
           setCustomQrLoading(false);
         }
       }
@@ -108,7 +111,10 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
 
     generateCustomQr();
 
-    return () => controller.abort();
+    return () => {
+      isCurrent = false;
+      controller.abort();
+    };
   }, [canShare, open, shareUrl]);
 
   useEffect(() => {
@@ -220,12 +226,12 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
               </DialogTitle>
             </DialogHeader>
             <div className="flex flex-col items-center gap-3 sm:gap-6 py-2 sm:py-5">
-              <div className="w-full max-w-[276px] sm:max-w-[456px] p-3 sm:p-7 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-2xl sm:rounded-3xl shadow-xl border-2 border-border/50 glow-purple">
-                <div className="p-0 bg-transparent rounded-xl sm:rounded-2xl relative">
+              <div className="w-full max-w-[276px] sm:max-w-[456px] p-0 rounded-2xl sm:rounded-3xl shadow-xl glow-purple">
+                <div className="p-0 bg-transparent rounded-xl sm:rounded-2xl relative overflow-hidden">
                   <div 
                     ref={qrRef}
                     className={cn(
-                      "relative flex items-center justify-center",
+                      "relative flex items-center justify-center rounded-xl sm:rounded-2xl",
                       customQrLoading && !customQrError && "min-h-[220px] sm:min-h-[360px]"
                     )}
                     style={{
@@ -239,7 +245,14 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
                         className="block h-auto w-full max-w-[236px] object-contain sm:max-w-[390px]"
                       />
                     ) : customQrLoading && !customQrError ? (
-                      <LoadingSpinner size="lg" />
+                      <div className="flex flex-col items-center justify-center gap-3 text-center font-mono text-sm text-muted-foreground">
+                        <span className="tracking-[0.25em] text-primary">qr-coding</span>
+                        <span className="flex gap-1" aria-hidden="true">
+                          <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce [animation-delay:-0.3s]" />
+                          <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce [animation-delay:-0.15s]" />
+                          <span className="h-1.5 w-1.5 rounded-full bg-primary animate-bounce" />
+                        </span>
+                      </div>
                     ) : (
                       <QRCodeCanvas
                         value={shareUrl}

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -212,15 +212,15 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
           </Button>
         </DialogTrigger>
         {canShare && (
-          <DialogContent className="sm:max-w-sm">
+          <DialogContent className="sm:max-w-xl">
             <DialogHeader>
               <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">
                 // share "{vault.name}"
               </DialogTitle>
             </DialogHeader>
-            <div className="flex flex-col items-center gap-4 sm:gap-6 py-2 sm:py-4">
-              <div className="p-4 sm:p-6 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-2xl shadow-xl border-2 border-border/50 glow-purple">
-                <div className="p-3 sm:p-4 bg-white rounded-xl relative">
+            <div className="flex flex-col items-center gap-4 sm:gap-6 py-2 sm:py-5">
+              <div className="p-4 sm:p-7 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-3xl shadow-xl border-2 border-border/50 glow-purple">
+                <div className="p-3 sm:p-5 bg-white rounded-2xl relative">
                   <div 
                     ref={qrRef}
                     className="relative flex items-center justify-center"
@@ -232,12 +232,12 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
                       <img
                         src={customQrUrl}
                         alt={`QR code for ${vault.name || 'vault'}`}
-                        className="h-[180px] w-[180px] sm:h-[200px] sm:w-[200px]"
+                        className="h-[240px] w-[240px] sm:h-[360px] sm:w-[360px]"
                       />
                     ) : (
                       <QRCodeCanvas
                         value={shareUrl}
-                        size={window.innerWidth < 640 ? 180 : 200}
+                        size={window.innerWidth < 640 ? 240 : 360}
                         level="H"
                         marginSize={2}
                         bgColor="#ffffff"

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -221,20 +221,25 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
             </DialogHeader>
             <div className="flex flex-col items-center gap-3 sm:gap-6 py-2 sm:py-5">
               <div className="w-full max-w-[276px] sm:max-w-[456px] p-3 sm:p-7 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-2xl sm:rounded-3xl shadow-xl border-2 border-border/50 glow-purple">
-                <div className="p-2 sm:p-5 bg-white rounded-xl sm:rounded-2xl relative">
+                <div className="p-0 bg-transparent rounded-xl sm:rounded-2xl relative">
                   <div 
                     ref={qrRef}
-                    className="relative flex items-center justify-center"
+                    className={cn(
+                      "relative flex items-center justify-center",
+                      customQrLoading && !customQrError && "min-h-[220px] sm:min-h-[360px]"
+                    )}
                     style={{
-                      filter: customQrUrl ? undefined : `drop-shadow(0 0 8px ${gradientColor}40)`,
+                      filter: customQrError ? `drop-shadow(0 0 8px ${gradientColor}40)` : undefined,
                     }}
                   >
                     {customQrUrl ? (
                       <img
                         src={customQrUrl}
                         alt={`QR code for ${vault.name || 'vault'}`}
-                        className="block h-auto w-full max-w-[220px] object-contain sm:max-w-[360px]"
+                        className="block h-auto w-full max-w-[236px] object-contain sm:max-w-[390px]"
                       />
+                    ) : customQrLoading && !customQrError ? (
+                      <LoadingSpinner size="lg" />
                     ) : (
                       <QRCodeCanvas
                         value={shareUrl}
@@ -244,11 +249,6 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
                         bgColor="#ffffff"
                         fgColor={gradientColor}
                       />
-                    )}
-                    {customQrLoading && (
-                      <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-white/70">
-                        <LoadingSpinner size="sm" />
-                      </div>
                     )}
                   </div>
                 </div>

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { QRCodeCanvas } from 'qrcode.react';
 import { Button } from '@/components/ui/button';
 import {
@@ -20,11 +20,13 @@ import {
 } from '@/components/ui/alert-dialog';
 import { QrCode, Download, Copy, Check, Lock, Globe, Users, AlertTriangle } from 'lucide-react';
 import { LoadingSpinner } from '@/components/ui/loading';
-import { useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { Vault } from '@/types/database';
 import { supabase } from '@/integrations/supabase/client';
 import { cn } from '@/lib/utils';
+
+const CUSTOM_QR_ENDPOINT = 'https://refhub-qr.netlify.app/api/generate-qr';
+const CUSTOM_QR_FREEDOM = 0;
 
 interface QRCodeDialogProps {
   vault: Vault;
@@ -37,13 +39,17 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
   const [upgrading, setUpgrading] = useState(false);
   const [gradientColor, setGradientColor] = useState('#8b5cf6');
+  const [customQrSvg, setCustomQrSvg] = useState<string | null>(null);
+  const [customQrUrl, setCustomQrUrl] = useState<string | null>(null);
+  const [customQrLoading, setCustomQrLoading] = useState(false);
+  const [customQrError, setCustomQrError] = useState<string | null>(null);
   const qrRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
 
   const isPrivate = vault.visibility === 'private';
   const canShare = vault.visibility !== 'private';
 
-  // Generate random aesthetic gradient color
+  // Generate random aesthetic gradient color for the fallback QR.
   const generateRandomColor = () => {
     const hue = Math.random() * 360;
     const saturation = 70 + Math.random() * 20; // 70-90%
@@ -55,6 +61,66 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
   const shareUrl = vault.visibility === 'public' && vault.public_slug
     ? `${window.location.origin}/public/${vault.public_slug}`
     : `${window.location.origin}/vault/${vault.id}`;
+
+  useEffect(() => {
+    if (!open || !canShare) {
+      setCustomQrSvg(null);
+      setCustomQrError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const generateCustomQr = async () => {
+      setCustomQrLoading(true);
+      setCustomQrError(null);
+      setCustomQrSvg(null);
+
+      try {
+        const response = await fetch(CUSTOM_QR_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: shareUrl, freedom: CUSTOM_QR_FREEDOM }),
+          signal: controller.signal,
+        });
+
+        const contentType = response.headers.get('content-type') ?? '';
+        if (!response.ok || !contentType.includes('image/svg+xml')) {
+          throw new Error('custom QR generator returned an invalid response');
+        }
+
+        const svg = await response.text();
+        if (!svg.trimStart().startsWith('<svg')) {
+          throw new Error('custom QR generator returned non-SVG content');
+        }
+
+        setCustomQrSvg(svg);
+      } catch (error) {
+        if ((error as DOMException).name === 'AbortError') return;
+        setCustomQrError((error as Error).message);
+      } finally {
+        if (!controller.signal.aborted) {
+          setCustomQrLoading(false);
+        }
+      }
+    };
+
+    generateCustomQr();
+
+    return () => controller.abort();
+  }, [canShare, open, shareUrl]);
+
+  useEffect(() => {
+    if (!customQrSvg) {
+      setCustomQrUrl(null);
+      return;
+    }
+
+    const blobUrl = URL.createObjectURL(new Blob([customQrSvg], { type: 'image/svg+xml' }));
+    setCustomQrUrl(blobUrl);
+
+    return () => URL.revokeObjectURL(blobUrl);
+  }, [customQrSvg]);
 
   const copyShareUrl = () => {
     navigator.clipboard.writeText(shareUrl);
@@ -102,10 +168,21 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
   };
 
   const downloadQR = () => {
+    const link = document.createElement('a');
+
+    if (customQrSvg) {
+      const blobUrl = URL.createObjectURL(new Blob([customQrSvg], { type: 'image/svg+xml' }));
+      link.download = `${vault.name || 'vault'}-qr.svg`;
+      link.href = blobUrl;
+      link.click();
+      URL.revokeObjectURL(blobUrl);
+      toast({ title: 'qr_code_downloaded' });
+      return;
+    }
+
     const canvas = qrRef.current?.querySelector('canvas');
     if (!canvas) return;
-    
-    const link = document.createElement('a');
+
     link.download = `${vault.name || 'vault'}-qr.png`;
     link.href = canvas.toDataURL('image/png');
     link.click();
@@ -142,27 +219,44 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
               </DialogTitle>
             </DialogHeader>
             <div className="flex flex-col items-center gap-4 sm:gap-6 py-2 sm:py-4">
-              {/* QR Code with gradient effect */}
               <div className="p-4 sm:p-6 bg-gradient-to-br from-background via-background/95 to-sidebar-accent rounded-2xl shadow-xl border-2 border-border/50 glow-purple">
                 <div className="p-3 sm:p-4 bg-white rounded-xl relative">
                   <div 
                     ref={qrRef}
-                    className="relative"
+                    className="relative flex items-center justify-center"
                     style={{
-                      filter: `drop-shadow(0 0 8px ${gradientColor}40)`,
+                      filter: customQrUrl ? undefined : `drop-shadow(0 0 8px ${gradientColor}40)`,
                     }}
                   >
-                    <QRCodeCanvas
-                      value={shareUrl}
-                      size={window.innerWidth < 640 ? 180 : 200}
-                      level="H"
-                      marginSize={2}
-                      bgColor="#ffffff"
-                      fgColor={gradientColor}
-                    />
+                    {customQrUrl ? (
+                      <img
+                        src={customQrUrl}
+                        alt={`QR code for ${vault.name || 'vault'}`}
+                        className="h-[180px] w-[180px] sm:h-[200px] sm:w-[200px]"
+                      />
+                    ) : (
+                      <QRCodeCanvas
+                        value={shareUrl}
+                        size={window.innerWidth < 640 ? 180 : 200}
+                        level="H"
+                        marginSize={2}
+                        bgColor="#ffffff"
+                        fgColor={gradientColor}
+                      />
+                    )}
+                    {customQrLoading && (
+                      <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-white/70">
+                        <LoadingSpinner size="sm" />
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>
+              {customQrError && (
+                <p className="-mt-2 text-center text-[11px] text-muted-foreground font-mono">
+                  // custom_qr_unavailable_using_fallback
+                </p>
+              )}
               
               <div className="text-center space-y-1">
                 <p className="text-xs text-muted-foreground font-mono">

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,13 +29,13 @@ const changelog: ChangelogEntry[] = [
         tag: 'feature',
         title: 'branded qr codes',
         description:
-          'vault share links now use custom refhub qr codes with a cleaner, more recognizable design.',
+          'vault share links now use custom refhub qr codes with a cleaner branded design and svg downloads.',
       },
       {
         tag: 'improvement',
         title: 'polished qr share dialog',
         description:
-          'qr sharing now loads more cleanly and fits better on mobile.',
+          'qr sharing now loads cleanly, avoids visual flicker, and fits better on mobile screens.',
       },
     ],
   },
@@ -46,15 +46,15 @@ const changelog: ChangelogEntry[] = [
     features: [
       {
         tag: 'improvement',
-        title: 'all papers now includes vault instance details',
+        title: 'vault context in all papers',
         description:
-          'the all_papers view stays deduplicated, but now enriches sparse canonical records from their vault copies and shows where each paper appears, including vault instance counts and aggregated tags.',
+          'the all_papers view now shows where each paper appears, including vault instance counts and aggregated tags.',
       },
       {
         tag: 'fix',
-        title: 'profile and all papers counts now use the same denominator',
+        title: 'consistent public paper counts',
         description:
-          'public profile paper counts now align with /all-papers by counting distinct publications instead of raw vault items, so duplicated vault instances no longer inflate the number.',
+          'public profile counts now match /all-papers by counting distinct publications instead of duplicate vault copies.',
       },
     ],
   },
@@ -65,27 +65,27 @@ const changelog: ChangelogEntry[] = [
     features: [
       {
         tag: 'feature',
-        title: 'request editor access on public vaults',
+        title: 'request editor access',
         description:
-          'signed-in users browsing a public vault can now click "collaborate" to request editor access. the vault owner receives a notification, reviews the request in vault settings, and can approve or reject it — optionally adjusting the granted role before approving.',
+          'signed-in users can request editor access from public vault pages, and owners can review and approve requests in settings.',
       },
       {
         tag: 'improvement',
-        title: 'access requests visible for public vaults in settings',
+        title: 'public vault access requests',
         description:
-          'the access_requests panel in vault settings now appears for public vaults, not just protected ones. it has a distinct purple tint and a scroll-to hint badge in the dialog header so pending requests are never missed.',
+          'access requests are now visible in public vault settings, with clearer pending-request indicators for vault owners.',
       },
       {
         tag: 'improvement',
-        title: 'share with users section for public vaults',
+        title: 'direct sharing for public vaults',
         description:
-          'vault owners can now directly grant or revoke editor access on public vaults from the settings panel, without requiring the other party to go through the request flow first.',
+          'vault owners can grant or revoke editor access on public vaults directly from the sharing settings.',
       },
       {
         tag: 'fix',
-        title: 'vault settings gear icon now consistent everywhere',
+        title: 'consistent vault settings access',
         description:
-          'the gear icon on sidebar vault items was missing when navigating to the codex, researchers, and researcher profile pages. it now appears uniformly across all pages that render the sidebar.',
+          'the vault settings gear now appears consistently across pages that render the sidebar.',
       },
     ],
   },
@@ -96,27 +96,27 @@ const changelog: ChangelogEntry[] = [
     features: [
       {
         tag: 'fix',
-        title: 'publication edits stay in place after save',
+        title: 'publication edits stay in place',
         description:
-          'the add/edit publication form now preserves its current values after saving, so follow-up edits and metadata checks no longer force you to re-enter the same details.',
+          'saving a publication no longer resets the form, so follow-up edits and metadata checks are less disruptive.',
       },
       {
         tag: 'improvement',
-        title: 'vault settings save flow feels immediate',
+        title: 'faster vault settings saves',
         description:
-          'saving vault settings now keeps the dialog open, supports ctrl/cmd+s, and uses consistent save button styling so quick metadata updates take fewer clicks.',
+          'vault settings now save in place with keyboard shortcut support and clearer button styling.',
       },
       {
         tag: 'improvement',
-        title: 'cleaner collaboration and researcher discovery',
+        title: 'cleaner collaboration discovery',
         description:
-          'vault collaborator autocomplete is more reliable, and the researchers directory now focuses on profiles that have completed setup instead of showing incomplete entries.',
+          'collaborator autocomplete is more reliable, and researcher discovery focuses on completed profiles.',
       },
       {
         tag: 'fix',
-        title: 'version and extension links now point to the right place',
+        title: 'correct version and extension links',
         description:
-          'the bug report control now reports the live app version correctly, and the browser extension install flow links directly to the current chrome web store listing.',
+          'bug reports now include the live app version, and extension links point to the current browser store listing.',
       },
     ],
   },
@@ -129,13 +129,13 @@ const changelog: ChangelogEntry[] = [
         tag: 'feature',
         title: 'refhub skill for claude code',
         description:
-          'manage your vaults directly from claude code with the refhub skill. search papers, add references, and query your vault through natural language — no context switching, no browser. install from github.com/refhub/refhub-skill.',
+          'manage vaults from claude code by searching papers, adding references, and querying vault content directly.',
       },
       {
         tag: 'feature',
-        title: 'refhub-cli: manage references from your terminal',
+        title: 'refhub cli',
         description:
-          'a full-featured command-line interface for refhub is now available on npm. install globally with npm i -g @refhub/cli and interact with your vaults, search papers, and automate reference workflows straight from your shell. source at github.com/refhub/refhub-cli.',
+          'a command-line interface is now available for searching papers, managing vaults, and automating reference workflows.',
       },
     ],
   },
@@ -146,15 +146,15 @@ const changelog: ChangelogEntry[] = [
     features: [
       {
         tag: 'feature',
-        title: 'google drive pdf links now show up across the vault ui',
+        title: 'google drive pdf links',
         description:
-          'pdfs saved by the extension into your managed google drive folder now surface directly in refhub. drive badges and quick-open actions are available across cards, tables, and publication dialogs so cloud-saved copies are always one click away.',
+          'pdfs saved by the extension now appear across vault cards, tables, and publication dialogs with quick-open actions.',
       },
       {
         tag: 'feature',
-        title: 'chrome + firefox browser extensions are now live',
+        title: 'browser extensions live',
         description:
-          'the refhub browser extensions are officially out on the chrome web store and firefox add-ons. save papers straight from the page you are reading, then jump to the github repo from the add paper dialog if you want the source or release history.',
+          'the chrome and firefox extensions are now available from the official browser stores for saving papers from the page.',
       },
     ],
   },
@@ -165,9 +165,9 @@ const changelog: ChangelogEntry[] = [
     features: [
       {
         tag: 'feature',
-        title: 'chrome & firefox extensions released on github',
+        title: 'chrome and firefox extensions',
         description:
-          'the refhub browser extensions are now available — install directly from github releases today. save papers to your vaults without ever leaving the tab you\'re reading. chrome & firefox store submissions are pending validation and dropping soon™.',
+          'the refhub browser extensions are available from github releases, with browser store submissions underway.',
       },
     ],
   },
@@ -180,25 +180,25 @@ const changelog: ChangelogEntry[] = [
         tag: 'feature',
         title: 'codex launched',
         description:
-          'the codex page is now live for browse-oriented research exploration. search and filter across public vaults with instant graph previews, nodes-of-interest hovers, and keyboard-first navigation for power users.',
+          'the codex page now supports browsing public vaults with search, filters, graph previews, and keyboard navigation.',
       },
       {
         tag: 'feature',
-        title: 'semantic scholar pipeline for smarter discovery',
+        title: 'semantic scholar discovery',
         description:
-          'deep integration with semantic scholar is now active: related works, citation paths, and referenced-by graphs are sourced from semantic scholar and link directly into your select/save workflow.',
+          'related works, citation paths, and referenced-by graphs now use semantic scholar data for richer paper discovery.',
       },
       {
         tag: 'feature',
-        title: 'vault forking + hearting',
+        title: 'vault forking and favorites',
         description:
-          'you can now fork public vaults to clone their paper sets instantly, and favorite vaults with a ❤️ for fast access in the dashboard. backup, remix, and curate with confidence.',
+          'public vaults can now be forked into your workspace and favorited for faster access from the dashboard.',
       },
       {
         tag: 'improvement',
-        title: 'minor ux improvements and fixes',
+        title: 'general ux polish',
         description:
-          'various small ui/ux polish updates were applied across auth, vault lists, and reader mode. improved focus ring handling, button spacing, keyboard response, and notification clarity.',
+          'auth, vault lists, reader mode, focus states, buttons, shortcuts, and notifications received small usability improvements.',
       },
     ],
   },
@@ -211,31 +211,31 @@ const changelog: ChangelogEntry[] = [
         tag: 'feature',
         title: 'researcher profile pages',
         description:
-          'every researcher now has a public profile at /profile/@username. click any card in the researchers directory to see their bio, stats, and a grid of their public vaults — each linking directly to the vault.',
+          'researchers now have public profile pages with bio, stats, and a grid of their public vaults.',
       },
       {
         tag: 'fix',
-        title: 'researcher directory showing correct counts',
+        title: 'accurate researcher counts',
         description:
-          'vault and paper counts for other researchers were always 0 due to an RLS policy restricting visibility to the owner only. a new migration and security definer function fix this — counts are now accurate for all researchers.',
+          'researcher directory vault and paper counts now display correctly for profiles beyond the current user.',
       },
       {
         tag: 'improvement',
-        title: 'relationship graph: disconnected components stay put',
+        title: 'steadier relationship graph',
         description:
-          'disconnected paper clusters no longer drift to the edges of the canvas. nodes are pre-positioned in a grid and pinned in place, rendering immediately without any animated settle or zoom jump.',
+          'disconnected paper clusters now stay positioned instead of drifting around the graph canvas.',
       },
       {
         tag: 'improvement',
-        title: 'keyboard shortcuts reorganised',
+        title: 'organized keyboard shortcuts',
         description:
-          'the help overlay (press ?) now groups shortcuts into focused panels: paper navigation, paper selection, paper popups & actions, and a combined dialogs & editor section — no more scrolling through a single long list.',
+          'the keyboard help overlay now groups shortcuts by task, making paper and dialog actions easier to scan.',
       },
       {
         tag: 'improvement',
-        title: 'mobile: toolbar keyboard hints hidden on narrow screens',
+        title: 'mobile toolbar polish',
         description:
-          'inline keyboard hint badges are now hidden below 768 px, preventing toolbar overflow. the discover_related button is also visible as an icon on all screen sizes.',
+          'toolbar keyboard hints are hidden on narrow screens, reducing overflow on mobile.',
       },
     ],
   },
@@ -246,33 +246,33 @@ const changelog: ChangelogEntry[] = [
     features: [
       {
         tag: 'feature',
-        title: 'vault augmentation via semantic scholar',
+        title: 'semantic scholar vault augmentation',
         description:
-          'select one or more papers and press r (or click discover_related) to discover related work — references, papers that cite them, and recommendations — directly from the semantic scholar api. add any discovery to the vault with one click.',
+          'select papers and discover related references, citations, and recommendations directly from semantic scholar.',
       },
       {
         tag: 'feature',
         title: 'automatic citation links',
         description:
-          'when you add a paper from the references or cited_by tabs, the citation relationship is automatically created and appears in the collection graph.',
+          'adding papers from references or cited_by results now creates the matching citation relationship automatically.',
       },
       {
         tag: 'improvement',
-        title: 'forward + backward search',
+        title: 'forward and backward search',
         description:
-          'the discovery panel distinguishes cites→ (papers the selected work builds on) from ←cited_by (papers that build on the selected work), making it easy to trace intellectual lineage in both directions.',
+          'discovery now separates papers a work cites from papers that cite it, making citation trails easier to follow.',
       },
       {
         tag: 'improvement',
-        title: 'abstract previews in discovery panel',
+        title: 'abstract previews in discovery',
         description:
-          'each discovered paper now shows an abstract snippet, full author list, and a direct doi or semantic scholar link so you can evaluate relevance before adding.',
+          'discovered papers now show abstracts, authors, and source links before you add them to a vault.',
       },
       {
         tag: 'improvement',
-        title: 'keyboard shortcut r',
+        title: 'keyboard shortcut for discovery',
         description:
-          'press r with one or more papers selected to open vault augmentation without reaching for the mouse.',
+          'press r with selected papers to open vault augmentation without leaving the keyboard.',
       },
     ],
   },

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -23,19 +23,19 @@ const changelog: ChangelogEntry[] = [
   {
     id: 10,
     date: '2026-05-22',
-    title: 'custom vault qr sharing',
+    title: 'better vault sharing',
     features: [
       {
         tag: 'feature',
-        title: 'custom refhub qr codes',
+        title: 'branded qr codes',
         description:
-          'vault sharing now uses the custom refhub qr generator for branded svg qr codes with the refhub mark and dot-matrix styling, while keeping a standard qr fallback if generation fails.',
+          'vault share links now use custom refhub qr codes with a cleaner, more recognizable design.',
       },
       {
         tag: 'improvement',
-        title: 'cleaner qr share dialog on mobile',
+        title: 'polished qr share dialog',
         description:
-          'the qr share dialog now gives the generated svg more room, removes the extra white matte, and shows a clean loading spinner instead of flashing the fallback qr while the custom code is loading.',
+          'qr sharing now loads more cleanly and fits better on mobile.',
       },
     ],
   },

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -21,6 +21,25 @@ export interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
+    id: 10,
+    date: '2026-05-22',
+    title: 'custom vault qr sharing',
+    features: [
+      {
+        tag: 'feature',
+        title: 'custom refhub qr codes',
+        description:
+          'vault sharing now uses the custom refhub qr generator for branded svg qr codes with the refhub mark and dot-matrix styling, while keeping a standard qr fallback if generation fails.',
+      },
+      {
+        tag: 'improvement',
+        title: 'cleaner qr share dialog on mobile',
+        description:
+          'the qr share dialog now gives the generated svg more room, removes the extra white matte, and shows a clean loading spinner instead of flashing the fallback qr while the custom code is loading.',
+      },
+    ],
+  },
+  {
     id: 9,
     date: '2026-05-12',
     title: 'clearer all papers counts and vault context',


### PR DESCRIPTION
## Summary
- request custom SVG QR codes from the hosted refhub-qr generator for vault share URLs
- render the SVG via a blob URL instead of raw HTML, with cleanup on changes
- keep the existing qrcode.react canvas as loading/error fallback and for PNG download fallback
- download SVG when custom generation succeeds, otherwise fall back to PNG canvas download

## Verification
- curl verified https://refhub-qr.netlify.app/api/generate-qr returns HTTP 200, CORS headers, and image/svg+xml
- npm run lint -- src/components/vaults/QRCodeDialog.tsx

Note: lint reports two pre-existing warnings in Dashboard.tsx and VaultDetail.tsx about unnecessary hook dependencies; no errors.