### PR TITLE
Fix theme class application for QR contrast

### DIFF
--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -7,7 +7,7 @@ export function ThemeToggle() {
   const [isDark, setIsDark] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('theme');
-      return stored ? stored === 'dark' : true; // default to dark if no preference
+      return stored ? stored === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
     return true;
   });

--- a/src/index.css
+++ b/src/index.css
@@ -114,10 +114,6 @@
     @apply border-border;
   }
 
-  html {
-    @apply dark;
-  }
-
   body {
     @apply bg-background text-foreground antialiased;
     font-family: 'Plus Jakarta Sans', system-ui, sans-serif;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,8 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
+const storedTheme = localStorage.getItem("theme");
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+document.documentElement.classList.toggle("dark", storedTheme ? storedTheme === "dark" : prefersDark);
+
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- remove `@apply dark` from `html`, which made Tailwind `dark:` rules compile as always-on `html …` selectors
- apply the initial `dark` class before React renders based on stored theme or system preference
- keep ThemeToggle state aligned with the same initial preference logic

## Why
The QR selector-based fix was present, but the compiled CSS included `html .qr-code…` dark rules because `html { @apply dark; }` was in base CSS. That made QR dark-mode styling always win, so toggling themes produced no visible QR contrast change.

## Verification
- `npm run lint` (passes; existing hook dependency warnings in Dashboard/VaultDetail)
- `npm run build` (passes; existing large chunk warning)
- inspected compiled CSS: no `html .qr-code` selector remains; QR CSS now compiles as base + `.dark …` selectors
