### PR TITLE
Add explicit Supabase Data API grants

### DIFF
--- a/supabase/migrations/20260527000000_explicit_data_api_grants.sql
+++ b/supabase/migrations/20260527000000_explicit_data_api_grants.sql
@@ -1,0 +1,18 @@
+-- Supabase Data API grants are no longer implicit for newly-created public
+-- schema objects. Keep PostgREST/GraphQL role privileges explicit while RLS
+-- policies continue to control row-level access.
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+
+GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT ALL ON TABLES TO anon, authenticated, service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary
- Add a migration that explicitly grants Supabase Data API roles access to current public schema tables, sequences, and functions
- Add default privileges for future public schema objects created by postgres
- Preserve existing RLS behavior; grants only restore role-level Data API exposure

## Audit notes
- Current schema.sql already contains explicit grants and default privileges for existing public objects.
- The migration history on origin/main only includes recent policy/function changes; future public objects still benefit from explicit default privileges after Supabase's default grant rollout.

## Verification
- Inspected supabase/schema.sql and supabase/migrations for CREATE TABLE/SEQUENCE/FUNCTION, GRANT, ALTER DEFAULT PRIVILEGES, and RLS policy coverage.
- Ran a Node assertion check against the new migration to verify required grant/default privilege statements are present.
- Did not run Supabase local validation because no Supabase CLI/psql binary is installed in this environment.