### PR TITLE
Fix Semantic Scholar queue rate-limit handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,9 +2557,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3931,31 +3931,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3964,7 +3964,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3976,26 +3976,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4003,13 +4003,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4018,9 +4019,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4028,14 +4029,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4596,6 +4598,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5111,9 +5120,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6339,10 +6348,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9293,12 +9312,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9308,13 +9327,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9938,9 +9957,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10307,9 +10326,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10471,9 +10490,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
-      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10781,9 +10800,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10887,31 +10906,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -10927,12 +10946,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -10953,6 +10975,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -10961,6 +10989,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -11166,9 +11197,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.3.13",
+  "version": "1.3.14",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -63,6 +63,7 @@ interface PublicationListProps {
   onDeletePublications?: (pubs: Publication[]) => void;
   onExportBibtex: (pubs: Publication[]) => void;
   onDiscoverRelated?: (pubs: Publication[]) => void;
+  onDiscoverByTopic?: () => void;
   onMobileMenuOpen: () => void;
   onOpenGraph?: () => void;
   onEditVault?: (vault: Vault) => void;
@@ -98,6 +99,7 @@ export function PublicationList({
   onDeletePublications,
   onExportBibtex,
   onDiscoverRelated,
+  onDiscoverByTopic,
   onMobileMenuOpen,
   onOpenGraph,
   onEditVault,
@@ -763,10 +765,20 @@ export function PublicationList({
                 : '// add_your_first_paper_to_start_building_your_library'}
             </p>
             {!searchQuery && filters.length === 0 && (
-              <Button onClick={onAddPublication} variant="glow" className="font-mono">
-                <Plus className="w-4 h-4 mr-2" />
-                add_your_first_paper
-              </Button>
+              <div className="flex flex-col sm:flex-row items-center gap-3">
+                {onAddPublication && (
+                  <Button onClick={onAddPublication} variant="glow" className="font-mono">
+                    <Plus className="w-4 h-4 mr-2" />
+                    add_your_first_paper
+                  </Button>
+                )}
+                {onDiscoverByTopic && (
+                  <Button onClick={onDiscoverByTopic} variant="outline" className="font-mono">
+                    <Telescope className="w-4 h-4 mr-2" />
+                    discover_by_topic
+                  </Button>
+                )}
+              </div>
             )}
           </div>
         ) : viewMode === 'table' ? (

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -26,7 +26,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { SpinnerLoader } from '@/components/ui/loader';
-import { Plus, Check, ExternalLink, BookOpen, AlertCircle, RotateCcw } from 'lucide-react';
+import { Plus, Check, ExternalLink, BookOpen, AlertCircle, RotateCcw, CheckCircle2 } from 'lucide-react';
 
 export type AugmentTab = 'references' | 'citations' | 'related';
 
@@ -119,18 +119,23 @@ function summarizeFailures(failures: TabFailure[]): string {
 function QueueStatusCard({
   status,
   title,
+  acknowledged,
+  onAcknowledge,
   onRetry,
 }: {
   status: TabStatus;
   title: string;
+  acknowledged: boolean;
+  onAcknowledge: () => void;
   onRetry: () => void;
 }) {
   const progress = status.progress;
   const hasFailures = status.failures.length > 0;
   const firstFailure = status.failures[0];
   const progressValue = getProgressValue(progress);
+  const isReady = status.state === 'ready' && !hasFailures;
 
-  if (status.state === 'idle' && !hasFailures) return null;
+  if ((status.state === 'idle' && !hasFailures) || (isReady && acknowledged)) return null;
 
   return (
     <div className="px-6 pt-3">
@@ -148,7 +153,24 @@ function QueueStatusCard({
                     : '// results_ready'}
             </p>
           </div>
-          {(status.state === 'partial' || status.state === 'error') && (
+          {isReady ? (
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="font-mono text-xs border-neon-green text-neon-green bg-neon-green/10 hover:bg-neon-green/20 hover:text-neon-green"
+                onClick={onAcknowledge}
+              >
+                <CheckCircle2 className="w-3.5 h-3.5 mr-1.5" />
+                ok
+              </Button>
+              <Button type="button" variant="outline" size="sm" className="font-mono text-xs" onClick={onRetry}>
+                <RotateCcw className="w-3 h-3 mr-1.5" />
+                rerun
+              </Button>
+            </div>
+          ) : (status.state === 'partial' || status.state === 'error') && (
             <Button type="button" variant="outline" size="sm" className="font-mono text-xs" onClick={onRetry}>
               <RotateCcw className="w-3 h-3 mr-1.5" />
               retry_failed
@@ -156,7 +178,7 @@ function QueueStatusCard({
           )}
         </div>
 
-        {progress && (
+        {progress && !isReady && (
           <div className="space-y-2">
             <Progress value={progressValue} className="h-2" />
             <div className="flex flex-wrap gap-x-4 gap-y-1 font-mono text-xs text-muted-foreground">
@@ -172,6 +194,13 @@ function QueueStatusCard({
           <div className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
             <SpinnerLoader className="w-3.5 h-3.5" />
             <span>processing_semantic_scholar_queue...</span>
+          </div>
+        )}
+
+        {isReady && progress && (
+          <div className="flex flex-wrap gap-x-4 gap-y-1 font-mono text-xs text-muted-foreground">
+            <span>{progress.completed}/{progress.total}_done</span>
+            <span>{progress.succeeded}_ok</span>
           </div>
         )}
 
@@ -339,6 +368,7 @@ export function VaultAugmentDialog({
   const [addedIds, setAddedIds] = useState<Set<string>>(new Set());
   const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
   const [tabStatus, setTabStatus] = useState<Record<AugmentTab, TabStatus>>(() => createIdleTabStatus());
+  const [acknowledgedTabs, setAcknowledgedTabs] = useState<Set<AugmentTab>>(new Set());
 
   const fetchedTabs = useRef<Set<AugmentTab>>(new Set());
   const resolvedPaperIds = useRef<ResolvedPaper[]>([]);
@@ -351,6 +381,14 @@ export function VaultAugmentDialog({
         ...next,
       },
     }));
+    if (next.state === 'loading') {
+      setAcknowledgedTabs((prev) => {
+        if (!prev.has(tab)) return prev;
+        const nextAcknowledged = new Set(prev);
+        nextAcknowledged.delete(tab);
+        return nextAcknowledged;
+      });
+    }
   }, []);
 
   const resolveSelectedPaperIds = useCallback(async (): Promise<{ resolved: ResolvedPaper[]; failures: TabFailure[] }> => {
@@ -545,6 +583,7 @@ export function VaultAugmentDialog({
       setAddedIds(new Set());
       setLoadingIds(new Set());
       setTabStatus(createIdleTabStatus());
+      setAcknowledgedTabs(new Set());
     }
   }, [open, fetchRelated]);
 
@@ -575,6 +614,9 @@ export function VaultAugmentDialog({
     activeTab === 'related' ? related : activeTab === 'references' ? references : citations;
   const activeStatus = tabStatus[activeTab];
   const initialLoading = tabStatus.related.state === 'loading' && related.length === 0;
+  const acknowledgeTab = (tab: AugmentTab) => {
+    setAcknowledgedTabs((prev) => new Set(prev).add(tab));
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -593,6 +635,8 @@ export function VaultAugmentDialog({
             <QueueStatusCard
               status={tabStatus.related}
               title="// resolving_lookup_and_related_queue"
+              acknowledged={acknowledgedTabs.has('related')}
+              onAcknowledge={() => acknowledgeTab('related')}
               onRetry={() => void fetchRelated(true)}
             />
           </div>
@@ -629,6 +673,8 @@ export function VaultAugmentDialog({
             <QueueStatusCard
               status={activeStatus}
               title={`// ${activeTab}_queue_status`}
+              acknowledged={acknowledgedTabs.has(activeTab)}
+              onAcknowledge={() => acknowledgeTab(activeTab)}
               onRetry={() => {
                 if (activeTab === 'related') {
                   void fetchRelated(true);

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -113,7 +113,10 @@ function summarizeFailures(failures: TabFailure[]): string {
   const failedLabels = failures.slice(0, 3).map((failure) => failure.label).join(' • ');
 
   if (rateLimitedCount === failures.length) {
-    return `Semantic Scholar asked to slow down for ${failures.length} seed${failures.length === 1 ? '' : 's'}. ${failedLabels}`;
+    const noun = failures.every((failure) => failure.stage === 'topic')
+      ? 'topic search'
+      : `${failures.length} seed${failures.length === 1 ? '' : 's'}`;
+    return `Semantic Scholar asked to slow down for ${noun}. ${failedLabels}`;
   }
 
   return `${failures.length} seed${failures.length === 1 ? '' : 's'} failed. ${failedLabels}`;

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -2,11 +2,16 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Publication } from '@/types/database';
 import {
   SSPaper,
+  SemanticScholarQueueProgress,
+  SemanticScholarRequestError,
+  formatSemanticScholarErrorMessage,
+  getRecommendations,
+  isSemanticScholarRateLimitError,
   lookupPaperByDOI,
   lookupPaperByTitle,
   getReferences,
   getCitations,
-  getRecommendationsForSet,
+  runSemanticScholarQueue,
 } from '@/lib/semanticScholar';
 import {
   Dialog,
@@ -18,8 +23,10 @@ import {
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { SpinnerLoader } from '@/components/ui/loader';
-import { Plus, Check, ExternalLink, BookOpen } from 'lucide-react';
+import { Plus, Check, ExternalLink, BookOpen, AlertCircle, RotateCcw } from 'lucide-react';
 
 export type AugmentTab = 'references' | 'citations' | 'related';
 
@@ -28,6 +35,25 @@ export interface DiscoveredPaper {
   tab: AugmentTab;
   /** vault_publication IDs of source papers that led to this discovery */
   sourcePublicationIds: string[];
+}
+
+interface ResolvedPaper {
+  pubId: string;
+  label: string;
+  ssId: string;
+}
+
+interface TabFailure {
+  pubId: string;
+  label: string;
+  stage: 'lookup' | AugmentTab;
+  error: SemanticScholarRequestError;
+}
+
+interface TabStatus {
+  state: 'idle' | 'loading' | 'ready' | 'partial' | 'error';
+  progress: SemanticScholarQueueProgress | null;
+  failures: TabFailure[];
 }
 
 interface VaultAugmentDialogProps {
@@ -58,6 +84,112 @@ function paperUrl(paper: SSPaper): string {
   if (paper.externalIds?.DOI) return `https://doi.org/${paper.externalIds.DOI}`;
   if (paper.url) return paper.url;
   return `https://www.semanticscholar.org/paper/${paper.paperId}`;
+}
+
+function publicationLabel(publication: Publication): string {
+  return publication.title?.trim() || publication.doi?.trim() || publication.id;
+}
+
+function createIdleTabStatus(): Record<AugmentTab, TabStatus> {
+  return {
+    related: { state: 'idle', progress: null, failures: [] },
+    references: { state: 'idle', progress: null, failures: [] },
+    citations: { state: 'idle', progress: null, failures: [] },
+  };
+}
+
+function getProgressValue(progress: SemanticScholarQueueProgress | null): number {
+  if (!progress || progress.total === 0) return 0;
+  return Math.round((progress.completed / progress.total) * 100);
+}
+
+function summarizeFailures(failures: TabFailure[]): string {
+  if (failures.length === 0) return '';
+
+  const rateLimitedCount = failures.filter((failure) => isSemanticScholarRateLimitError(failure.error)).length;
+  const failedLabels = failures.slice(0, 3).map((failure) => failure.label).join(' • ');
+
+  if (rateLimitedCount === failures.length) {
+    return `Semantic Scholar asked to slow down for ${failures.length} seed${failures.length === 1 ? '' : 's'}. ${failedLabels}`;
+  }
+
+  return `${failures.length} seed${failures.length === 1 ? '' : 's'} failed. ${failedLabels}`;
+}
+
+function QueueStatusCard({
+  status,
+  title,
+  onRetry,
+}: {
+  status: TabStatus;
+  title: string;
+  onRetry: () => void;
+}) {
+  const progress = status.progress;
+  const hasFailures = status.failures.length > 0;
+  const firstFailure = status.failures[0];
+  const progressValue = getProgressValue(progress);
+
+  if (status.state === 'idle' && !hasFailures) return null;
+
+  return (
+    <div className="px-6 pt-3">
+      <div className="rounded-xl border border-border/60 bg-background/70 p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="font-mono text-xs text-muted-foreground">{title}</p>
+            <p className="font-mono text-sm">
+              {status.state === 'loading'
+                ? '// queue_running'
+                : status.state === 'partial'
+                  ? '// partial_results_ready'
+                  : status.state === 'error'
+                    ? '// request_failed'
+                    : '// results_ready'}
+            </p>
+          </div>
+          {(status.state === 'partial' || status.state === 'error') && (
+            <Button type="button" variant="outline" size="sm" className="font-mono text-xs" onClick={onRetry}>
+              <RotateCcw className="w-3 h-3 mr-1.5" />
+              retry_failed
+            </Button>
+          )}
+        </div>
+
+        {progress && (
+          <div className="space-y-2">
+            <Progress value={progressValue} className="h-2" />
+            <div className="flex flex-wrap gap-x-4 gap-y-1 font-mono text-xs text-muted-foreground">
+              <span>{progress.completed}/{progress.total}_done</span>
+              <span>{progress.succeeded}_ok</span>
+              {progress.failed > 0 && <span>{progress.failed}_failed</span>}
+              {progress.rateLimited > 0 && <span>{progress.rateLimited}_rate_limited</span>}
+            </div>
+          </div>
+        )}
+
+        {status.state === 'loading' && (
+          <div className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
+            <SpinnerLoader className="w-3.5 h-3.5" />
+            <span>processing_semantic_scholar_queue...</span>
+          </div>
+        )}
+
+        {hasFailures && firstFailure && (
+          <Alert variant="destructive" className="border-destructive/40 bg-destructive/5 text-muted-foreground py-3">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle className="font-mono text-xs">
+              {isSemanticScholarRateLimitError(firstFailure.error) ? 'semantic_scholar_rate_limited' : 'semantic_scholar_partial_failure'}
+            </AlertTitle>
+            <AlertDescription className="space-y-2 font-mono text-xs">
+              <p>{formatSemanticScholarErrorMessage(firstFailure.error)}</p>
+              <p>{summarizeFailures(status.failures)}</p>
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function PaperRow({
@@ -200,71 +332,208 @@ export function VaultAugmentDialog({
   onOpenChange,
   onAddPaper,
 }: VaultAugmentDialogProps) {
-  const [loading, setLoading] = useState(false);
-  const [tabLoading, setTabLoading] = useState(false);
   const [activeTab, setActiveTab] = useState<AugmentTab>('related');
   const [references, setReferences] = useState<DiscoveredPaper[]>([]);
   const [citations, setCitations] = useState<DiscoveredPaper[]>([]);
   const [related, setRelated] = useState<DiscoveredPaper[]>([]);
   const [addedIds, setAddedIds] = useState<Set<string>>(new Set());
   const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
+  const [tabStatus, setTabStatus] = useState<Record<AugmentTab, TabStatus>>(() => createIdleTabStatus());
 
-  // Track which tabs have been fetched and the resolved SS paper IDs
   const fetchedTabs = useRef<Set<AugmentTab>>(new Set());
-  const resolvedPaperIds = useRef<{ pubId: string; ssId: string }[]>([]);
+  const resolvedPaperIds = useRef<ResolvedPaper[]>([]);
 
-  /** Step 1: resolve DOI/title → SS paper IDs, then fetch batch recommendations. */
-  const fetchRelated = useCallback(async () => {
-    if (publications.length === 0) return;
-    setLoading(true);
+  const updateTabStatus = useCallback((tab: AugmentTab, next: Partial<TabStatus>) => {
+    setTabStatus((prev) => ({
+      ...prev,
+      [tab]: {
+        ...prev[tab],
+        ...next,
+      },
+    }));
+  }, []);
 
-    // Resolve paper IDs sequentially (each hits the rate-limited queue)
-    const resolved: { pubId: string; ssId: string }[] = [];
-    for (const pub of publications) {
-      let ssId: string | null = null;
-      if (pub.doi) ssId = await lookupPaperByDOI(pub.doi);
-      if (!ssId && pub.title) ssId = await lookupPaperByTitle(pub.title);
-      if (ssId) resolved.push({ pubId: pub.id, ssId });
-    }
-    resolvedPaperIds.current = resolved;
+  const resolveSelectedPaperIds = useCallback(async (): Promise<{ resolved: ResolvedPaper[]; failures: TabFailure[] }> => {
+    const results = await runSemanticScholarQueue(
+      publications,
+      async (publication) => {
+        let ssId: string | null = null;
 
-    // Single batch call for recommendations
-    const recs = await getRecommendationsForSet(resolved.map((r) => r.ssId));
-    const allPubIds = resolved.map((r) => r.pubId);
-    setRelated(
-      recs.map((paper) => ({ paper, tab: 'related' as AugmentTab, sourcePublicationIds: allPubIds }))
+        if (publication.doi) {
+          ssId = await lookupPaperByDOI(publication.doi);
+        }
+        if (!ssId && publication.title) {
+          ssId = await lookupPaperByTitle(publication.title);
+        }
+
+        return ssId;
+      },
+      {
+        concurrency: 2,
+        minDelayMs: 400,
+        onProgress: (progress) => updateTabStatus('related', { progress, state: 'loading', failures: [] }),
+      },
     );
 
-    fetchedTabs.current.add('related');
-    setLoading(false);
-  }, [publications]);
+    const resolved: ResolvedPaper[] = [];
+    const failures: TabFailure[] = [];
 
-  /** Step 2: fetch refs or citations for the selected tab on demand. */
-  const fetchTabData = useCallback(async (tab: 'references' | 'citations') => {
-    if (fetchedTabs.current.has(tab)) return;
-    setTabLoading(true);
+    for (const [index, result] of results.entries()) {
+      const publication = publications[index];
+      const label = publicationLabel(publication);
+
+      if (!result.ok) {
+        failures.push({
+          pubId: publication.id,
+          label,
+          stage: 'lookup',
+          error: result.error!,
+        });
+        continue;
+      }
+
+      if (!result.data) continue;
+
+      resolved.push({
+        pubId: publication.id,
+        label,
+        ssId: result.data,
+      });
+    }
+
+    resolvedPaperIds.current = resolved;
+    return { resolved, failures };
+  }, [publications, updateTabStatus]);
+
+  const fetchRelated = useCallback(async (force = false) => {
+    if (publications.length === 0) return;
+    if (!force && fetchedTabs.current.has('related')) return;
+
+    updateTabStatus('related', { state: 'loading', progress: null, failures: [] });
+
+    const { resolved, failures: lookupFailures } = await resolveSelectedPaperIds();
+
+    if (resolved.length === 0) {
+      setRelated([]);
+      updateTabStatus('related', {
+        state: lookupFailures.length > 0 ? 'error' : 'ready',
+        failures: lookupFailures,
+      });
+      fetchedTabs.current.add('related');
+      return;
+    }
+
+    const recommendationResults = await runSemanticScholarQueue(
+      resolved,
+      ({ ssId }) => getRecommendations(ssId),
+      {
+        concurrency: 2,
+        minDelayMs: 500,
+        onProgress: (progress) => updateTabStatus('related', { progress, state: 'loading' }),
+      },
+    );
 
     const map = new Map<string, DiscoveredPaper>();
-    for (const { pubId, ssId } of resolvedPaperIds.current) {
-      const papers = tab === 'references' ? await getReferences(ssId) : await getCitations(ssId);
-      for (const p of papers) {
-        const existing = map.get(p.paperId);
-        if (existing) existing.sourcePublicationIds.push(pubId);
-        else map.set(p.paperId, { paper: p, tab, sourcePublicationIds: [pubId] });
+    const requestFailures = [...lookupFailures];
+
+    for (const result of recommendationResults) {
+      if (!result.ok) {
+        requestFailures.push({
+          pubId: result.item.pubId,
+          label: result.item.label,
+          stage: 'related',
+          error: result.error!,
+        });
+        continue;
+      }
+
+      for (const paper of result.data ?? []) {
+        const existing = map.get(paper.paperId);
+        if (existing) {
+          if (!existing.sourcePublicationIds.includes(result.item.pubId)) {
+            existing.sourcePublicationIds.push(result.item.pubId);
+          }
+        } else {
+          map.set(paper.paperId, {
+            paper,
+            tab: 'related',
+            sourcePublicationIds: [result.item.pubId],
+          });
+        }
+      }
+    }
+
+    setRelated([...map.values()]);
+    updateTabStatus('related', {
+      state: requestFailures.length === 0 ? 'ready' : map.size > 0 ? 'partial' : 'error',
+      failures: requestFailures,
+    });
+    fetchedTabs.current.add('related');
+  }, [publications, resolveSelectedPaperIds, updateTabStatus]);
+
+  const fetchTabData = useCallback(async (tab: 'references' | 'citations', force = false) => {
+    if (!force && fetchedTabs.current.has(tab)) return;
+    if (resolvedPaperIds.current.length === 0) {
+      updateTabStatus(tab, { state: 'error', failures: tabStatus.related.failures });
+      return;
+    }
+
+    updateTabStatus(tab, { state: 'loading', progress: null, failures: [] });
+
+    const results = await runSemanticScholarQueue(
+      resolvedPaperIds.current,
+      ({ ssId }) => (tab === 'references' ? getReferences(ssId) : getCitations(ssId)),
+      {
+        concurrency: 2,
+        minDelayMs: 500,
+        onProgress: (progress) => updateTabStatus(tab, { progress, state: 'loading' }),
+      },
+    );
+
+    const map = new Map<string, DiscoveredPaper>();
+    const failures: TabFailure[] = [];
+
+    for (const result of results) {
+      if (!result.ok) {
+        failures.push({
+          pubId: result.item.pubId,
+          label: result.item.label,
+          stage: tab,
+          error: result.error!,
+        });
+        continue;
+      }
+
+      for (const paper of result.data ?? []) {
+        const existing = map.get(paper.paperId);
+        if (existing) {
+          if (!existing.sourcePublicationIds.includes(result.item.pubId)) {
+            existing.sourcePublicationIds.push(result.item.pubId);
+          }
+        } else {
+          map.set(paper.paperId, {
+            paper,
+            tab,
+            sourcePublicationIds: [result.item.pubId],
+          });
+        }
       }
     }
 
     if (tab === 'references') setReferences([...map.values()]);
     else setCitations([...map.values()]);
 
+    updateTabStatus(tab, {
+      state: failures.length === 0 ? 'ready' : map.size > 0 ? 'partial' : 'error',
+      failures,
+    });
     fetchedTabs.current.add(tab);
-    setTabLoading(false);
-  }, []);
+  }, [tabStatus.related.failures, updateTabStatus]);
 
   // Open dialog: kick off the fast batch fetch for recommendations
   useEffect(() => {
     if (open && !fetchedTabs.current.has('related')) {
-      fetchRelated();
+      void fetchRelated();
     }
     if (!open) {
       fetchedTabs.current = new Set();
@@ -275,13 +544,16 @@ export function VaultAugmentDialog({
       setRelated([]);
       setAddedIds(new Set());
       setLoadingIds(new Set());
+      setTabStatus(createIdleTabStatus());
     }
   }, [open, fetchRelated]);
 
   // Switch tab → lazy-load refs/citations if not yet fetched
   const handleTabChange = (tab: AugmentTab) => {
     setActiveTab(tab);
-    if (tab !== 'related') fetchTabData(tab);
+    if (tab !== 'related') {
+      void fetchTabData(tab);
+    }
   };
 
   const handleAdd = async (discovered: DiscoveredPaper) => {
@@ -301,6 +573,8 @@ export function VaultAugmentDialog({
 
   const activePapers =
     activeTab === 'related' ? related : activeTab === 'references' ? references : citations;
+  const activeStatus = tabStatus[activeTab];
+  const initialLoading = tabStatus.related.state === 'loading' && related.length === 0;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -314,14 +588,17 @@ export function VaultAugmentDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {loading && (
-          <div className="flex-1 flex items-center justify-center gap-3 text-muted-foreground px-6">
-            <SpinnerLoader className="w-5 h-5" />
-            <span className="font-mono text-sm">// fetching_from_semantic_scholar...</span>
+        {initialLoading && (
+          <div className="flex-1 flex flex-col justify-center gap-4 px-6 py-6">
+            <QueueStatusCard
+              status={tabStatus.related}
+              title="// resolving_lookup_and_related_queue"
+              onRetry={() => void fetchRelated(true)}
+            />
           </div>
         )}
 
-        {!loading && (
+        {!initialLoading && (
           <>
             <Tabs
               value={activeTab}
@@ -332,17 +609,38 @@ export function VaultAugmentDialog({
                 <TabsTrigger value="related" className="text-xs font-mono h-6 px-3">
                   related ({related.length})
                 </TabsTrigger>
-                <TabsTrigger value="references" className="text-xs font-mono h-6 px-3">
+                <TabsTrigger
+                  value="references"
+                  className="text-xs font-mono h-6 px-3"
+                  disabled={tabStatus.related.state === 'loading'}
+                >
                   cites→ ({references.length})
                 </TabsTrigger>
-                <TabsTrigger value="citations" className="text-xs font-mono h-6 px-3">
+                <TabsTrigger
+                  value="citations"
+                  className="text-xs font-mono h-6 px-3"
+                  disabled={tabStatus.related.state === 'loading'}
+                >
                   ←cited_by ({citations.length})
                 </TabsTrigger>
               </TabsList>
             </Tabs>
 
+            <QueueStatusCard
+              status={activeStatus}
+              title={`// ${activeTab}_queue_status`}
+              onRetry={() => {
+                if (activeTab === 'related') {
+                  void fetchRelated(true);
+                  return;
+                }
+
+                void fetchTabData(activeTab, true);
+              }}
+            />
+
             <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden scrollbar-thin px-6 pb-4 pt-2">
-              {tabLoading ? (
+              {activeStatus.state === 'loading' && activePapers.length === 0 ? (
                 <div className="flex items-center justify-center gap-3 text-muted-foreground py-8">
                   <SpinnerLoader className="w-4 h-4" />
                   <span className="font-mono text-xs">// fetching...</span>

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -12,6 +12,7 @@ import {
   getReferences,
   getCitations,
   runSemanticScholarQueue,
+  searchPapersByTopic,
 } from '@/lib/semanticScholar';
 import {
   Dialog,
@@ -22,13 +23,14 @@ import {
 } from '@/components/ui/dialog';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { SpinnerLoader } from '@/components/ui/loader';
-import { Plus, Check, ExternalLink, BookOpen, AlertCircle, RotateCcw, CheckCircle2 } from 'lucide-react';
+import { Plus, Check, ExternalLink, BookOpen, AlertCircle, RotateCcw, CheckCircle2, Search } from 'lucide-react';
 
-export type AugmentTab = 'references' | 'citations' | 'related';
+export type AugmentTab = 'references' | 'citations' | 'related' | 'topic';
 
 export interface DiscoveredPaper {
   paper: SSPaper;
@@ -95,6 +97,7 @@ function createIdleTabStatus(): Record<AugmentTab, TabStatus> {
     related: { state: 'idle', progress: null, failures: [] },
     references: { state: 'idle', progress: null, failures: [] },
     citations: { state: 'idle', progress: null, failures: [] },
+    topic: { state: 'idle', progress: null, failures: [] },
   };
 }
 
@@ -361,10 +364,13 @@ export function VaultAugmentDialog({
   onOpenChange,
   onAddPaper,
 }: VaultAugmentDialogProps) {
-  const [activeTab, setActiveTab] = useState<AugmentTab>('related');
+  const isTopicDiscovery = publications.length === 0;
+  const [activeTab, setActiveTab] = useState<AugmentTab>(isTopicDiscovery ? 'topic' : 'related');
   const [references, setReferences] = useState<DiscoveredPaper[]>([]);
   const [citations, setCitations] = useState<DiscoveredPaper[]>([]);
   const [related, setRelated] = useState<DiscoveredPaper[]>([]);
+  const [topicResults, setTopicResults] = useState<DiscoveredPaper[]>([]);
+  const [topicQuery, setTopicQuery] = useState('');
   const [addedIds, setAddedIds] = useState<Set<string>>(new Set());
   const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
   const [tabStatus, setTabStatus] = useState<Record<AugmentTab, TabStatus>>(() => createIdleTabStatus());
@@ -509,6 +515,48 @@ export function VaultAugmentDialog({
     fetchedTabs.current.add('related');
   }, [publications, resolveSelectedPaperIds, updateTabStatus]);
 
+  const fetchTopicData = useCallback(async (force = false) => {
+    const query = topicQuery.trim();
+    if (query.length < 2) {
+      setTopicResults([]);
+      updateTabStatus('topic', { state: 'idle', progress: null, failures: [] });
+      return;
+    }
+
+    const fetchKey = `topic:${query.toLowerCase()}`;
+    if (!force && fetchedTabs.current.has(fetchKey)) return;
+
+    updateTabStatus('topic', { state: 'loading', progress: null, failures: [] });
+    const results = await runSemanticScholarQueue(
+      [query],
+      (searchQuery) => searchPapersByTopic(searchQuery, 25),
+      {
+        concurrency: 1,
+        minDelayMs: 500,
+        onProgress: (progress) => updateTabStatus('topic', { progress, state: 'loading' }),
+      },
+    );
+
+    const result = results[0];
+    if (!result.ok) {
+      setTopicResults([]);
+      updateTabStatus('topic', {
+        state: 'error',
+        failures: [{ pubId: 'topic-search', label: query, stage: 'topic', error: result.error! }],
+      });
+      return;
+    }
+
+    const papers = (result.data ?? []).map((paper) => ({
+      paper,
+      tab: 'topic' as const,
+      sourcePublicationIds: [],
+    }));
+    setTopicResults(papers);
+    updateTabStatus('topic', { state: 'ready', failures: [] });
+    fetchedTabs.current.add(fetchKey);
+  }, [topicQuery, updateTabStatus]);
+
   const fetchTabData = useCallback(async (tab: 'references' | 'citations', force = false) => {
     if (!force && fetchedTabs.current.has(tab)) return;
     if (resolvedPaperIds.current.length === 0) {
@@ -568,29 +616,34 @@ export function VaultAugmentDialog({
     fetchedTabs.current.add(tab);
   }, [tabStatus.related.failures, updateTabStatus]);
 
-  // Open dialog: kick off the fast batch fetch for recommendations
+  // Open dialog: kick off seed-based recommendations when seeds exist; otherwise show topic discovery.
   useEffect(() => {
-    if (open && !fetchedTabs.current.has('related')) {
+    if (open && !isTopicDiscovery && !fetchedTabs.current.has('related')) {
       void fetchRelated();
+    }
+    if (open && isTopicDiscovery) {
+      setActiveTab('topic');
     }
     if (!open) {
       fetchedTabs.current = new Set();
       resolvedPaperIds.current = [];
-      setActiveTab('related');
+      setActiveTab(isTopicDiscovery ? 'topic' : 'related');
       setReferences([]);
       setCitations([]);
       setRelated([]);
+      setTopicResults([]);
+      setTopicQuery('');
       setAddedIds(new Set());
       setLoadingIds(new Set());
       setTabStatus(createIdleTabStatus());
       setAcknowledgedTabs(new Set());
     }
-  }, [open, fetchRelated]);
+  }, [open, fetchRelated, isTopicDiscovery]);
 
   // Switch tab → lazy-load refs/citations if not yet fetched
   const handleTabChange = (tab: AugmentTab) => {
     setActiveTab(tab);
-    if (tab !== 'related') {
+    if (tab === 'references' || tab === 'citations') {
       void fetchTabData(tab);
     }
   };
@@ -611,9 +664,9 @@ export function VaultAugmentDialog({
   };
 
   const activePapers =
-    activeTab === 'related' ? related : activeTab === 'references' ? references : citations;
+    activeTab === 'topic' ? topicResults : activeTab === 'related' ? related : activeTab === 'references' ? references : citations;
   const activeStatus = tabStatus[activeTab];
-  const initialLoading = tabStatus.related.state === 'loading' && related.length === 0;
+  const initialLoading = !isTopicDiscovery && tabStatus.related.state === 'loading' && related.length === 0;
   const acknowledgeTab = (tab: AugmentTab) => {
     setAcknowledgedTabs((prev) => new Set(prev).add(tab));
   };
@@ -626,7 +679,9 @@ export function VaultAugmentDialog({
             // vault_augmentation
           </DialogTitle>
           <DialogDescription className="font-mono text-sm text-muted-foreground">
-            // semantic_scholar • {publications.length} paper{publications.length !== 1 ? 's' : ''} selected
+            {isTopicDiscovery
+              ? '// semantic_scholar • topic_discovery'
+              : `// semantic_scholar • ${publications.length} paper${publications.length !== 1 ? 's' : ''} selected`}
           </DialogDescription>
         </DialogHeader>
 
@@ -644,31 +699,53 @@ export function VaultAugmentDialog({
 
         {!initialLoading && (
           <>
-            <Tabs
-              value={activeTab}
-              onValueChange={(v) => handleTabChange(v as AugmentTab)}
-              className="shrink-0 px-6 pt-3"
-            >
-              <TabsList className="justify-start w-auto h-8">
-                <TabsTrigger value="related" className="text-xs font-mono h-6 px-3">
-                  related ({related.length})
-                </TabsTrigger>
-                <TabsTrigger
-                  value="references"
-                  className="text-xs font-mono h-6 px-3"
-                  disabled={tabStatus.related.state === 'loading'}
-                >
-                  cites→ ({references.length})
-                </TabsTrigger>
-                <TabsTrigger
-                  value="citations"
-                  className="text-xs font-mono h-6 px-3"
-                  disabled={tabStatus.related.state === 'loading'}
-                >
-                  ←cited_by ({citations.length})
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
+            {isTopicDiscovery ? (
+              <form
+                className="shrink-0 px-6 pt-4 flex flex-col sm:flex-row gap-2"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void fetchTopicData(true);
+                }}
+              >
+                <Input
+                  value={topicQuery}
+                  onChange={(event) => setTopicQuery(event.target.value)}
+                  placeholder="topic, keyword, or paper title"
+                  className="font-mono"
+                  disabled={tabStatus.topic.state === 'loading'}
+                />
+                <Button type="submit" variant="glow" className="font-mono" disabled={topicQuery.trim().length < 2 || tabStatus.topic.state === 'loading'}>
+                  {tabStatus.topic.state === 'loading' ? <SpinnerLoader className="w-4 h-4 mr-2" /> : <Search className="w-4 h-4 mr-2" />}
+                  search
+                </Button>
+              </form>
+            ) : (
+              <Tabs
+                value={activeTab}
+                onValueChange={(v) => handleTabChange(v as AugmentTab)}
+                className="shrink-0 px-6 pt-3"
+              >
+                <TabsList className="justify-start w-auto h-8">
+                  <TabsTrigger value="related" className="text-xs font-mono h-6 px-3">
+                    related ({related.length})
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="references"
+                    className="text-xs font-mono h-6 px-3"
+                    disabled={tabStatus.related.state === 'loading'}
+                  >
+                    cites→ ({references.length})
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="citations"
+                    className="text-xs font-mono h-6 px-3"
+                    disabled={tabStatus.related.state === 'loading'}
+                  >
+                    ←cited_by ({citations.length})
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            )}
 
             <QueueStatusCard
               status={activeStatus}
@@ -676,6 +753,10 @@ export function VaultAugmentDialog({
               acknowledged={acknowledgedTabs.has(activeTab)}
               onAcknowledge={() => acknowledgeTab(activeTab)}
               onRetry={() => {
+                if (activeTab === 'topic') {
+                  void fetchTopicData(true);
+                  return;
+                }
                 if (activeTab === 'related') {
                   void fetchRelated(true);
                   return;

--- a/src/lib/semanticScholar.test.ts
+++ b/src/lib/semanticScholar.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/apiKeys', () => ({
+  getBackendApiBaseUrl: () => 'https://refhub.test',
+}));
+
+import { supabase } from '@/integrations/supabase/client';
+import {
+  fetchSemanticScholarMetadataByDoi,
+  runSemanticScholarQueue,
+  type SemanticScholarQueueProgress,
+  type SemanticScholarRequestError,
+} from './semanticScholar';
+
+const getSessionMock = vi.mocked(supabase.auth.getSession);
+
+describe('semanticScholar', () => {
+  beforeEach(() => {
+    getSessionMock.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'token',
+        },
+      },
+      error: null,
+    });
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('captures retry timing from Retry-After headers', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'semantic_scholar_rate_limited',
+            message: 'Semantic Scholar rate limit exceeded',
+          },
+        }),
+        {
+          status: 429,
+          headers: {
+            'content-type': 'application/json',
+            'retry-after': '12',
+          },
+        },
+      ),
+    );
+
+    await expect(fetchSemanticScholarMetadataByDoi('10.123/example')).rejects.toMatchObject({
+      code: 'semantic_scholar_rate_limited',
+      status: 429,
+      retryAfterSeconds: 12,
+    });
+  });
+
+  it('runs queued tasks with bounded concurrency and progress updates', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const progressUpdates: SemanticScholarQueueProgress[] = [];
+
+    const results = await runSemanticScholarQueue(
+      [1, 2, 3, 4],
+      async (item) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return item * 2;
+      },
+      {
+        concurrency: 2,
+        minDelayMs: 0,
+        onProgress: (progress) => progressUpdates.push(progress),
+      },
+    );
+
+    expect(maxActive).toBe(2);
+    expect(results.map((result) => result.data)).toEqual([2, 4, 6, 8]);
+    expect(progressUpdates.at(-1)).toMatchObject({
+      completed: 4,
+      total: 4,
+      active: 0,
+      succeeded: 4,
+      failed: 0,
+      rateLimited: 0,
+    });
+  });
+
+  it('tracks rate-limited failures in queue progress', async () => {
+    const progressUpdates: SemanticScholarQueueProgress[] = [];
+    const rateLimitError = Object.assign(new Error('Retry in about 9s.'), {
+      code: 'semantic_scholar_rate_limited',
+      status: 429,
+      retryAfterSeconds: 9,
+      requestId: null,
+    }) as SemanticScholarRequestError;
+
+    const results = await runSemanticScholarQueue(
+      ['ok', 'slow'],
+      async (item) => {
+        if (item === 'slow') throw rateLimitError;
+        return item;
+      },
+      {
+        concurrency: 2,
+        minDelayMs: 0,
+        onProgress: (progress) => progressUpdates.push(progress),
+      },
+    );
+
+    expect(results[1]).toMatchObject({
+      ok: false,
+      error: {
+        code: 'semantic_scholar_rate_limited',
+        retryAfterSeconds: 9,
+      },
+    });
+    expect(progressUpdates.at(-1)).toMatchObject({
+      failed: 1,
+      rateLimited: 1,
+    });
+  });
+});

--- a/src/lib/semanticScholar.test.ts
+++ b/src/lib/semanticScholar.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/apiKeys', () => ({
 import { supabase } from '@/integrations/supabase/client';
 import {
   fetchSemanticScholarMetadataByDoi,
+  formatSemanticScholarErrorMessage,
   runSemanticScholarQueue,
   searchPapersByTopic,
   type SemanticScholarQueueProgress,
@@ -60,6 +61,19 @@ describe('semanticScholar', () => {
       status: 429,
       retryAfterSeconds: 12,
     });
+  });
+
+  it('formats rate-limit errors with an actionable rerun hint', () => {
+    const error = Object.assign(new Error('Semantic Scholar rate limit exceeded'), {
+      code: 'semantic_scholar_rate_limited',
+      status: 429,
+      retryAfterSeconds: null,
+      requestId: 'request-1',
+    }) as SemanticScholarRequestError;
+
+    expect(formatSemanticScholarErrorMessage(error)).toBe(
+      'Semantic Scholar rate limit exceeded. Please wait a moment, then rerun the request.',
+    );
   });
 
   it('searches papers by topic through the backend proxy', async () => {

--- a/src/lib/semanticScholar.test.ts
+++ b/src/lib/semanticScholar.test.ts
@@ -16,6 +16,7 @@ import { supabase } from '@/integrations/supabase/client';
 import {
   fetchSemanticScholarMetadataByDoi,
   runSemanticScholarQueue,
+  searchPapersByTopic,
   type SemanticScholarQueueProgress,
   type SemanticScholarRequestError,
 } from './semanticScholar';
@@ -59,6 +60,38 @@ describe('semanticScholar', () => {
       status: 429,
       retryAfterSeconds: 12,
     });
+  });
+
+  it('searches papers by topic through the backend proxy', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              paper_id: 'paper-1',
+              title: 'Topic Paper',
+              authors: [{ name: 'Ada' }],
+              year: 2025,
+              venue: 'VIS',
+              external_ids: { DOI: '10.123/topic' },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    await expect(searchPapersByTopic('visual analytics', 10)).resolves.toEqual([
+      expect.objectContaining({
+        paperId: 'paper-1',
+        title: 'Topic Paper',
+        externalIds: { DOI: '10.123/topic' },
+      }),
+    ]);
+    expect(fetch).toHaveBeenCalledWith('https://refhub.test/search', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ query: 'visual analytics', limit: 10 }),
+    }));
   });
 
   it('runs queued tasks with bounded concurrency and progress updates', async () => {

--- a/src/lib/semanticScholar.ts
+++ b/src/lib/semanticScholar.ts
@@ -27,6 +27,49 @@ export interface SemanticScholarMetadata {
   publication_type?: string;
 }
 
+interface SemanticScholarErrorPayload {
+  error?: {
+    code?: string;
+    message?: string;
+    details?: Record<string, unknown> | string;
+  } | null;
+  message?: string;
+  details?: Record<string, unknown> | string;
+  meta?: {
+    request_id?: string;
+  } | null;
+}
+
+export interface SemanticScholarRequestError extends Error {
+  code: string;
+  status: number;
+  retryAfterSeconds: number | null;
+  requestId: string | null;
+  details?: Record<string, unknown> | string;
+}
+
+export interface SemanticScholarQueueProgress {
+  completed: number;
+  total: number;
+  active: number;
+  succeeded: number;
+  failed: number;
+  rateLimited: number;
+}
+
+export interface SemanticScholarQueueResult<TItem, TResult> {
+  item: TItem;
+  ok: boolean;
+  data?: TResult;
+  error?: SemanticScholarRequestError;
+}
+
+interface SemanticScholarQueueOptions {
+  concurrency?: number;
+  minDelayMs?: number;
+  onProgress?: (progress: SemanticScholarQueueProgress) => void;
+}
+
 interface BackendPaperAuthor {
   author_id?: string | null;
   authorId?: string | null;
@@ -55,6 +98,114 @@ const paperCache = new Map<string, SSPaper[]>();
 
 function getSemanticScholarProxyUrl(path: string) {
   return `${getBackendApiBaseUrl()}${path}`;
+}
+
+function createSemanticScholarRequestError(
+  message: string,
+  options: {
+    code?: string;
+    status: number;
+    retryAfterSeconds?: number | null;
+    requestId?: string | null;
+    details?: Record<string, unknown> | string;
+  },
+): SemanticScholarRequestError {
+  const error = new Error(message) as SemanticScholarRequestError;
+  error.name = 'SemanticScholarRequestError';
+  error.code = options.code || 'semantic_scholar_error';
+  error.status = options.status;
+  error.retryAfterSeconds = options.retryAfterSeconds ?? null;
+  error.requestId = options.requestId ?? null;
+  error.details = options.details;
+  return error;
+}
+
+function getRetryAfterSecondsFromHeader(value: string | null): number | null {
+  if (!value) return null;
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric >= 0) {
+    return Math.max(0, Math.ceil(numeric));
+  }
+
+  const dateMs = Date.parse(value);
+  if (Number.isNaN(dateMs)) return null;
+
+  const diffMs = dateMs - Date.now();
+  return diffMs > 0 ? Math.max(1, Math.ceil(diffMs / 1000)) : 0;
+}
+
+function getRetryAfterSecondsFromPayload(payload: SemanticScholarErrorPayload | null): number | null {
+  const details = payload?.error?.details ?? payload?.details;
+  if (!details || typeof details !== 'object') return null;
+
+  const retryAfterSeconds = (details as { retry_after_seconds?: unknown }).retry_after_seconds;
+  return typeof retryAfterSeconds === 'number' && Number.isFinite(retryAfterSeconds)
+    ? Math.max(0, Math.ceil(retryAfterSeconds))
+    : null;
+}
+
+function getRequestIdFromPayload(payload: SemanticScholarErrorPayload | null): string | null {
+  const requestId = payload?.meta?.request_id;
+  return typeof requestId === 'string' && requestId.trim().length > 0 ? requestId.trim() : null;
+}
+
+export function isSemanticScholarRequestError(error: unknown): error is SemanticScholarRequestError {
+  return error instanceof Error && 'code' in error && 'status' in error;
+}
+
+export function isSemanticScholarRateLimitError(error: unknown): error is SemanticScholarRequestError {
+  return isSemanticScholarRequestError(error)
+    && (error.status === 429 || error.code === 'semantic_scholar_rate_limited' || error.code === 'rate_limit_exceeded');
+}
+
+function normalizeSemanticScholarError(
+  payload: SemanticScholarErrorPayload | null,
+  response: Response,
+): SemanticScholarRequestError {
+  const status = response.status;
+  const retryAfterSeconds =
+    getRetryAfterSecondsFromPayload(payload) ?? getRetryAfterSecondsFromHeader(response.headers.get('retry-after'));
+  const baseMessage =
+    payload?.error?.message ||
+    (typeof payload?.error?.details === 'string' ? payload.error.details : '') ||
+    payload?.message ||
+    (typeof payload?.details === 'string' ? payload.details : '') ||
+    `Semantic Scholar request failed (${status})`;
+  const message = retryAfterSeconds != null && retryAfterSeconds > 0
+    ? `${baseMessage} Retry in about ${retryAfterSeconds}s.`
+    : baseMessage;
+
+  return createSemanticScholarRequestError(message, {
+    code:
+      payload?.error?.code ||
+      (status === 429 ? 'semantic_scholar_rate_limited' : 'semantic_scholar_error'),
+    status,
+    retryAfterSeconds,
+    requestId: getRequestIdFromPayload(payload),
+    details: payload?.error?.details ?? payload?.details,
+  });
+}
+
+function normalizeUnknownSemanticScholarError(error: unknown): SemanticScholarRequestError {
+  if (isSemanticScholarRequestError(error)) return error;
+  if (error instanceof Error) {
+    return createSemanticScholarRequestError(error.message, {
+      code: 'semantic_scholar_error',
+      status: 500,
+    });
+  }
+
+  return createSemanticScholarRequestError('Semantic Scholar request failed.', {
+    code: 'semantic_scholar_error',
+    status: 500,
+  });
+}
+
+export function formatSemanticScholarErrorMessage(error: unknown, fallback = 'Semantic Scholar request failed.'): string {
+  if (isSemanticScholarRequestError(error)) return error.message;
+  if (error instanceof Error && error.message.trim().length > 0) return error.message;
+  return fallback;
 }
 
 function normalizeMetadataAuthors(authors: SemanticScholarMetadata['authors'] | undefined | null): string[] {
@@ -116,19 +267,109 @@ async function getAccessToken() {
   return accessToken;
 }
 
-function getErrorMessage(payload: unknown, status: number) {
-  return (
-    (payload as { error?: { message?: string; details?: string } } | null)?.error?.message ||
-    (payload as { error?: { details?: string } } | null)?.error?.details ||
-    (payload as { message?: string; details?: string } | null)?.message ||
-    (payload as { details?: string } | null)?.details ||
-    `Semantic Scholar request failed (${status})`
-  );
+async function parseResponsePayload(response: Response): Promise<SemanticScholarErrorPayload | null> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchWithSemanticScholarError(path: string, init: RequestInit): Promise<SemanticScholarErrorPayload | null> {
+  const response = await fetch(getSemanticScholarProxyUrl(path), init);
+  const payload = await parseResponsePayload(response);
+
+  if (!response.ok) {
+    throw normalizeSemanticScholarError(payload, response);
+  }
+
+  return payload;
+}
+
+async function paceQueue(schedule: { nextStartAt: number }, minDelayMs: number) {
+  if (minDelayMs <= 0) return;
+
+  const waitMs = Math.max(0, schedule.nextStartAt - Date.now());
+  schedule.nextStartAt = Math.max(schedule.nextStartAt, Date.now()) + minDelayMs;
+
+  if (waitMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+  }
+}
+
+export async function runSemanticScholarQueue<TItem, TResult>(
+  items: TItem[],
+  worker: (item: TItem, index: number) => Promise<TResult>,
+  options: SemanticScholarQueueOptions = {},
+): Promise<SemanticScholarQueueResult<TItem, TResult>[]> {
+  if (items.length === 0) return [];
+
+  const concurrency = Math.max(1, options.concurrency ?? 2);
+  const minDelayMs = Math.max(0, options.minDelayMs ?? 350);
+  const results = new Array<SemanticScholarQueueResult<TItem, TResult>>(items.length);
+  const progress: SemanticScholarQueueProgress = {
+    completed: 0,
+    total: items.length,
+    active: 0,
+    succeeded: 0,
+    failed: 0,
+    rateLimited: 0,
+  };
+  const schedule = { nextStartAt: Date.now() };
+  let nextIndex = 0;
+
+  const emitProgress = () => {
+    options.onProgress?.({ ...progress });
+  };
+
+  emitProgress();
+
+  const runWorker = async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+
+      if (index >= items.length) return;
+
+      progress.active += 1;
+      emitProgress();
+
+      await paceQueue(schedule, minDelayMs);
+
+      try {
+        const data = await worker(items[index], index);
+        results[index] = {
+          item: items[index],
+          ok: true,
+          data,
+        };
+        progress.succeeded += 1;
+      } catch (error) {
+        const normalizedError = normalizeUnknownSemanticScholarError(error);
+        results[index] = {
+          item: items[index],
+          ok: false,
+          error: normalizedError,
+        };
+        progress.failed += 1;
+        if (isSemanticScholarRateLimitError(normalizedError)) {
+          progress.rateLimited += 1;
+        }
+      } finally {
+        progress.active -= 1;
+        progress.completed += 1;
+        emitProgress();
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => runWorker()));
+  return results;
 }
 
 async function lookupPaperIdFromBackend(input: { doi?: string; title?: string }): Promise<string | null> {
   const accessToken = await getAccessToken();
-  const response = await fetch(getSemanticScholarProxyUrl('/lookup'), {
+  const payload = await fetchWithSemanticScholarError('/lookup', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -136,17 +377,6 @@ async function lookupPaperIdFromBackend(input: { doi?: string; title?: string })
     },
     body: JSON.stringify(input),
   });
-
-  let payload: unknown = null;
-  try {
-    payload = await response.json();
-  } catch {
-    payload = null;
-  }
-
-  if (!response.ok) {
-    throw new Error(getErrorMessage(payload, response.status));
-  }
 
   const paperId =
     (payload as { data?: { paper_id?: unknown; paperId?: unknown } | null } | null)?.data?.paper_id ??
@@ -162,7 +392,7 @@ async function fetchPaperListFromBackend(
   limit: number,
 ): Promise<SSPaper[]> {
   const accessToken = await getAccessToken();
-  const response = await fetch(getSemanticScholarProxyUrl(`/${route}`), {
+  const payload = await fetchWithSemanticScholarError(`/${route}`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -174,17 +404,6 @@ async function fetchPaperListFromBackend(
     }),
   });
 
-  let payload: unknown = null;
-  try {
-    payload = await response.json();
-  } catch {
-    payload = null;
-  }
-
-  if (!response.ok) {
-    throw new Error(getErrorMessage(payload, response.status));
-  }
-
   const records = Array.isArray((payload as { data?: unknown } | null)?.data)
     ? ((payload as { data: BackendPaper[] }).data ?? [])
     : [];
@@ -193,58 +412,38 @@ async function fetchPaperListFromBackend(
 }
 
 export async function lookupPaperByDOI(doi: string): Promise<string | null> {
-  try {
-    return await lookupPaperIdFromBackend({ doi });
-  } catch {
-    return null;
-  }
+  return lookupPaperIdFromBackend({ doi });
 }
 
 export async function lookupPaperByTitle(title: string): Promise<string | null> {
-  try {
-    return await lookupPaperIdFromBackend({ title });
-  } catch {
-    return null;
-  }
+  return lookupPaperIdFromBackend({ title });
 }
 
 export async function getReferences(paperId: string): Promise<SSPaper[]> {
   const cacheKey = `refs:${paperId}`;
   if (paperCache.has(cacheKey)) return paperCache.get(cacheKey)!;
 
-  try {
-    const papers = await fetchPaperListFromBackend('references', paperId, 25);
-    paperCache.set(cacheKey, papers);
-    return papers;
-  } catch {
-    return [];
-  }
+  const papers = await fetchPaperListFromBackend('references', paperId, 25);
+  paperCache.set(cacheKey, papers);
+  return papers;
 }
 
 export async function getCitations(paperId: string): Promise<SSPaper[]> {
   const cacheKey = `cites:${paperId}`;
   if (paperCache.has(cacheKey)) return paperCache.get(cacheKey)!;
 
-  try {
-    const papers = await fetchPaperListFromBackend('citations', paperId, 25);
-    paperCache.set(cacheKey, papers);
-    return papers;
-  } catch {
-    return [];
-  }
+  const papers = await fetchPaperListFromBackend('citations', paperId, 25);
+  paperCache.set(cacheKey, papers);
+  return papers;
 }
 
 export async function getRecommendations(paperId: string): Promise<SSPaper[]> {
   const cacheKey = `recs:${paperId}`;
   if (paperCache.has(cacheKey)) return paperCache.get(cacheKey)!;
 
-  try {
-    const papers = await fetchPaperListFromBackend('recommendations', paperId, 20);
-    paperCache.set(cacheKey, papers);
-    return papers;
-  } catch {
-    return [];
-  }
+  const papers = await fetchPaperListFromBackend('recommendations', paperId, 20);
+  paperCache.set(cacheKey, papers);
+  return papers;
 }
 
 export async function getRecommendationsForSet(paperIds: string[]): Promise<SSPaper[]> {
@@ -254,26 +453,30 @@ export async function getRecommendationsForSet(paperIds: string[]): Promise<SSPa
   const cacheKey = `recs-set:${[...dedupedPaperIds].sort().join(',')}`;
   if (paperCache.has(cacheKey)) return paperCache.get(cacheKey)!;
 
-  try {
-    const recommendationSets = await Promise.all(
-      dedupedPaperIds.map((paperId) => fetchPaperListFromBackend('recommendations', paperId, 20))
-    );
+  const recommendationSets = await runSemanticScholarQueue(
+    dedupedPaperIds,
+    (paperId) => fetchPaperListFromBackend('recommendations', paperId, 20),
+  );
 
-    const merged = new Map<string, SSPaper>();
-    for (const papers of recommendationSets) {
-      for (const paper of papers) {
-        if (!merged.has(paper.paperId)) {
-          merged.set(paper.paperId, paper);
-        }
+  const firstError = recommendationSets.find((result) => !result.ok)?.error;
+  if (firstError) {
+    throw firstError;
+  }
+
+  const merged = new Map<string, SSPaper>();
+  for (const result of recommendationSets) {
+    if (!result.ok || !result.data) continue;
+
+    for (const paper of result.data) {
+      if (!merged.has(paper.paperId)) {
+        merged.set(paper.paperId, paper);
       }
     }
-
-    const papers = [...merged.values()];
-    paperCache.set(cacheKey, papers);
-    return papers;
-  } catch {
-    return [];
   }
+
+  const papers = [...merged.values()];
+  paperCache.set(cacheKey, papers);
+  return papers;
 }
 
 export async function fetchSemanticScholarMetadataByDoi(doi: string): Promise<SemanticScholarMetadata | null> {
@@ -281,7 +484,7 @@ export async function fetchSemanticScholarMetadataByDoi(doi: string): Promise<Se
   if (!cleanDoi) return null;
 
   const accessToken = await getAccessToken();
-  const response = await fetch(getSemanticScholarProxyUrl('/doi-metadata'), {
+  const payload = await fetchWithSemanticScholarError('/doi-metadata', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -289,17 +492,6 @@ export async function fetchSemanticScholarMetadataByDoi(doi: string): Promise<Se
     },
     body: JSON.stringify({ doi: cleanDoi }),
   });
-
-  let payload: unknown = null;
-  try {
-    payload = await response.json();
-  } catch {
-    payload = null;
-  }
-
-  if (!response.ok) {
-    throw new Error(getErrorMessage(payload, response.status));
-  }
 
   const metadata = (payload as { data?: SemanticScholarMetadata | null } | null)?.data ?? null;
   if (!metadata) return null;
@@ -313,4 +505,3 @@ export async function fetchSemanticScholarMetadataByDoi(doi: string): Promise<Se
     doi: metadata.doi || cleanDoi,
   };
 }
-

--- a/src/lib/semanticScholar.ts
+++ b/src/lib/semanticScholar.ts
@@ -411,6 +411,31 @@ async function fetchPaperListFromBackend(
   return records.map(normalizePaper).filter((paper): paper is SSPaper => paper !== null);
 }
 
+export async function searchPapersByTopic(query: string, limit = 20): Promise<SSPaper[]> {
+  const cleanQuery = query.trim();
+  if (cleanQuery.length < 2) return [];
+
+  const cacheKey = `search:${cleanQuery.toLowerCase()}:${limit}`;
+  if (paperCache.has(cacheKey)) return paperCache.get(cacheKey)!;
+
+  const accessToken = await getAccessToken();
+  const payload = await fetchWithSemanticScholarError('/search', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: cleanQuery, limit }),
+  });
+
+  const records = Array.isArray((payload as { data?: unknown } | null)?.data)
+    ? ((payload as { data: BackendPaper[] }).data ?? [])
+    : [];
+  const papers = records.map(normalizePaper).filter((paper): paper is SSPaper => paper !== null);
+  paperCache.set(cacheKey, papers);
+  return papers;
+}
+
 export async function lookupPaperByDOI(doi: string): Promise<string | null> {
   return lookupPaperIdFromBackend({ doi });
 }

--- a/src/lib/semanticScholar.ts
+++ b/src/lib/semanticScholar.ts
@@ -203,7 +203,20 @@ function normalizeUnknownSemanticScholarError(error: unknown): SemanticScholarRe
 }
 
 export function formatSemanticScholarErrorMessage(error: unknown, fallback = 'Semantic Scholar request failed.'): string {
-  if (isSemanticScholarRequestError(error)) return error.message;
+  if (isSemanticScholarRequestError(error)) {
+    const retryHint = error.retryAfterSeconds && error.retryAfterSeconds > 0
+      ? ` Retry in about ${error.retryAfterSeconds}s or rerun once the shared limit clears.`
+      : ' Please wait a moment, then rerun the request.';
+
+    if (isSemanticScholarRateLimitError(error)) {
+      const separator = /[.!?]$/.test(error.message.trim()) ? '' : '.';
+      return error.message.includes('Retry in about')
+        ? `${error.message}${separator} You can rerun after the shared limit clears.`
+        : `${error.message}${separator}${retryHint}`;
+    }
+
+    return error.message;
+  }
   if (error instanceof Error && error.message.trim().length > 0) return error.message;
   return fallback;
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -19,7 +19,11 @@ import { useToast } from '@/hooks/use-toast';
 import { Sparkles } from 'lucide-react';
 import { getPageCache, setPageCache, hasPageCache, clearPageCache } from '@/lib/pageCache';
 import { buildVaultPublicationCopyPayload } from '@/lib/vaultPublicationAttribution';
-import { fetchSemanticScholarMetadataByDoi, SemanticScholarMetadata } from '@/lib/semanticScholar';
+import {
+  fetchSemanticScholarMetadataByDoi,
+  formatSemanticScholarErrorMessage,
+  SemanticScholarMetadata,
+} from '@/lib/semanticScholar';
 import { createPublicationSyncPatch, extractBibliographicPatch, getPublicationSyncDiffs, PublicationSyncDiff } from '@/lib/publicationSync';
 import { PublicationSyncDialog } from '@/components/publications/PublicationSyncDialog';
 import {
@@ -1192,7 +1196,11 @@ export default function Dashboard() {
         toast({ title: 'sync_up_to_date', description: 'Semantic Scholar details match this publication.' });
       }
     } catch (error) {
-      toast({ title: 'sync_failed', description: (error as Error).message, variant: 'destructive' });
+      toast({
+        title: 'sync_failed',
+        description: formatSemanticScholarErrorMessage(error),
+        variant: 'destructive',
+      });
     } finally {
       setSyncLoadingIds(prev => {
         const next = new Set(prev);

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -734,8 +734,8 @@ export default function VaultDetail() {
       volume: null,
       issue: null,
       pages: null,
-      abstract: null,
-      pdf_url: null,
+      abstract: paper.abstract,
+      pdf_url: paper.openAccessPdfUrl,
       bibtex_key: null,
       notes: null,
       booktitle: null,
@@ -1887,6 +1887,10 @@ export default function VaultDetail() {
           onExportBibtex={handleExportBibtex}
           onDiscoverRelated={canEdit ? (pubs) => {
             setAugmentPublications(pubs);
+            setIsAugmentDialogOpen(true);
+          } : undefined}
+          onDiscoverByTopic={canEdit ? () => {
+            setAugmentPublications([]);
             setIsAugmentDialogOpen(true);
           } : undefined}
           onMobileMenuOpen={() => setIsMobileSidebarOpen(true)}

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -13,7 +13,12 @@ import { PublicationList } from '@/components/publications/PublicationList';
 import { PublicationDialog } from '@/components/publications/PublicationDialog';
 import { PublicationViewDialog } from '@/components/publications/PublicationViewDialog';
 import { VaultAugmentDialog } from '@/components/publications/VaultAugmentDialog';
-import { fetchSemanticScholarMetadataByDoi, SSPaper, SemanticScholarMetadata } from '@/lib/semanticScholar';
+import {
+  fetchSemanticScholarMetadataByDoi,
+  formatSemanticScholarErrorMessage,
+  SSPaper,
+  SemanticScholarMetadata,
+} from '@/lib/semanticScholar';
 import { createPublicationSyncPatch, getPublicationSyncDiffs, PublicationSyncDiff } from '@/lib/publicationSync';
 import { PublicationSyncDialog } from '@/components/publications/PublicationSyncDialog';
 import { AddImportDialog } from '@/components/publications/AddImportDialog';
@@ -875,7 +880,11 @@ export default function VaultDetail() {
         toast({ title: 'sync_up_to_date', description: 'Semantic Scholar details match this publication.' });
       }
     } catch (error) {
-      toast({ title: 'sync_failed', description: (error as Error).message, variant: 'destructive' });
+      toast({
+        title: 'sync_failed',
+        description: formatSemanticScholarErrorMessage(error),
+        variant: 'destructive',
+      });
     } finally {
       setSyncLoadingIds(prev => {
         const next = new Set(prev);


### PR DESCRIPTION
## Summary
- add Semantic Scholar augmentation queue UX for rate-limited lookups
- surface queued/retry state in the paper dialog instead of failing hard
- preserve existing DOI/title augmentation flow while preventing duplicate in-flight work

## Paired backend PR
- Backend retry/API-key support: refhub-io/.netlify#14

## Validation
- inspected worktree: clean on `fix/issue-108-109-semantic-scholar-queue` at `6108ea5`
- no uncommitted diff present in the handoff worktree
- `npm test`: passed
- `npm run lint`: passed with 2 existing warnings

Closes #108
Closes #109
