### PR TITLE
Show vault paper loading state

### DIFF
--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -37,6 +37,7 @@ import {
   MoreVertical,
   Tags,
   Telescope,
+  Loader2,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -78,6 +79,8 @@ interface PublicationListProps {
   syncLoadingIds?: Set<string>;
   syncCooldowns?: Record<string, number>;
   onCheckPublicationSync?: (pub: Publication) => void;
+  isLoadingPublications?: boolean;
+  loadingMessage?: string;
 }
 
 export function PublicationList({
@@ -112,6 +115,8 @@ export function PublicationList({
   syncLoadingIds = new Set(),
   syncCooldowns = {},
   onCheckPublicationSync,
+  isLoadingPublications = false,
+  loadingMessage = 'hang_on_getting_your_papers',
 }: PublicationListProps) {
   const openPublication = onOpenPublication || onEditPublication;
   const [searchQuery, setSearchQuery] = useState('');
@@ -750,25 +755,39 @@ export function PublicationList({
         {...kbNav.containerProps}
       >
         {filteredPublications.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <div className="w-20 h-20 rounded-3xl bg-gradient-primary flex items-center justify-center mb-6 shadow-lg glow-purple">
-              <Sparkles className="w-10 h-10 text-white" />
+          isLoadingPublications ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center" role="status" aria-live="polite">
+              <div className="w-20 h-20 rounded-3xl bg-gradient-primary flex items-center justify-center mb-6 shadow-lg glow-purple">
+                <Loader2 className="w-10 h-10 text-white animate-spin" />
+              </div>
+              <h3 className="text-2xl font-bold mb-2 font-mono">
+                {loadingMessage}
+              </h3>
+              <p className="text-muted-foreground max-w-sm mb-8 font-mono text-sm">
+                // fetching_your_research_collection
+              </p>
             </div>
-            <h3 className="text-2xl font-bold mb-2 font-mono">
-              {searchQuery || filters.length > 0 ? 'no_results_found' : 'no_papers_yet'}
-            </h3>
-            <p className="text-muted-foreground max-w-sm mb-8 font-mono text-sm">
-              {searchQuery || filters.length > 0
-                ? '// try_adjusting_your_search_or_filters'
-                : '// add_your_first_paper_to_start_building_your_library'}
-            </p>
-            {!searchQuery && filters.length === 0 && (
-              <Button onClick={onAddPublication} variant="glow" className="font-mono">
-                <Plus className="w-4 h-4 mr-2" />
-                add_your_first_paper
-              </Button>
-            )}
-          </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <div className="w-20 h-20 rounded-3xl bg-gradient-primary flex items-center justify-center mb-6 shadow-lg glow-purple">
+                <Sparkles className="w-10 h-10 text-white" />
+              </div>
+              <h3 className="text-2xl font-bold mb-2 font-mono">
+                {searchQuery || filters.length > 0 ? 'no_results_found' : 'no_papers_yet'}
+              </h3>
+              <p className="text-muted-foreground max-w-sm mb-8 font-mono text-sm">
+                {searchQuery || filters.length > 0
+                  ? '// try_adjusting_your_search_or_filters'
+                  : '// add_your_first_paper_to_start_building_your_library'}
+              </p>
+              {!searchQuery && filters.length === 0 && (
+                <Button onClick={onAddPublication} variant="glow" className="font-mono">
+                  <Plus className="w-4 h-4 mr-2" />
+                  add_your_first_paper
+                </Button>
+              )}
+            </div>
+          )
         ) : viewMode === 'table' ? (
           <PublicationTable
             publications={filteredPublications}

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -1897,6 +1897,8 @@ export default function VaultDetail() {
           syncLoadingIds={syncLoadingIds}
           syncCooldowns={syncCooldowns}
           onCheckPublicationSync={canEdit ? handleCheckPublicationSync : undefined}
+          isLoadingPublications={contentLoading && publications.length === 0}
+          loadingMessage="hang_on_getting_your_papers"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- add a publication-list loading state so empty lists do not claim `no_papers_yet` while content is still loading
- wire vault detail to show `hang_on_getting_your_papers` while vault publications are unresolved
- keep the existing empty state once loading finishes

## Verification
- npm run lint (passes with 2 existing react-hooks warnings, 0 errors)
