### PR TITLE
Fix QR code theme contrast on vault shares

### DIFF
--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -28,6 +28,7 @@ const CUSTOM_QR_ENDPOINT = 'https://refhub-qr.netlify.app/api/generate-qr';
 const CUSTOM_QR_FREEDOM = 0;
 const QR_DOWNLOAD_BACKGROUND = '#0d0d0f';
 const QR_DOWNLOAD_SIZE = 2048;
+const QR_DARK_BACKGROUND = '#0d0d0f';
 
 interface QRCodeDialogProps {
   vault: Vault;
@@ -176,6 +177,18 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
     }
   };
 
+  const getThemeAwareSvg = (svg: string) => {
+    const withModuleClass = svg.replace(/<circle\b/g, '<circle class="qr-module"');
+
+    if (/<rect\b/.test(withModuleClass)) {
+      return withModuleClass.replace(/<rect\b(?![^>]*class=)/, '<rect class="qr-background"');
+    }
+
+    return withModuleClass.replace(/(<svg\b[^>]*>)/, '$1<rect class="qr-background" width="100%" height="100%"/>');
+  };
+
+  const themedCustomQrSvg = customQrSvg ? getThemeAwareSvg(customQrSvg) : null;
+
   const getDownloadableSvg = (svg: string) => {
     const viewBoxMatch = svg.match(/<svg[^>]*viewBox="([^"]+)"/);
     const [, , width = '1024', height = '1024'] = viewBoxMatch?.[1]?.split(/\s+/) ?? [];
@@ -217,9 +230,9 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
   };
 
   const downloadQR = async () => {
-    if (customQrSvg) {
+    if (themedCustomQrSvg) {
       try {
-        await downloadPngFromSvg(customQrSvg);
+        await downloadPngFromSvg(themedCustomQrSvg);
         toast({ title: 'qr_code_downloaded' });
       } catch (error) {
         toast({
@@ -270,24 +283,24 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
                 // share "{vault.name}"
               </DialogTitle>
             </DialogHeader>
-            <div className="flex flex-col items-center gap-3 sm:gap-6 py-2 sm:py-5">
-              <div className="mx-auto w-full max-w-[276px] self-center rounded-2xl bg-[#0d0d0f] p-0 shadow-xl glow-purple sm:max-w-[456px] sm:rounded-3xl">
-                <div className="relative overflow-hidden rounded-xl bg-[#0d0d0f] p-0 sm:rounded-2xl">
+            <div className="flex min-h-[calc(100dvh-9rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col items-center justify-center gap-3 py-2 sm:min-h-0 sm:gap-6 sm:py-5">
+              <div className="mx-auto w-full max-w-[276px] self-center rounded-2xl bg-white p-0 shadow-xl glow-purple dark:bg-[#0d0d0f] sm:max-w-[456px] sm:rounded-3xl">
+                <div className="relative overflow-hidden rounded-xl bg-white p-0 dark:bg-[#0d0d0f] sm:rounded-2xl">
                   <div 
                     ref={qrRef}
                     className={cn(
-                      "relative flex items-center justify-center rounded-xl bg-[#0d0d0f] sm:rounded-2xl",
+                      "relative flex items-center justify-center rounded-xl bg-white dark:bg-[#0d0d0f] sm:rounded-2xl",
                       customQrLoading && !customQrError && "min-h-[220px] sm:min-h-[360px]"
                     )}
                     style={{
                       filter: customQrError ? `drop-shadow(0 0 8px ${gradientColor}40)` : undefined,
                     }}
                   >
-                    {customQrUrl ? (
-                      <img
-                        src={customQrUrl}
-                        alt={`QR code for ${vault.name || 'vault'}`}
-                        className="mx-auto block h-auto w-full max-w-[236px] object-contain sm:max-w-[390px]"
+                    {themedCustomQrSvg ? (
+                      <div
+                        aria-label={`QR code for ${vault.name || 'vault'}`}
+                        className="qr-code-svg mx-auto block h-auto w-full max-w-[236px] object-contain sm:max-w-[390px]"
+                        dangerouslySetInnerHTML={{ __html: themedCustomQrSvg }}
                       />
                     ) : customQrLoading && !customQrError ? (
                       <div className="flex flex-col items-center justify-center gap-3 text-center font-mono text-sm text-muted-foreground">
@@ -304,7 +317,7 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
                         size={fallbackQrSize}
                         level="H"
                         marginSize={2}
-                        bgColor={QR_DOWNLOAD_BACKGROUND}
+                        bgColor={QR_DARK_BACKGROUND}
                         fgColor={gradientColor}
                       />
                     )}

--- a/src/components/vaults/QRCodeDialog.tsx
+++ b/src/components/vaults/QRCodeDialog.tsx
@@ -177,18 +177,6 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
     }
   };
 
-  const getThemeAwareSvg = (svg: string) => {
-    const withModuleClass = svg.replace(/<circle\b/g, '<circle class="qr-module"');
-
-    if (/<rect\b/.test(withModuleClass)) {
-      return withModuleClass.replace(/<rect\b(?![^>]*class=)/, '<rect class="qr-background"');
-    }
-
-    return withModuleClass.replace(/(<svg\b[^>]*>)/, '$1<rect class="qr-background" width="100%" height="100%"/>');
-  };
-
-  const themedCustomQrSvg = customQrSvg ? getThemeAwareSvg(customQrSvg) : null;
-
   const getDownloadableSvg = (svg: string) => {
     const viewBoxMatch = svg.match(/<svg[^>]*viewBox="([^"]+)"/);
     const [, , width = '1024', height = '1024'] = viewBoxMatch?.[1]?.split(/\s+/) ?? [];
@@ -230,9 +218,9 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
   };
 
   const downloadQR = async () => {
-    if (themedCustomQrSvg) {
+    if (customQrSvg) {
       try {
-        await downloadPngFromSvg(themedCustomQrSvg);
+        await downloadPngFromSvg(customQrSvg);
         toast({ title: 'qr_code_downloaded' });
       } catch (error) {
         toast({
@@ -296,11 +284,11 @@ export function QRCodeDialog({ vault, onVaultUpdate }: QRCodeDialogProps) {
                       filter: customQrError ? `drop-shadow(0 0 8px ${gradientColor}40)` : undefined,
                     }}
                   >
-                    {themedCustomQrSvg ? (
+                    {customQrSvg ? (
                       <div
                         aria-label={`QR code for ${vault.name || 'vault'}`}
-                        className="qr-code-svg mx-auto block h-auto w-full max-w-[236px] object-contain sm:max-w-[390px]"
-                        dangerouslySetInnerHTML={{ __html: themedCustomQrSvg }}
+                        className="qr-code mx-auto block h-auto w-full max-w-[236px] object-contain sm:max-w-[390px]"
+                        dangerouslySetInnerHTML={{ __html: customQrSvg }}
                       />
                     ) : customQrLoading && !customQrError ? (
                       <div className="flex flex-col items-center justify-center gap-3 text-center font-mono text-sm text-muted-foreground">

--- a/src/index.css
+++ b/src/index.css
@@ -283,25 +283,22 @@
 }
 
 @layer components {
-  .qr-code-svg svg {
+  .qr-code > svg {
     display: block;
     width: 100%;
     height: auto;
+    background: #ffffff;
   }
 
-  .qr-code-svg .qr-background {
-    fill: #ffffff;
-  }
-
-  .qr-code-svg .qr-module {
+  .qr-code > svg > circle[fill="rgb(255,255,255)"] {
     fill: #0d0d0f;
   }
 
-  .dark .qr-code-svg .qr-background {
-    fill: #0d0d0f;
+  .dark .qr-code > svg {
+    background: #0d0d0f;
   }
 
-  .dark .qr-code-svg .qr-module {
+  .dark .qr-code > svg > circle[fill="rgb(255,255,255)"] {
     fill: #ffffff;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -281,3 +281,27 @@
     max-height: 100dvh;
   }
 }
+
+@layer components {
+  .qr-code-svg svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .qr-code-svg .qr-background {
+    fill: #ffffff;
+  }
+
+  .qr-code-svg .qr-module {
+    fill: #0d0d0f;
+  }
+
+  .dark .qr-code-svg .qr-background {
+    fill: #0d0d0f;
+  }
+
+  .dark .qr-code-svg .qr-module {
+    fill: #ffffff;
+  }
+}


### PR DESCRIPTION
## Summary
- render custom QR SVG inline so module/background fills can be themed
- add QR SVG classes/CSS for dark and light contrast
- vertically center the QR share content on mobile dialogs

## Verification
- npm run lint (passes; existing hook dependency warnings in Dashboard/VaultDetail)
- npm run build (passes; existing large chunk warning)