### PR TITLE
Fix publication dialog mobile safe areas

### DIFF
--- a/src/components/profile/ProfileDialog.tsx
+++ b/src/components/profile/ProfileDialog.tsx
@@ -283,7 +283,7 @@ export function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
       />
       <Dialog open={open} onOpenChange={handleDialogClose}>
         <DialogContent className="dialog-mobile max-w-[100vw] sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-3xl sm:max-h-[90vh] border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col gap-0 p-0">
-        <DialogHeader className="px-6 pt-6 pb-4">
+        <DialogHeader className="px-6 pt-[max(env(safe-area-inset-top),1.5rem)] sm:pt-6 pb-4">
           <DialogTitle className="text-xl sm:text-2xl font-bold font-mono">// edit_profile</DialogTitle>
         </DialogHeader>
 
@@ -484,7 +484,7 @@ export function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
             </div>
             </div>
 
-            <div className="shrink-0 flex items-center justify-between gap-2 py-3 px-6 border-t border-border">
+            <div className="shrink-0 flex items-center justify-between gap-2 pt-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] sm:py-3 px-6 border-t border-border">
               <div className="flex items-center gap-1">
                 <Button
                   type="button"

--- a/src/components/publications/FilterBuilder.tsx
+++ b/src/components/publications/FilterBuilder.tsx
@@ -359,7 +359,7 @@ export function FilterBuilder({ filters, onFiltersChange, tags, vaults, open: co
         <SheetTrigger asChild>
           {filterTrigger}
         </SheetTrigger>
-        <SheetContent side="bottom" className="px-4 pb-8 pt-4 max-h-[80vh] overflow-y-auto" onCloseAutoFocus={onCloseAutoFocus}>
+        <SheetContent side="bottom" className="px-4 pb-[max(env(safe-area-inset-bottom),2rem)] pt-4 max-h-[80vh] overflow-y-auto" onCloseAutoFocus={onCloseAutoFocus}>
           <SheetHeader className="mb-4">
             <SheetTitle className="font-mono text-left">filter_papers</SheetTitle>
           </SheetHeader>

--- a/src/components/publications/PublicationDialog.tsx
+++ b/src/components/publications/PublicationDialog.tsx
@@ -884,9 +884,9 @@ export function PublicationDialog({
       {/* Main Dialog - hidden when fullscreen is active */}
       <Dialog open={open && !notesFullscreen} onOpenChange={handleDialogClose}>
         <DialogContent 
-          className="w-screen max-w-none box-border h-screen sm:w-[95vw] sm:max-w-3xl sm:h-auto sm:max-h-[90vh] m-0 p-0 border-0 sm:border-2 bg-card/95 backdrop-blur-xl overflow-x-hidden overflow-y-auto flex flex-col"
+          className="w-screen max-w-none box-border h-[100dvh] max-h-[100dvh] sm:w-[95vw] sm:max-w-3xl sm:h-auto sm:max-h-[90vh] m-0 p-0 border-0 sm:border-2 bg-card/95 backdrop-blur-xl overflow-hidden flex flex-col"
         >
-        <DialogHeader className="px-2 py-3 sm:p-6 pb-2 sm:pb-0">
+        <DialogHeader className="shrink-0 px-2 pt-[calc(env(safe-area-inset-top)+0.75rem)] pb-2 sm:p-6 sm:pb-0">
           <DialogTitle className="text-xl sm:text-2xl font-bold font-mono pr-8 sm:pr-10">
             {publication ? (
               <span>// edit_<span className="text-gradient">paper</span></span>
@@ -926,8 +926,8 @@ export function PublicationDialog({
           </div>
         )}
 
-        <ScrollArea className="flex-1 overflow-auto w-full min-w-0">
-          <form onSubmit={handleSubmit} className="px-2 py-3 sm:p-6 sm:pt-4 space-y-3 sm:space-y-5 w-full box-border overflow-hidden">
+        <ScrollArea className="flex-1 min-h-0 overflow-auto w-full min-w-0">
+          <form onSubmit={handleSubmit} className="px-2 pt-3 pb-[calc(env(safe-area-inset-bottom)+5.75rem)] sm:p-6 sm:pt-4 sm:pb-6 space-y-3 sm:space-y-5 w-full box-border overflow-hidden">
             {/* Title */}
             <div className="space-y-1 sm:space-y-2 w-full box-border overflow-hidden">
               <div className="flex items-center gap-2">
@@ -1636,12 +1636,12 @@ export function PublicationDialog({
             )}
 
             {/* Actions */}
-            <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3 pt-3 sm:pt-4 border-t border-border w-full box-border">
-              <Button type="button" variant="outline" onClick={() => handleDialogClose(false)} className="font-mono w-full sm:w-auto text-xs sm:text-sm h-9 sm:h-10">
+            <div className="sticky bottom-0 z-20 -mx-2 flex flex-col-reverse gap-2 border-t border-border bg-card/95 px-2 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-3 backdrop-blur sm:static sm:z-auto sm:mx-0 sm:flex-row sm:justify-end sm:gap-3 sm:bg-transparent sm:px-0 sm:pb-0 sm:pt-4 sm:backdrop-blur-none w-auto sm:w-full box-border">
+              <Button type="button" variant="outline" onClick={() => handleDialogClose(false)} className="font-mono w-full sm:w-auto text-xs sm:text-sm h-10">
                 <X className="w-3 h-3 mr-1.5" />
                 close
               </Button>
-              <Button type="submit" variant="glow" disabled={saving} className="font-mono w-full sm:w-auto text-xs sm:text-sm h-9 sm:h-10">
+              <Button type="submit" variant="glow" disabled={saving} className="font-mono w-full sm:w-auto text-xs sm:text-sm h-10">
                 {saving ? (
                   'saving...'
                 ) : publication ? (

--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -105,7 +105,7 @@ export function PublicationViewDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="dialog-mobile publication-view-dialog max-w-[100vw] border-2 bg-card/95 backdrop-blur-xl overflow-hidden shadow-2xl sm:rounded-2xl sm:h-auto sm:w-[95vw] sm:max-w-3xl sm:max-h-[90vh] p-0 gap-0">
-        <DialogHeader className="shrink-0 space-y-3 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 border-b border-border/60">
+        <DialogHeader className="shrink-0 space-y-3 px-4 sm:px-6 pt-[max(env(safe-area-inset-top),1rem)] sm:pt-6 pb-4 border-b border-border/60">
           <div className="flex flex-wrap items-center gap-2">
             {publication.publication_type && (
               <Badge variant="outline" className="font-mono text-xs">
@@ -286,7 +286,7 @@ export function PublicationViewDialog({
         </div>
 
         {(onEdit || onExport) && (
-          <DialogFooter className="shrink-0 border-t border-border/60 px-4 sm:px-6 py-4 flex-col-reverse sm:flex-row gap-2">
+          <DialogFooter className="shrink-0 border-t border-border/60 px-4 sm:px-6 pt-4 pb-[max(env(safe-area-inset-bottom),1rem)] sm:py-4 flex-col-reverse sm:flex-row gap-2">
             {onExport && (
               <Button type="button" variant="outline" className="w-full sm:w-auto font-mono" onClick={() => onExport(publication)}>
                 <Download className="w-4 h-4 mr-2" />

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100vw-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-lg max-h-[calc(100dvh-2rem)] overflow-y-auto duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 flex flex-col w-[calc(100vw-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-lg max-h-[calc(100dvh-2rem)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
@@ -44,12 +44,12 @@ const AlertDialogContent = React.forwardRef<
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-2 text-center sm:text-left dialog-mobile-safe-header", className)} {...props} />
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left dialog-mobile-safe-header overflow-y-auto min-h-0", className)} {...props} />
 );
 AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2 dialog-mobile-safe-footer", className)} {...props} />
+  <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2 dialog-mobile-safe-footer shrink-0", className)} {...props} />
 );
 AlertDialogFooter.displayName = "AlertDialogFooter";
 

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -44,12 +44,12 @@ const AlertDialogContent = React.forwardRef<
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left dialog-mobile-safe-header", className)} {...props} />
 );
 AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2", className)} {...props} />
+  <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2 dialog-mobile-safe-footer", className)} {...props} />
 );
 AlertDialogFooter.displayName = "AlertDialogFooter";
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -52,12 +52,24 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-1.5 text-left", className)} {...props} />
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-left dialog-mobile-safe-header",
+      className,
+    )}
+    {...props}
+  />
 );
 DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 dialog-mobile-safe-footer",
+      className,
+    )}
+    {...props}
+  />
 );
 DialogFooter.displayName = "DialogFooter";
 

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -49,7 +49,7 @@ const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 DrawerHeader.displayName = "DrawerHeader";
 
 const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />
+  <div className={cn("mt-auto flex flex-col gap-2 p-4 dialog-mobile-safe-footer", className)} {...props} />
 );
 DrawerFooter.displayName = "DrawerFooter";
 

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -210,13 +210,13 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
 
       {/* Upgrade Dialog */}
       <AlertDialog open={showUpgradeDialog} onOpenChange={setShowUpgradeDialog}>
-        <AlertDialogContent>
+        <AlertDialogContent className="overflow-x-hidden rounded-lg sm:max-w-sm">
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2 font-mono">
               <AlertTriangle className="w-5 h-5 text-yellow-500" />
               private_vault
             </AlertDialogTitle>
-            <AlertDialogDescription className="space-y-3 font-mono text-sm">
+            <AlertDialogDescription className="space-y-3 font-mono text-sm break-all">
               <p>
                 // qr_code_sharing_requires_vault_to_be_protected_or_public
               </p>

--- a/src/index.css
+++ b/src/index.css
@@ -280,4 +280,22 @@
     height: 100dvh;
     max-height: 100dvh;
   }
+
+  .dialog-mobile-safe-header {
+    padding-top: max(env(safe-area-inset-top), 0px);
+  }
+
+  .dialog-mobile-safe-footer {
+    padding-bottom: max(env(safe-area-inset-bottom), 0px);
+  }
+
+  @media (min-width: 640px) {
+    .dialog-mobile-safe-header {
+      padding-top: 0;
+    }
+
+    .dialog-mobile-safe-footer {
+      padding-bottom: 0;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- use dynamic viewport height for the publication edit dialog on mobile
- add safe-area padding to the dialog header so it does not sit under status/browser chrome
- make the form content the scroll container and keep footer actions sticky above the mobile browser controls

## Tests
- npm run lint -- src/components/publications/PublicationDialog.tsx
- git diff --check