### PR TITLE
Add onboarding help center

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.3.13",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.3.13",
+      "version": "1.4.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.3.14",
+  "version": "1.4.0",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,10 @@ import { ScrollToTopButton } from "@/components/layout/ScrollToTopButton";
 import { queryClient, initQueryPersistence } from "@/lib/queryClient";
 import { KeyboardProvider } from "@/contexts/KeyboardContext";
 import { KeyboardHelpOverlay } from "@/components/ui/KeyboardHelpOverlay";
+import { OnboardingWelcomeDialog } from "@/components/ui/OnboardingWelcomeDialog";
 import { useKeyboardAnalytics } from "@/hooks/useKeyboardAnalytics";
+import { useOnboarding } from "@/hooks/useOnboarding";
+import { useKeyboardContext } from "@/contexts/KeyboardContext";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import AuthCallback from "./pages/AuthCallback";
@@ -36,6 +39,24 @@ import { ChickenOverlay } from "@/components/easter-egg/ChickenOverlay";
 function KeyboardAnalyticsTracker() {
   useKeyboardAnalytics();
   return null;
+}
+
+function OnboardingWelcome() {
+  const { open, onOpenChange, dismiss } = useOnboarding();
+  const { openHelpOverlay } = useKeyboardContext();
+
+  const handleOpenGuide = () => {
+    dismiss();
+    openHelpOverlay('guide');
+  };
+
+  return (
+    <OnboardingWelcomeDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      onOpenGuide={handleOpenGuide}
+    />
+  );
 }
 
 function CluckEasterEgg() {
@@ -68,6 +89,7 @@ const App = () => {
               <BugReportButton />
               <CluckEasterEgg />
               <KeyboardHelpOverlay />
+              <OnboardingWelcome />
               <BrowserRouter>
                 <Routes>
                   <Route path="/" element={<Index />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { OnboardingWelcomeDialog } from "@/components/ui/OnboardingWelcomeDialog
 import { useKeyboardAnalytics } from "@/hooks/useKeyboardAnalytics";
 import { useOnboarding } from "@/hooks/useOnboarding";
 import { useKeyboardContext } from "@/contexts/KeyboardContext";
+import { useAuth } from "@/hooks/useAuth";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import AuthCallback from "./pages/AuthCallback";
@@ -42,7 +43,8 @@ function KeyboardAnalyticsTracker() {
 }
 
 function OnboardingWelcome() {
-  const { open, onOpenChange, dismiss } = useOnboarding();
+  const { user, loading } = useAuth();
+  const { open, onOpenChange, dismiss } = useOnboarding(user, loading);
   const { openHelpOverlay } = useKeyboardContext();
 
   const handleOpenGuide = () => {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -220,6 +220,7 @@ export function Sidebar({
           <Link
             to="/codex"
             onClick={onMobileClose}
+            data-onboarding-target="codex-link"
             className={cn(
               "w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 border-2",
               isCodexActive
@@ -277,7 +278,7 @@ export function Sidebar({
             </button>
 
             {isVaultsExpanded && (
-              <div className="mt-2 space-y-1" role="listbox" aria-label="My vaults">
+              <div className="mt-2 space-y-1" role="listbox" aria-label="My vaults" data-onboarding-target="vault-list">
                 {vaults.map((vault, index) => (
                   <div
                     key={vault.id}
@@ -337,6 +338,7 @@ export function Sidebar({
                     onCreateVault();
                     onMobileClose();
                   }}
+                  data-onboarding-target="new-vault"
                   className="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-sidebar-foreground/50 hover:text-sidebar-primary hover:bg-sidebar-accent/50 transition-all duration-200 border-2 border-dashed border-sidebar-border hover:border-sidebar-primary/50"
                 >
                   <Plus className="w-4 h-4" />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -240,6 +240,7 @@ export function Sidebar({
           <Link
             to="/users"
             onClick={onMobileClose}
+            data-onboarding-target="researchers-link"
             className={cn(
               "w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 border-2",
               location.pathname === '/users'
@@ -261,6 +262,7 @@ export function Sidebar({
           <div className="pt-4">
             <button
               onClick={() => setIsVaultsExpanded(!isVaultsExpanded)}
+              data-onboarding-target="vaults-section"
               className="w-full flex items-center justify-between px-4 py-2 text-xs font-bold uppercase tracking-widest text-sidebar-foreground/40 hover:text-sidebar-foreground/60 transition-colors font-mono"
             >
               <span className="flex items-center gap-2">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -454,7 +454,7 @@ export function Sidebar({
         {/* User section */}
         <div className="shrink-0 border-t-2 border-sidebar-border">
           <div className="p-4">
-            <div className="flex items-center gap-3 px-3 py-3 rounded-xl bg-sidebar-accent/50 mb-3">
+            <div className="flex items-center gap-3 px-3 py-3 rounded-xl bg-sidebar-accent/50 mb-3" data-onboarding-target="user-controls">
               <ProfileAvatar
                 name={profile?.display_name || user?.email?.split('@')[0] || 'User'}
                 avatarUrl={profile?.avatar_url}

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -518,6 +518,7 @@ export function PublicationList({
               <Button 
                 onClick={() => onEditVault(selectedVault)} 
                 variant="outline" 
+                data-onboarding-target="vault-settings"
                 className="h-9 font-mono hidden lg:flex"
               >
                 <Settings className="w-4 h-4 mr-2" />
@@ -590,7 +591,7 @@ export function PublicationList({
             )}
 
             {onAddPublication && (
-              <Button onClick={onAddPublication} variant="glow" className="h-9 w-9 sm:w-auto sm:px-3 font-mono">
+              <Button onClick={onAddPublication} variant="glow" data-onboarding-target="add-paper" className="h-9 w-9 sm:w-auto sm:px-3 font-mono">
                 <Plus className="w-4 h-4 sm:mr-2" />
                 <span className="hidden sm:inline">add_paper</span>
               </Button>
@@ -754,6 +755,7 @@ export function PublicationList({
       <div
         ref={listContainerRef}
         className="flex-1 overflow-y-auto scrollbar-thin overflow-x-hidden p-3 sm:p-4 lg:p-8 pb-[calc(1rem+env(safe-area-inset-bottom))] outline-none"
+        data-onboarding-target="publication-content"
         {...kbNav.containerProps}
       >
         {filteredPublications.length === 0 ? (
@@ -785,7 +787,7 @@ export function PublicationList({
               {!searchQuery && filters.length === 0 && (
                 <div className="flex flex-col sm:flex-row items-center gap-3">
                   {onAddPublication && (
-                    <Button onClick={onAddPublication} variant="glow" className="font-mono">
+                    <Button onClick={onAddPublication} variant="glow" data-onboarding-target="add-paper" className="font-mono">
                       <Plus className="w-4 h-4 mr-2" />
                       add_your_first_paper
                     </Button>

--- a/src/components/ui/KeyboardHelpOverlay.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.tsx
@@ -224,6 +224,7 @@ export function KeyboardShortcutsButton({ className }: { className?: string }) {
       size="icon"
       onClick={() => openHelpOverlay('keyboard')}
       title="help center (?)"
+      data-onboarding-target="help-center"
       className={cn('h-9 w-9 text-muted-foreground hover:text-primary relative group', className)}
     >
       <Keyboard className="w-4 h-4" />

--- a/src/components/ui/KeyboardHelpOverlay.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.tsx
@@ -42,7 +42,7 @@ export function KeyboardHelpOverlay() {
     [
       {
         combo: '?',
-        description: 'Toggle help center',
+        description: 'toggle help center',
         handler: () => {
           setHelpOverlayOpen(!helpOverlayOpen);
           return true;
@@ -64,16 +64,16 @@ export function KeyboardHelpOverlay() {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
-      toast({ title: 'Shortcuts copied to clipboard' });
+      toast({ title: 'shortcuts copied to clipboard' });
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      toast({ title: 'Failed to copy', variant: 'destructive' });
+      toast({ title: 'failed to copy', variant: 'destructive' });
     }
   }, [toast]);
 
   return (
     <Dialog open={helpOverlayOpen} onOpenChange={setHelpOverlayOpen}>
-      <DialogContent className="dialog-mobile max-w-[100vw] flex flex-col p-0 gap-0 border-primary/20 shadow-2xl shadow-primary/10 sm:rounded-2xl sm:max-w-3xl sm:h-auto sm:max-h-[85vh]">
+      <DialogContent className="dialog-mobile max-w-[100vw] flex flex-col overflow-hidden p-0 gap-0 border-primary/20 shadow-2xl shadow-primary/10 sm:rounded-2xl sm:max-w-3xl sm:h-[85vh] sm:max-h-[85vh]">
         {/* ── Header ────────────────────────────────────────────── */}
         <DialogHeader className="shrink-0 px-6 pt-6 pb-4 border-b border-border/60">
           <div className="flex items-start justify-between gap-4">
@@ -101,23 +101,23 @@ export function KeyboardHelpOverlay() {
           </div>
         </DialogHeader>
 
-        <Tabs value={helpOverlayTab} onValueChange={(value) => setHelpOverlayTab(value as 'keyboard' | 'guide')} className="flex min-h-0 flex-1 flex-col">
+        <Tabs value={helpOverlayTab} onValueChange={(value) => setHelpOverlayTab(value as 'keyboard' | 'guide')} className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <div className="shrink-0 border-b border-border/60 px-6 py-3">
             <TabsList className="grid w-full grid-cols-2 font-mono sm:w-80">
               <TabsTrigger value="keyboard" className="gap-2 text-xs">
                 <Keyboard className="h-3.5 w-3.5" />
-                Keyboard
+                keyboard
               </TabsTrigger>
               <TabsTrigger value="guide" className="gap-2 text-xs">
                 <BookOpen className="h-3.5 w-3.5" />
-                Guide
+                guide
               </TabsTrigger>
             </TabsList>
           </div>
 
-          <TabsContent value="keyboard" className="m-0 min-h-0 flex-1 data-[state=inactive]:hidden">
+          <TabsContent value="keyboard" className="m-0 min-h-0 flex-1 overflow-hidden data-[state=inactive]:hidden">
             {/* ── Shortcut grid ─────────────────────────────────────── */}
-            <ScrollArea className="h-full">
+            <ScrollArea className="h-full max-h-full">
               <div className="p-6 grid grid-cols-1 md:grid-cols-2 gap-5">
                 {SHORTCUT_HELP.map((group) => (
                   <div
@@ -175,8 +175,8 @@ export function KeyboardHelpOverlay() {
             </ScrollArea>
           </TabsContent>
 
-          <TabsContent value="guide" className="m-0 min-h-0 flex-1 data-[state=inactive]:hidden">
-            <ScrollArea className="h-full">
+          <TabsContent value="guide" className="m-0 min-h-0 flex-1 overflow-hidden data-[state=inactive]:hidden">
+            <ScrollArea className="h-full max-h-full">
               <MarkdownRenderer compact className="px-6 py-5 prose-headings:font-mono prose-h1:mt-0 prose-h2:border-t prose-h2:border-border/60 prose-h2:pt-5">
                 {helpGuide}
               </MarkdownRenderer>
@@ -223,7 +223,7 @@ export function KeyboardShortcutsButton({ className }: { className?: string }) {
       variant="ghost"
       size="icon"
       onClick={() => openHelpOverlay('keyboard')}
-      title="Help center (?)"
+      title="help center (?)"
       className={cn('h-9 w-9 text-muted-foreground hover:text-primary relative group', className)}
     >
       <Keyboard className="w-4 h-4" />

--- a/src/components/ui/KeyboardHelpOverlay.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.tsx
@@ -3,6 +3,7 @@ import { useKeyboardContext } from '@/contexts/KeyboardContext';
 import { useHotkeys } from '@/hooks/useKeyboardNavigation';
 import { SHORTCUT_HELP, formatCombo } from '@/lib/keyboard';
 import { cn } from '@/lib/utils';
+import helpGuide from '@/content/help-guide.md?raw';
 import {
   Dialog,
   DialogContent,
@@ -13,7 +14,9 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Copy, Check, Keyboard, Terminal } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
+import { BookOpen, Copy, Check, Keyboard } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
 /**
@@ -22,17 +25,24 @@ import { useToast } from '@/hooks/use-toast';
  * JetBrains Mono / refhub code aesthetic.
  */
 export function KeyboardHelpOverlay() {
-  const { helpOverlayOpen, setHelpOverlayOpen, enabled, setEnabled } = useKeyboardContext();
+  const {
+    helpOverlayOpen,
+    setHelpOverlayOpen,
+    helpOverlayTab,
+    setHelpOverlayTab,
+    enabled,
+    setEnabled,
+  } = useKeyboardContext();
   const { toast } = useToast();
   const [copied, setCopied] = useState(false);
 
-  // Register the ? shortcut globally to toggle the overlay
+  // Register the ? shortcut globally to toggle the help center.
   useHotkeys(
     'global',
     [
       {
         combo: '?',
-        description: 'Toggle keyboard help overlay',
+        description: 'Toggle help center',
         handler: () => {
           setHelpOverlayOpen(!helpOverlayOpen);
           return true;
@@ -66,11 +76,14 @@ export function KeyboardHelpOverlay() {
       <DialogContent className="dialog-mobile max-w-[100vw] flex flex-col p-0 gap-0 border-primary/20 shadow-2xl shadow-primary/10 sm:rounded-2xl sm:max-w-3xl sm:h-auto sm:max-h-[85vh]">
         {/* ── Header ────────────────────────────────────────────── */}
         <DialogHeader className="shrink-0 px-6 pt-6 pb-4 border-b border-border/60">
-          <div className="flex items-center justify-between">
-            <DialogTitle className="font-mono flex items-center gap-2.5 text-xl sm:text-2xl font-bold">
-              <span>// <span className="text-gradient">keyboard</span><span className="text-muted-foreground">_shortcuts()</span></span>
-            </DialogTitle>
-            <div className="flex items-center gap-2">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <DialogTitle className="font-mono flex items-center gap-2.5 text-xl sm:text-2xl font-bold">
+                <span>// <span className="text-gradient">help</span><span className="text-muted-foreground">_center()</span></span>
+              </DialogTitle>
+              <p className="mt-1 text-xs text-muted-foreground font-mono">keyboard shortcuts + product guide</p>
+            </div>
+            {helpOverlayTab === 'keyboard' && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -84,67 +97,92 @@ export function KeyboardHelpOverlay() {
                 )}
                 {copied ? 'copied!' : 'copy_all'}
               </Button>
-            </div>
+            )}
           </div>
         </DialogHeader>
 
-        {/* ── Shortcut grid ─────────────────────────────────────── */}
-        <ScrollArea className="flex-1 min-h-0">
-          <div className="p-6 grid grid-cols-1 md:grid-cols-2 gap-5">
-            {SHORTCUT_HELP.map((group) => (
-              <div
-                key={group.context}
-                className="rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm overflow-hidden"
-              >
-                {/* Group header */}
-                <div className="px-4 py-2.5 border-b border-border/40 bg-muted/30">
-                  <h3 className="text-[11px] font-bold uppercase tracking-[0.15em] text-primary font-mono flex items-center gap-2">
-                    <span className="w-1.5 h-1.5 rounded-full bg-gradient-primary shadow-sm" />
-                    {group.label}
-                  </h3>
-                </div>
-
-                {/* Shortcut rows */}
-                <div className="px-3 py-2 space-y-0.5">
-                  {group.shortcuts.map((shortcut, idx) => (
-                    <div
-                      key={`${shortcut.combo}-${idx}`}
-                      className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-muted/40 transition-colors group"
-                    >
-                      <span className="text-xs text-foreground/70 group-hover:text-foreground/90 transition-colors truncate mr-3">
-                        {shortcut.description}
-                      </span>
-                      <div className="flex items-center gap-1 shrink-0">
-                        {shortcut.combo.split(' / ').map((combo, i) => (
-                          <span key={combo} className="inline-flex items-center gap-0.5">
-                            {i > 0 && (
-                              <span className="text-muted-foreground/30 mx-0.5 text-[10px]">
-                                /
-                              </span>
-                            )}
-                            {combo.split(' ').map((part, j) => (
-                              <kbd
-                                key={`${combo}-${j}`}
-                                className={cn(
-                                  'inline-flex items-center justify-center rounded-md border font-mono select-none',
-                                  'bg-background/80 border-border/80 text-foreground/80',
-                                  'shadow-[0_1px_0_1px_rgba(0,0,0,0.15),inset_0_0.5px_0_rgba(255,255,255,0.05)]',
-                                  'min-w-[1.4rem] h-[1.4rem] px-1.5 text-[10px] leading-none',
-                                )}
-                              >
-                                {part.length <= 3 ? part : formatCombo(part)}
-                              </kbd>
-                            ))}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
+        <Tabs value={helpOverlayTab} onValueChange={(value) => setHelpOverlayTab(value as 'keyboard' | 'guide')} className="flex min-h-0 flex-1 flex-col">
+          <div className="shrink-0 border-b border-border/60 px-6 py-3">
+            <TabsList className="grid w-full grid-cols-2 font-mono sm:w-80">
+              <TabsTrigger value="keyboard" className="gap-2 text-xs">
+                <Keyboard className="h-3.5 w-3.5" />
+                Keyboard
+              </TabsTrigger>
+              <TabsTrigger value="guide" className="gap-2 text-xs">
+                <BookOpen className="h-3.5 w-3.5" />
+                Guide
+              </TabsTrigger>
+            </TabsList>
           </div>
-        </ScrollArea>
+
+          <TabsContent value="keyboard" className="m-0 min-h-0 flex-1 data-[state=inactive]:hidden">
+            {/* ── Shortcut grid ─────────────────────────────────────── */}
+            <ScrollArea className="h-full">
+              <div className="p-6 grid grid-cols-1 md:grid-cols-2 gap-5">
+                {SHORTCUT_HELP.map((group) => (
+                  <div
+                    key={group.context}
+                    className="rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm overflow-hidden"
+                  >
+                    {/* Group header */}
+                    <div className="px-4 py-2.5 border-b border-border/40 bg-muted/30">
+                      <h3 className="text-[11px] font-bold uppercase tracking-[0.15em] text-primary font-mono flex items-center gap-2">
+                        <span className="w-1.5 h-1.5 rounded-full bg-gradient-primary shadow-sm" />
+                        {group.label}
+                      </h3>
+                    </div>
+
+                    {/* Shortcut rows */}
+                    <div className="px-3 py-2 space-y-0.5">
+                      {group.shortcuts.map((shortcut, idx) => (
+                        <div
+                          key={`${shortcut.combo}-${idx}`}
+                          className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-muted/40 transition-colors group"
+                        >
+                          <span className="text-xs text-foreground/70 group-hover:text-foreground/90 transition-colors truncate mr-3">
+                            {shortcut.description}
+                          </span>
+                          <div className="flex items-center gap-1 shrink-0">
+                            {shortcut.combo.split(' / ').map((combo, i) => (
+                              <span key={combo} className="inline-flex items-center gap-0.5">
+                                {i > 0 && (
+                                  <span className="text-muted-foreground/30 mx-0.5 text-[10px]">
+                                    /
+                                  </span>
+                                )}
+                                {combo.split(' ').map((part, j) => (
+                                  <kbd
+                                    key={`${combo}-${j}`}
+                                    className={cn(
+                                      'inline-flex items-center justify-center rounded-md border font-mono select-none',
+                                      'bg-background/80 border-border/80 text-foreground/80',
+                                      'shadow-[0_1px_0_1px_rgba(0,0,0,0.15),inset_0_0.5px_0_rgba(255,255,255,0.05)]',
+                                      'min-w-[1.4rem] h-[1.4rem] px-1.5 text-[10px] leading-none',
+                                    )}
+                                  >
+                                    {part.length <= 3 ? part : formatCombo(part)}
+                                  </kbd>
+                                ))}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="guide" className="m-0 min-h-0 flex-1 data-[state=inactive]:hidden">
+            <ScrollArea className="h-full">
+              <MarkdownRenderer compact className="px-6 py-5 prose-headings:font-mono prose-h1:mt-0 prose-h2:border-t prose-h2:border-border/60 prose-h2:pt-5">
+                {helpGuide}
+              </MarkdownRenderer>
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
 
         {/* ── Footer ────────────────────────────────────────────── */}
         <div className="shrink-0 px-6 py-4 border-t border-border/60 bg-muted/20">
@@ -175,17 +213,17 @@ export function KeyboardHelpOverlay() {
 
 /**
  * Small trigger button for the header area.
- * Opens the keyboard shortcuts overlay on click.
+ * Opens the help center on click.
  */
 export function KeyboardShortcutsButton({ className }: { className?: string }) {
-  const { setHelpOverlayOpen } = useKeyboardContext();
+  const { openHelpOverlay } = useKeyboardContext();
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={() => setHelpOverlayOpen(true)}
-      title="Keyboard shortcuts (?)"
+      onClick={() => openHelpOverlay('keyboard')}
+      title="Help center (?)"
       className={cn('h-9 w-9 text-muted-foreground hover:text-primary relative group', className)}
     >
       <Keyboard className="w-4 h-4" />

--- a/src/components/ui/OnboardingSpotlight.tsx
+++ b/src/components/ui/OnboardingSpotlight.tsx
@@ -171,7 +171,7 @@ export function OnboardingSpotlight({
       <div
         className={cn(
           "fixed rounded-2xl border-2 border-primary bg-primary/5",
-          "shadow-[0_0_0_9999px_rgba(0,0,0,0.38),0_0_28px_hsl(var(--primary)/0.45)]",
+          "shadow-[0_0_0_9999px_rgba(0,0,0,0.28),0_0_28px_hsl(var(--primary)/0.45)]",
           "transition-all duration-200 ease-out",
         )}
         style={{

--- a/src/components/ui/OnboardingSpotlight.tsx
+++ b/src/components/ui/OnboardingSpotlight.tsx
@@ -12,6 +12,7 @@ interface SpotlightRect {
 interface OnboardingSpotlightProps {
   selectors: readonly string[];
   label: string;
+  heading?: string;
   enabled: boolean;
 }
 
@@ -21,14 +22,19 @@ const MIN_DESKTOP_WIDTH = 768;
 function getTarget(selectors: readonly string[]): HTMLElement | null {
   if (typeof document === "undefined") return null;
 
+  let fallback: HTMLElement | null = null;
+
   for (const selector of selectors) {
     const element = document.querySelector(selector);
     if (element instanceof HTMLElement) {
-      return element;
+      fallback ??= element;
+      if (isElementVisible(element)) {
+        return element;
+      }
     }
   }
 
-  return null;
+  return fallback;
 }
 
 function isElementVisible(element: HTMLElement): boolean {
@@ -80,6 +86,7 @@ function getTooltipStyle(rect: SpotlightRect): React.CSSProperties {
 export function OnboardingSpotlight({
   selectors,
   label,
+  heading = '// highlighted_area',
   enabled,
 }: OnboardingSpotlightProps) {
   const [rect, setRect] = useState<SpotlightRect | null>(null);
@@ -178,7 +185,7 @@ export function OnboardingSpotlight({
         className="fixed rounded-xl border border-primary/40 bg-card/95 px-3 py-2 font-mono text-[11px] text-foreground shadow-2xl shadow-primary/20 backdrop-blur-xl"
         style={tooltipStyle}
       >
-        <div className="mb-1 text-primary">// current_step_target</div>
+        <div className="mb-1 text-primary">{heading}</div>
         <div>{label}</div>
       </div>
     </div>,

--- a/src/components/ui/OnboardingSpotlight.tsx
+++ b/src/components/ui/OnboardingSpotlight.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+interface SpotlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface OnboardingSpotlightProps {
+  selectors: readonly string[];
+  label: string;
+  enabled: boolean;
+}
+
+const SPOTLIGHT_PADDING = 8;
+const MIN_DESKTOP_WIDTH = 768;
+
+function getTarget(selectors: readonly string[]): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+
+  for (const selector of selectors) {
+    const element = document.querySelector(selector);
+    if (element instanceof HTMLElement) {
+      return element;
+    }
+  }
+
+  return null;
+}
+
+function isElementVisible(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect();
+  const style = window.getComputedStyle(element);
+
+  return (
+    rect.width > 0 &&
+    rect.height > 0 &&
+    style.visibility !== "hidden" &&
+    style.display !== "none"
+  );
+}
+
+function getSpotlightRect(element: HTMLElement): SpotlightRect {
+  const rect = element.getBoundingClientRect();
+
+  return {
+    top: Math.max(8, rect.top - SPOTLIGHT_PADDING),
+    left: Math.max(8, rect.left - SPOTLIGHT_PADDING),
+    width: rect.width + SPOTLIGHT_PADDING * 2,
+    height: rect.height + SPOTLIGHT_PADDING * 2,
+  };
+}
+
+function getTooltipStyle(rect: SpotlightRect): React.CSSProperties {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const tooltipWidth = 220;
+  const gap = 14;
+
+  const preferRight =
+    rect.left + rect.width + tooltipWidth + gap < viewportWidth;
+  const preferLeft = rect.left - tooltipWidth - gap > 0;
+  const left = preferRight
+    ? rect.left + rect.width + gap
+    : preferLeft
+      ? rect.left - tooltipWidth - gap
+      : Math.min(Math.max(12, rect.left), viewportWidth - tooltipWidth - 12);
+
+  const top = Math.min(
+    Math.max(12, rect.top + rect.height / 2 - 34),
+    viewportHeight - 80,
+  );
+
+  return { left, top, width: tooltipWidth };
+}
+
+export function OnboardingSpotlight({
+  selectors,
+  label,
+  enabled,
+}: OnboardingSpotlightProps) {
+  const [rect, setRect] = useState<SpotlightRect | null>(null);
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth >= MIN_DESKTOP_WIDTH;
+  });
+  const selectorKey = useMemo(() => selectors.join(","), [selectors]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const handleResize = () =>
+      setIsDesktop(window.innerWidth >= MIN_DESKTOP_WIDTH);
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !isDesktop) {
+      setRect(null);
+      return undefined;
+    }
+
+    let animationFrame = 0;
+    const target = getTarget(selectors);
+
+    if (!target || !isElementVisible(target)) {
+      setRect(null);
+      return undefined;
+    }
+
+    target.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+      behavior: "smooth",
+    });
+
+    const updateRect = () => {
+      const nextTarget = getTarget(selectors);
+      if (!nextTarget || !isElementVisible(nextTarget)) {
+        setRect(null);
+        return;
+      }
+
+      setRect(getSpotlightRect(nextTarget));
+    };
+
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(updateRect);
+    };
+
+    const observer = new ResizeObserver(scheduleUpdate);
+    observer.observe(target);
+    updateRect();
+
+    window.addEventListener("resize", scheduleUpdate);
+    window.addEventListener("scroll", scheduleUpdate, true);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      observer.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+      window.removeEventListener("scroll", scheduleUpdate, true);
+    };
+  }, [enabled, isDesktop, selectorKey, selectors]);
+
+  if (!enabled || !isDesktop || !rect || typeof document === "undefined") {
+    return null;
+  }
+
+  const tooltipStyle = getTooltipStyle(rect);
+
+  return createPortal(
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-[60] hidden md:block"
+    >
+      <div
+        className={cn(
+          "fixed rounded-2xl border-2 border-primary bg-primary/5",
+          "shadow-[0_0_0_9999px_rgba(0,0,0,0.38),0_0_28px_hsl(var(--primary)/0.45)]",
+          "transition-all duration-200 ease-out",
+        )}
+        style={{
+          top: rect.top,
+          left: rect.left,
+          width: rect.width,
+          height: rect.height,
+        }}
+      />
+      <div
+        className="fixed rounded-xl border border-primary/40 bg-card/95 px-3 py-2 font-mono text-[11px] text-foreground shadow-2xl shadow-primary/20 backdrop-blur-xl"
+        style={tooltipStyle}
+      >
+        <div className="mb-1 text-primary">// current_step_target</div>
+        <div>{label}</div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { OnboardingSpotlight } from '@/components/ui/OnboardingSpotlight';
 import { cn } from '@/lib/utils';
 
 interface OnboardingWelcomeDialogProps {
@@ -22,20 +23,26 @@ const ONBOARDING_STEPS = [
     eyebrow: 'step_01',
     title: 'create vaults',
     description: 'group papers by project, survey, topic, lab, or reading list. vaults keep curation separate from paper metadata.',
+    targetLabel: 'vaults live in the sidebar. start with new_vault.',
+    targetSelectors: ['[data-onboarding-target="new-vault"]', '[data-onboarding-target="vault-list"]'],
   },
   {
     icon: Search,
     eyebrow: 'step_02',
     title: 'import and discover',
     description: 'add papers by doi, bibtex, url, existing library item, pdf, or semantic scholar discovery.',
+    targetLabel: 'add papers from the main toolbar or empty state.',
+    targetSelectors: ['[data-onboarding-target="add-paper"]', '[data-onboarding-target="publication-content"]'],
   },
   {
     icon: Share2,
     eyebrow: 'step_03',
     title: 'share when ready',
     description: 'keep vaults private, invite collaborators, or publish curated collections to the codex.',
+    targetLabel: 'use help, profile, vault settings, or the codex when ready.',
+    targetSelectors: ['[data-onboarding-target="help-center"]', '[data-onboarding-target="codex-link"]', '[data-onboarding-target="vault-settings"]'],
   },
-];
+] as const;
 
 export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: OnboardingWelcomeDialogProps) {
   const [stepIndex, setStepIndex] = useState(0);
@@ -60,9 +67,15 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
   const Icon = activeStep.icon;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[95vw] max-w-lg overflow-hidden border-primary/20 bg-card/95 p-0 shadow-2xl shadow-primary/10 backdrop-blur-xl sm:rounded-2xl">
-        <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/60">
+    <>
+      <OnboardingSpotlight
+        enabled={open}
+        selectors={activeStep.targetSelectors}
+        label={activeStep.targetLabel}
+      />
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="w-[95vw] max-w-lg overflow-hidden border-primary/20 bg-card/95 p-0 shadow-2xl shadow-primary/10 backdrop-blur-xl sm:rounded-2xl md:left-auto md:right-6 md:top-1/2 md:translate-x-0">
+          <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/60">
           <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
             <Sparkles className="h-5 w-5" />
           </div>
@@ -72,9 +85,9 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
           <DialogDescription className="text-sm leading-relaxed">
             refhub helps collect papers, organize vaults, and share curated research context.
           </DialogDescription>
-        </DialogHeader>
+          </DialogHeader>
 
-        <div className="px-6 py-5">
+          <div className="px-6 py-5">
           <div className="mb-4 flex items-center justify-between font-mono text-[10px] text-muted-foreground">
             <span>// onboarding</span>
             <span>{progressLabel}</span>
@@ -117,7 +130,7 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
           </div>
         </div>
 
-        <div className="flex flex-col-reverse gap-2 border-t border-border/60 bg-muted/20 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col-reverse gap-2 border-t border-border/60 bg-muted/20 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <Button variant="ghost" className="font-mono" onClick={() => onOpenChange(false)}>
             skip
           </Button>
@@ -145,8 +158,9 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
               )}
             </Button>
           </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -146,12 +146,12 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
             {isLastStep && (
               <Button variant="outline" className="font-mono" onClick={handleOpenGuide}>
                 <BookOpen className="mr-2 h-4 w-4" />
-                open_guide
+                open guide
               </Button>
             )}
             <Button variant="glow" className="font-mono" onClick={isLastStep ? handleOpenApp : handleNext}>
               {isLastStep ? (
-                'open_app'
+                'open app'
               ) : (
                 <>
                   next

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, CheckCircle2, ChevronLeft, ChevronRight, FolderOpen, Search, Share2, Sparkles } from 'lucide-react';
+import { BookOpen, CheckCircle2, ChevronLeft, ChevronRight, FolderOpen, Search, Share2, Sparkles, Scroll, Users } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -23,24 +23,45 @@ const ONBOARDING_STEPS = [
     eyebrow: 'step_01',
     title: 'create vaults',
     description: 'group papers by project, survey, topic, lab, or reading list. vaults keep curation separate from paper metadata.',
-    targetLabel: 'vaults live in the sidebar. start with new_vault.',
-    targetSelectors: ['[data-onboarding-target="new-vault"]', '[data-onboarding-target="vault-list"]'],
+    targetHeading: '// new_vault',
+    targetLabel: 'start here to create a focused research space.',
+    targetSelectors: ['[data-onboarding-target="new-vault"]', '[data-onboarding-target="vaults-section"]', '[data-onboarding-target="vault-list"]'],
   },
   {
     icon: Search,
     eyebrow: 'step_02',
     title: 'import and discover',
     description: 'add papers by doi, bibtex, url, existing library item, pdf, or semantic scholar discovery.',
+    targetHeading: '// add_paper',
     targetLabel: 'add papers from the main toolbar or empty state.',
     targetSelectors: ['[data-onboarding-target="add-paper"]', '[data-onboarding-target="publication-content"]'],
   },
   {
-    icon: Share2,
+    icon: Users,
     eyebrow: 'step_03',
+    title: 'researchers overview',
+    description: 'browse public profiles, find people by topic, and see what vaults researchers choose to share.',
+    targetHeading: '// researchers',
+    targetLabel: 'open the researchers directory from the sidebar.',
+    targetSelectors: ['[data-onboarding-target="researchers-link"]'],
+  },
+  {
+    icon: Scroll,
+    eyebrow: 'step_04',
+    title: 'the codex',
+    description: 'discover public vaults, inspect curated reading lists, and reuse context from the wider refhub network.',
+    targetHeading: '// the_codex',
+    targetLabel: 'the codex collects public vaults for discovery.',
+    targetSelectors: ['[data-onboarding-target="codex-link"]'],
+  },
+  {
+    icon: Share2,
+    eyebrow: 'step_05',
     title: 'share when ready',
-    description: 'keep vaults private, invite collaborators, or publish curated collections to the codex.',
-    targetLabel: 'use help, profile, vault settings, or the codex when ready.',
-    targetSelectors: ['[data-onboarding-target="help-center"]', '[data-onboarding-target="codex-link"]', '[data-onboarding-target="vault-settings"]'],
+    description: 'keep vaults private, invite collaborators, or publish curated collections when the context is ready.',
+    targetHeading: '// share_controls',
+    targetLabel: 'use vault settings when you are ready to invite or publish.',
+    targetSelectors: ['[data-onboarding-target="vault-settings"]', '[data-onboarding-target="help-center"]'],
   },
 ] as const;
 
@@ -71,9 +92,10 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
         enabled={open}
         selectors={activeStep.targetSelectors}
         label={activeStep.targetLabel}
+        heading={activeStep.targetHeading}
       />
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-[95vw] max-w-lg overflow-hidden border-primary/20 bg-card/95 p-0 shadow-2xl shadow-primary/10 backdrop-blur-xl sm:rounded-2xl md:left-auto md:right-6 md:top-1/2 md:translate-x-0">
+        <DialogContent className="w-[95vw] max-w-lg overflow-hidden border-primary/20 bg-card/95 p-0 shadow-2xl shadow-primary/10 backdrop-blur-xl sm:rounded-2xl">
           <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/60">
           <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
             <Sparkles className="h-5 w-5" />

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -55,12 +55,11 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
     onOpenGuide();
   };
 
-  const handleNext = () => {
-    if (isLastStep) {
-      handleOpenGuide();
-      return;
-    }
+  const handleOpenApp = () => {
+    onOpenChange(false);
+  };
 
+  const handleNext = () => {
     setStepIndex((current) => Math.min(current + 1, ONBOARDING_STEPS.length - 1));
   };
 
@@ -144,12 +143,15 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
               <ChevronLeft className="mr-1 h-4 w-4" />
               back
             </Button>
-            <Button variant="glow" className="font-mono" onClick={handleNext}>
+            {isLastStep && (
+              <Button variant="outline" className="font-mono" onClick={handleOpenGuide}>
+                <BookOpen className="mr-2 h-4 w-4" />
+                open_guide
+              </Button>
+            )}
+            <Button variant="glow" className="font-mono" onClick={isLastStep ? handleOpenApp : handleNext}>
               {isLastStep ? (
-                <>
-                  <BookOpen className="mr-2 h-4 w-4" />
-                  open_guide
-                </>
+                'open_app'
               ) : (
                 <>
                   next

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -95,7 +95,10 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
         heading={activeStep.targetHeading}
       />
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-[95vw] max-w-lg overflow-hidden border-primary/20 bg-card/95 p-0 shadow-2xl shadow-primary/10 backdrop-blur-xl sm:rounded-2xl">
+        <DialogContent
+          overlayClassName="bg-transparent"
+          className="z-[70] w-[95vw] max-w-lg overflow-hidden border-primary/20 bg-card/95 p-0 shadow-2xl shadow-primary/10 backdrop-blur-xl sm:rounded-2xl"
+        >
           <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/60">
           <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
             <Sparkles className="h-5 w-5" />

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -1,0 +1,88 @@
+import { BookOpen, CheckCircle2, FolderOpen, Search, Share2, Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface OnboardingWelcomeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenGuide: () => void;
+}
+
+const ORIENTATION_ITEMS = [
+  {
+    icon: FolderOpen,
+    title: 'Create vaults',
+    description: 'Group papers by project, survey, topic, lab, or reading list.',
+  },
+  {
+    icon: Search,
+    title: 'Import and discover',
+    description: 'Add papers by DOI, BibTeX, URL, existing papers, PDFs, or Semantic Scholar discovery.',
+  },
+  {
+    icon: Share2,
+    title: 'Share when ready',
+    description: 'Keep vaults private, invite collaborators, or publish them to the Codex.',
+  },
+];
+
+export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: OnboardingWelcomeDialogProps) {
+  const handleOpenGuide = () => {
+    onOpenGuide();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[95vw] max-w-lg overflow-hidden border-primary/20 bg-card/95 p-0 shadow-2xl shadow-primary/10 backdrop-blur-xl sm:rounded-2xl">
+        <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/60">
+          <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <Sparkles className="h-5 w-5" />
+          </div>
+          <DialogTitle className="font-mono text-2xl font-bold">
+            welcome_to_<span className="text-gradient">refhub</span>()
+          </DialogTitle>
+          <DialogDescription className="text-sm leading-relaxed">
+            RefHub helps you collect papers, organize them into vaults, and share curated research context.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 px-6 py-5">
+          {ORIENTATION_ITEMS.map(({ icon: Icon, title, description }) => (
+            <div key={title} className="flex gap-3 rounded-xl border border-border/60 bg-muted/20 p-3">
+              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-background/70 text-primary">
+                <Icon className="h-4 w-4" />
+              </div>
+              <div className="min-w-0">
+                <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+                <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+              </div>
+            </div>
+          ))}
+
+          <div className="flex items-start gap-2 rounded-xl bg-primary/10 p-3 text-xs text-primary">
+            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>
+              This welcome can be dismissed. You can always reopen the full guide from the <span className="font-mono">?</span> help button.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col-reverse gap-2 border-t border-border/60 bg-muted/20 px-6 py-4 sm:flex-row sm:justify-end">
+          <Button variant="ghost" className="font-mono" onClick={() => onOpenChange(false)}>
+            skip
+          </Button>
+          <Button variant="glow" className="font-mono" onClick={handleOpenGuide}>
+            <BookOpen className="mr-2 h-4 w-4" />
+            open_guide
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -61,7 +61,7 @@ const ONBOARDING_STEPS = [
     description: 'keep vaults private, invite collaborators, or publish curated collections when the context is ready.',
     targetHeading: '// share_controls',
     targetLabel: 'use vault settings when you are ready to invite or publish.',
-    targetSelectors: ['[data-onboarding-target="vault-settings"]', '[data-onboarding-target="help-center"]'],
+    targetSelectors: ['[data-onboarding-target="vault-settings"]', '[data-onboarding-target="vault-list"]', '[data-onboarding-target="vaults-section"]'],
   },
 ] as const;
 

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -57,11 +57,11 @@ const ONBOARDING_STEPS = [
   {
     icon: Share2,
     eyebrow: 'step_05',
-    title: 'share when ready',
-    description: 'keep vaults private, invite collaborators, or publish curated collections when the context is ready.',
-    targetHeading: '// share_controls',
-    targetLabel: 'use vault settings when you are ready to invite or publish.',
-    targetSelectors: ['[data-onboarding-target="vault-settings"]', '[data-onboarding-target="vault-list"]', '[data-onboarding-target="vaults-section"]'],
+    title: 'manage and share vaults',
+    description: 'create vaults, keep them private, invite collaborators, or publish curated collections when the context is ready.',
+    targetHeading: '// vault_controls',
+    targetLabel: 'create, manage, and share vaults from this area.',
+    targetSelectors: ['[data-onboarding-target="new-vault"]', '[data-onboarding-target="vault-settings"]', '[data-onboarding-target="vault-list"]', '[data-onboarding-target="vaults-section"]'],
   },
 ] as const;
 

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -1,4 +1,5 @@
-import { BookOpen, CheckCircle2, FolderOpen, Search, Share2, Sparkles } from 'lucide-react';
+import { BookOpen, CheckCircle2, ChevronLeft, ChevronRight, FolderOpen, Search, Share2, Sparkles } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -7,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
 
 interface OnboardingWelcomeDialogProps {
   open: boolean;
@@ -14,28 +16,48 @@ interface OnboardingWelcomeDialogProps {
   onOpenGuide: () => void;
 }
 
-const ORIENTATION_ITEMS = [
+const ONBOARDING_STEPS = [
   {
     icon: FolderOpen,
-    title: 'Create vaults',
-    description: 'Group papers by project, survey, topic, lab, or reading list.',
+    eyebrow: 'step_01',
+    title: 'create vaults',
+    description: 'group papers by project, survey, topic, lab, or reading list. vaults keep curation separate from paper metadata.',
   },
   {
     icon: Search,
-    title: 'Import and discover',
-    description: 'Add papers by DOI, BibTeX, URL, existing papers, PDFs, or Semantic Scholar discovery.',
+    eyebrow: 'step_02',
+    title: 'import and discover',
+    description: 'add papers by doi, bibtex, url, existing library item, pdf, or semantic scholar discovery.',
   },
   {
     icon: Share2,
-    title: 'Share when ready',
-    description: 'Keep vaults private, invite collaborators, or publish them to the Codex.',
+    eyebrow: 'step_03',
+    title: 'share when ready',
+    description: 'keep vaults private, invite collaborators, or publish curated collections to the codex.',
   },
 ];
 
 export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: OnboardingWelcomeDialogProps) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const activeStep = ONBOARDING_STEPS[stepIndex];
+  const isFirstStep = stepIndex === 0;
+  const isLastStep = stepIndex === ONBOARDING_STEPS.length - 1;
+  const progressLabel = useMemo(() => `${stepIndex + 1}/${ONBOARDING_STEPS.length}`, [stepIndex]);
+
   const handleOpenGuide = () => {
     onOpenGuide();
   };
+
+  const handleNext = () => {
+    if (isLastStep) {
+      handleOpenGuide();
+      return;
+    }
+
+    setStepIndex((current) => Math.min(current + 1, ONBOARDING_STEPS.length - 1));
+  };
+
+  const Icon = activeStep.icon;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -48,39 +70,81 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
             welcome_to_<span className="text-gradient">refhub</span>()
           </DialogTitle>
           <DialogDescription className="text-sm leading-relaxed">
-            RefHub helps you collect papers, organize them into vaults, and share curated research context.
+            refhub helps collect papers, organize vaults, and share curated research context.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-3 px-6 py-5">
-          {ORIENTATION_ITEMS.map(({ icon: Icon, title, description }) => (
-            <div key={title} className="flex gap-3 rounded-xl border border-border/60 bg-muted/20 p-3">
-              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-background/70 text-primary">
-                <Icon className="h-4 w-4" />
+        <div className="px-6 py-5">
+          <div className="mb-4 flex items-center justify-between font-mono text-[10px] text-muted-foreground">
+            <span>// onboarding</span>
+            <span>{progressLabel}</span>
+          </div>
+
+          <div className="rounded-2xl border border-border/60 bg-muted/20 p-5">
+            <div className="mb-4 flex items-center gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-background/70 text-primary">
+                <Icon className="h-5 w-5" />
               </div>
               <div className="min-w-0">
-                <h3 className="text-sm font-semibold text-foreground">{title}</h3>
-                <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+                <p className="font-mono text-[10px] text-primary">{activeStep.eyebrow}</p>
+                <h3 className="text-base font-semibold text-foreground">{activeStep.title}</h3>
               </div>
             </div>
-          ))}
+            <p className="text-sm leading-relaxed text-muted-foreground">{activeStep.description}</p>
+          </div>
 
-          <div className="flex items-start gap-2 rounded-xl bg-primary/10 p-3 text-xs text-primary">
+          <div className="mt-4 flex items-center justify-center gap-2" aria-label="onboarding progress">
+            {ONBOARDING_STEPS.map((step, index) => (
+              <button
+                key={step.eyebrow}
+                type="button"
+                aria-label={`go to ${step.eyebrow}`}
+                aria-current={index === stepIndex ? 'step' : undefined}
+                onClick={() => setStepIndex(index)}
+                className={cn(
+                  'h-1.5 rounded-full transition-all',
+                  index === stepIndex ? 'w-7 bg-primary' : 'w-1.5 bg-muted-foreground/30 hover:bg-muted-foreground/50',
+                )}
+              />
+            ))}
+          </div>
+
+          <div className="mt-5 flex items-start gap-2 rounded-xl bg-primary/10 p-3 text-xs text-primary">
             <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
             <p>
-              This welcome can be dismissed. You can always reopen the full guide from the <span className="font-mono">?</span> help button.
+              dismiss this anytime. reopen the full guide from the <span className="font-mono">?</span> help button.
             </p>
           </div>
         </div>
 
-        <div className="flex flex-col-reverse gap-2 border-t border-border/60 bg-muted/20 px-6 py-4 sm:flex-row sm:justify-end">
+        <div className="flex flex-col-reverse gap-2 border-t border-border/60 bg-muted/20 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <Button variant="ghost" className="font-mono" onClick={() => onOpenChange(false)}>
             skip
           </Button>
-          <Button variant="glow" className="font-mono" onClick={handleOpenGuide}>
-            <BookOpen className="mr-2 h-4 w-4" />
-            open_guide
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              className="font-mono"
+              onClick={() => setStepIndex((current) => Math.max(current - 1, 0))}
+              disabled={isFirstStep}
+            >
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              back
+            </Button>
+            <Button variant="glow" className="font-mono" onClick={handleNext}>
+              {isLastStep ? (
+                <>
+                  <BookOpen className="mr-2 h-4 w-4" />
+                  open_guide
+                </>
+              ) : (
+                <>
+                  next
+                  <ChevronRight className="ml-1 h-4 w-4" />
+                </>
+              )}
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, CheckCircle2, ChevronLeft, ChevronRight, FolderOpen, Search, Share2, Sparkles, Scroll, Users } from 'lucide-react';
+import { BookOpen, CheckCircle2, ChevronLeft, ChevronRight, FolderOpen, Search, Settings, Sparkles, Scroll, Users } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -22,7 +22,7 @@ const ONBOARDING_STEPS = [
     icon: FolderOpen,
     eyebrow: 'step_01',
     title: 'create vaults',
-    description: 'group papers by project, survey, topic, lab, or reading list. vaults keep curation separate from paper metadata.',
+    description: 'a vault is a focused research collection for a project, survey, topic, lab, or reading list. create, manage, and share vaults from here.',
     targetHeading: '// new_vault',
     targetLabel: 'start here to create a focused research space.',
     targetSelectors: ['[data-onboarding-target="new-vault"]', '[data-onboarding-target="vaults-section"]', '[data-onboarding-target="vault-list"]'],
@@ -55,13 +55,13 @@ const ONBOARDING_STEPS = [
     targetSelectors: ['[data-onboarding-target="codex-link"]'],
   },
   {
-    icon: Share2,
+    icon: Settings,
     eyebrow: 'step_05',
-    title: 'manage and share vaults',
-    description: 'create vaults, keep them private, invite collaborators, or publish curated collections when the context is ready.',
-    targetHeading: '// vault_controls',
-    targetLabel: 'create, manage, and share vaults from this area.',
-    targetSelectors: ['[data-onboarding-target="new-vault"]', '[data-onboarding-target="vault-settings"]', '[data-onboarding-target="vault-list"]', '[data-onboarding-target="vaults-section"]'],
+    title: 'account and settings',
+    description: 'use the sidebar controls for profile settings, theme, keyboard help, what’s new, and sign out.',
+    targetHeading: '// user_controls',
+    targetLabel: 'manage profile, settings, help, and account controls here.',
+    targetSelectors: ['[data-onboarding-target="user-controls"]'],
   },
 ] as const;
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -29,10 +29,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { overlayClassName?: string }
+>(({ className, overlayClassName, children, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -21,6 +21,37 @@ export interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
+    id: 11,
+    date: '2026-06-19',
+    title: 'semantic scholar queues and onboarding',
+    features: [
+      {
+        tag: 'feature',
+        title: 'guided onboarding',
+        description:
+          'new users now get a skippable onboarding stepper with highlighted app areas for vaults, papers, researchers, the codex, and sharing.',
+      },
+      {
+        tag: 'feature',
+        title: 'help center guide',
+        description:
+          'the ? menu now includes a scrollable guide tab alongside keyboard shortcuts, with concise explanations of core refhub workflows.',
+      },
+      {
+        tag: 'improvement',
+        title: 'semantic scholar queue polish',
+        description:
+          'semantic scholar augmentation now handles queued requests, rate limits, retry states, and completion feedback more clearly.',
+      },
+      {
+        tag: 'fix',
+        title: 'minor workflow fixes',
+        description:
+          'recent fixes improved collaborator lookup, new-vault redirects, edit-paper links, profile back navigation, and small onboarding details.',
+      },
+    ],
+  },
+  {
     id: 10,
     date: '2026-05-22',
     title: 'better vault sharing',

--- a/src/content/help-guide.md
+++ b/src/content/help-guide.md
@@ -1,78 +1,78 @@
-# RefHub guide
+# refhub guide
 
-RefHub is a vault-based workspace for collecting papers, curating context, and sharing research collections.
+refhub is a vault-based workspace for collecting papers, curating context, and sharing research collections.
 
-## Vaults
+## vaults
 
-A **vault** is a research collection. Use vaults for a project, reading list, class, survey, lab theme, or public bibliography. A paper can appear in multiple vaults without losing the vault-specific notes, tags, and sharing context around it.
+A **vault** is a research collection. use vaults for a project, reading list, class, survey, lab theme, or public bibliography. a paper can appear in multiple vaults without losing the vault-specific notes, tags, and sharing context around it.
 
-## Adding and importing papers
+## adding and importing papers
 
-Use `add_paper` from all_papers or a vault to bring papers into RefHub.
+use `add_paper` from `all_papers` or a vault to bring papers into refhub.
 
-- **DOI lookup** fetches publication details when a DOI is available.
-- **BibTeX import** accepts pasted `.bib` text or uploaded BibTeX files for bulk import.
-- **URL / manual entry** lets you add papers when structured metadata is incomplete.
-- **Existing papers** can be added into another vault without creating a duplicate library item.
-- **PDFs** can be attached to papers. When Google Drive is connected, RefHub can store saved PDFs in your managed Drive folder.
+- **doi lookup** fetches publication details when a doi is available.
+- **bibtex import** accepts pasted `.bib` text or uploaded bibtex files for bulk import.
+- **url / manual entry** lets you add papers when structured metadata is incomplete.
+- **existing papers** can be added into another vault without creating a duplicate library item.
+- **pdfs** can be attached to papers. when google drive is connected, refhub can store saved pdfs in your managed drive folder.
 
-## Organizing papers
+## organizing papers
 
-Each paper has bibliographic metadata such as title, authors, year, venue, DOI, URL, abstract, and publication type. Vaults add curation on top:
+each paper has bibliographic metadata such as title, authors, year, venue, doi, url, abstract, and publication type. vaults add curation on top:
 
-- **Tags** organize papers inside a vault and can be hierarchical.
-- **Notes / comments** capture why a paper matters in this collection.
-- **Relationships** connect papers as references, citations, or related work.
+- **tags** organize papers inside a vault and can be hierarchical.
+- **notes / comments** capture why a paper matters in this collection.
+- **relationships** connect papers as references, citations, or related work.
 
-Paper-level metadata should describe the publication itself. Vault-specific metadata should describe how that paper is used in the current vault.
+paper-level metadata should describe the publication itself. vault-specific metadata should describe how that paper is used in the current vault.
 
-## Semantic Scholar tools
+## semantic scholar tools
 
-RefHub uses Semantic Scholar where available to reduce manual metadata work and support discovery.
+refhub uses semantic scholar where available to reduce manual metadata work and support discovery.
 
-- **Enrich / sync** checks a paper by DOI and lets you review incoming metadata before applying it.
-- **Related papers, references, and citations** help expand a vault from a selected paper.
-- **Topic or empty-vault discovery** can seed a collection when you do not yet have papers.
-- **Queue and rate limits** are normal: discovery requests may be queued or slowed so RefHub stays within upstream API limits.
+- **enrich / sync** checks a paper by doi and lets you review incoming metadata before applying it.
+- **related papers, references, and citations** help expand a vault from a selected paper.
+- **topic or empty-vault discovery** can seed a collection when you do not yet have papers.
+- **queue and rate limits** are normal: discovery requests may be queued or slowed so refhub stays within upstream api limits.
 
-## Managing a vault
+## managing a vault
 
-Open vault settings from the vault gear or the `o` shortcut when a vault is active. Settings cover:
+open vault settings from the vault gear or the `o` shortcut when a vault is active. settings cover:
 
-- Name, description, category, abstract, and color.
-- Visibility: private, protected, or public.
-- Public slug for shareable public vault URLs.
-- Access requests and collaborator management when sharing is enabled.
+- name, description, category, abstract, and color.
+- visibility: private, protected, or public.
+- public slug for shareable public vault urls.
+- access requests and collaborator management when sharing is enabled.
 
-## Sharing and access
+## sharing and access
 
-Vaults can stay private, be shared with collaborators, or become public entries in the Codex.
+vaults can stay private, be shared with collaborators, or become public entries in the codex.
 
-- **Protected vaults** require approved access.
-- **Public vaults** can be viewed through their public slug.
-- **Collaborators** can be invited or approved as viewers or editors.
-- **Viewers** can read. **Editors** can help curate where permissions allow.
-- Public viewers can request collaborator access when the vault allows it.
+- **protected vaults** require approved access.
+- **public vaults** can be viewed through their public slug.
+- **collaborators** can be invited or approved as viewers or editors.
+- **viewers** can read. **editors** can help curate where permissions allow.
+- public viewers can request collaborator access when the vault allows it.
 
-## Export
+## export
 
-Use export from a vault, public vault, or selected papers to take data out of RefHub. Export supports bibliographic workflows such as BibTeX and selected-field exports where available.
+use export from a vault, public vault, or selected papers to take data out of refhub. export supports bibliographic workflows such as bibtex and selected-field exports where available.
 
-## The Codex
+## the codex
 
-The Codex is RefHub's public discovery surface. Public vaults appear there so other researchers can browse, reuse, and request collaboration on curated collections.
+the codex is refhub's public discovery surface. public vaults appear there so other researchers can browse, reuse, and request collaboration on curated collections.
 
-## Profile and settings
+## profile and settings
 
-Open profile/settings from the sidebar user menu.
+open profile/settings from the sidebar user menu.
 
-- Profile identity controls your display name, username, avatar, bio, and links.
-- Google Drive connects storage for managed PDF assets.
-- API keys let external tools access allowed RefHub data.
-- Theme and account controls live alongside profile settings where applicable.
+- profile identity controls your display name, username, avatar, bio, and links.
+- google drive connects storage for managed pdf assets.
+- api keys let external tools access allowed refhub data.
+- theme and account controls live alongside profile settings where applicable.
 
-## API and external workflows
+## api and external workflows
 
-API keys are created from profile settings. Give each key a clear label, choose scopes such as read/write/export, and optionally restrict access to selected vaults. Copy the secret when it is created; only the prefix remains visible later.
+api keys are created from profile settings. give each key a clear label, choose scopes such as read/write/export, and optionally restrict access to selected vaults. copy the secret when it is created; only the prefix remains visible later.
 
-RefHub also supports browser-extension and integration workflows where enabled, so papers found elsewhere can be sent into your library or vaults without manual re-entry.
+refhub also supports browser-extension and integration workflows where enabled, so papers found elsewhere can be sent into your library or vaults without manual re-entry.

--- a/src/content/help-guide.md
+++ b/src/content/help-guide.md
@@ -1,0 +1,78 @@
+# RefHub guide
+
+RefHub is a vault-based workspace for collecting papers, curating context, and sharing research collections.
+
+## Vaults
+
+A **vault** is a research collection. Use vaults for a project, reading list, class, survey, lab theme, or public bibliography. A paper can appear in multiple vaults without losing the vault-specific notes, tags, and sharing context around it.
+
+## Adding and importing papers
+
+Use `add_paper` from all_papers or a vault to bring papers into RefHub.
+
+- **DOI lookup** fetches publication details when a DOI is available.
+- **BibTeX import** accepts pasted `.bib` text or uploaded BibTeX files for bulk import.
+- **URL / manual entry** lets you add papers when structured metadata is incomplete.
+- **Existing papers** can be added into another vault without creating a duplicate library item.
+- **PDFs** can be attached to papers. When Google Drive is connected, RefHub can store saved PDFs in your managed Drive folder.
+
+## Organizing papers
+
+Each paper has bibliographic metadata such as title, authors, year, venue, DOI, URL, abstract, and publication type. Vaults add curation on top:
+
+- **Tags** organize papers inside a vault and can be hierarchical.
+- **Notes / comments** capture why a paper matters in this collection.
+- **Relationships** connect papers as references, citations, or related work.
+
+Paper-level metadata should describe the publication itself. Vault-specific metadata should describe how that paper is used in the current vault.
+
+## Semantic Scholar tools
+
+RefHub uses Semantic Scholar where available to reduce manual metadata work and support discovery.
+
+- **Enrich / sync** checks a paper by DOI and lets you review incoming metadata before applying it.
+- **Related papers, references, and citations** help expand a vault from a selected paper.
+- **Topic or empty-vault discovery** can seed a collection when you do not yet have papers.
+- **Queue and rate limits** are normal: discovery requests may be queued or slowed so RefHub stays within upstream API limits.
+
+## Managing a vault
+
+Open vault settings from the vault gear or the `o` shortcut when a vault is active. Settings cover:
+
+- Name, description, category, abstract, and color.
+- Visibility: private, protected, or public.
+- Public slug for shareable public vault URLs.
+- Access requests and collaborator management when sharing is enabled.
+
+## Sharing and access
+
+Vaults can stay private, be shared with collaborators, or become public entries in the Codex.
+
+- **Protected vaults** require approved access.
+- **Public vaults** can be viewed through their public slug.
+- **Collaborators** can be invited or approved as viewers or editors.
+- **Viewers** can read. **Editors** can help curate where permissions allow.
+- Public viewers can request collaborator access when the vault allows it.
+
+## Export
+
+Use export from a vault, public vault, or selected papers to take data out of RefHub. Export supports bibliographic workflows such as BibTeX and selected-field exports where available.
+
+## The Codex
+
+The Codex is RefHub's public discovery surface. Public vaults appear there so other researchers can browse, reuse, and request collaboration on curated collections.
+
+## Profile and settings
+
+Open profile/settings from the sidebar user menu.
+
+- Profile identity controls your display name, username, avatar, bio, and links.
+- Google Drive connects storage for managed PDF assets.
+- API keys let external tools access allowed RefHub data.
+- Theme and account controls live alongside profile settings where applicable.
+
+## API and external workflows
+
+API keys are created from profile settings. Give each key a clear label, choose scopes such as read/write/export, and optionally restrict access to selected vaults. Copy the secret when it is created; only the prefix remains visible later.
+
+RefHub also supports browser-extension and integration workflows where enabled, so papers found elsewhere can be sent into your library or vaults without manual re-entry.

--- a/src/contexts/KeyboardContext.tsx
+++ b/src/contexts/KeyboardContext.tsx
@@ -73,6 +73,8 @@ interface KeyboardState {
   rangeAnchor: number | null;
   /** Whether the help overlay is visible. */
   helpOverlayOpen: boolean;
+  /** Active tab in the help center. */
+  helpOverlayTab: 'keyboard' | 'guide';
   /** Whether keyboard nav is enabled (feature flag + user pref). */
   enabled: boolean;
 }
@@ -104,6 +106,10 @@ interface KeyboardContextValue extends KeyboardState {
   toggleHelpOverlay: () => void;
   /** Set the help overlay open state directly. */
   setHelpOverlayOpen: (open: boolean) => void;
+  /** Set the active help center tab. */
+  setHelpOverlayTab: (tab: 'keyboard' | 'guide') => void;
+  /** Open the help center to a specific tab. */
+  openHelpOverlay: (tab?: 'keyboard' | 'guide') => void;
   /** Enable or disable keyboard navigation. */
   setEnabled: (enabled: boolean) => void;
   /** Register an analytics callback. */
@@ -121,6 +127,7 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [rangeAnchor, setRangeAnchor] = useState<number | null>(null);
   const [helpOverlayOpen, setHelpOverlayOpen] = useState(false);
+  const [helpOverlayTab, setHelpOverlayTab] = useState<'keyboard' | 'guide'>('keyboard');
   const lastFocusedRef = useRef<Element | null>(null);
 
   // Context stack for push/pop
@@ -216,6 +223,11 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
     setHelpOverlayOpen((prev) => !prev);
   }, []);
 
+  const openHelpOverlay = useCallback((tab: 'keyboard' | 'guide' = 'keyboard') => {
+    setHelpOverlayTab(tab);
+    setHelpOverlayOpen(true);
+  }, []);
+
   const onAnalytics = useCallback((cb: AnalyticsCallback) => {
     analyticsCallbacksRef.current.add(cb);
     return () => {
@@ -298,6 +310,7 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
     selectedIds,
     rangeAnchor,
     helpOverlayOpen,
+    helpOverlayTab,
     enabled,
     pushContext,
     popContext,
@@ -312,6 +325,8 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
     clearSelection,
     toggleHelpOverlay,
     setHelpOverlayOpen,
+    setHelpOverlayTab,
+    openHelpOverlay,
     setEnabled,
     onAnalytics,
   };

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -35,19 +35,59 @@ function emitOnboardingCompleted() {
   window.dispatchEvent(new Event(ONBOARDING_COMPLETED_EVENT));
 }
 
+function hasVisibleOnboardingTarget(): boolean {
+  if (typeof document === 'undefined') return false;
+
+  const target = document.querySelector('[data-onboarding-target="new-vault"]');
+  if (!(target instanceof HTMLElement)) return false;
+
+  const rect = target.getBoundingClientRect();
+  const style = window.getComputedStyle(target);
+
+  return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+}
+
 export function useOnboarding(user: User | null, authLoading: boolean) {
   const [open, setOpen] = useState(false);
   const storageKey = useMemo(() => (user ? getOnboardingStorageKey(user.id) : null), [user]);
 
   useEffect(() => {
-    if (authLoading) return;
+    if (authLoading) return undefined;
 
     if (!storageKey) {
       setOpen(false);
-      return;
+      return undefined;
     }
 
-    setOpen(!hasDismissedOnboarding(storageKey));
+    if (hasDismissedOnboarding(storageKey)) {
+      setOpen(false);
+      return undefined;
+    }
+
+    let timeoutId = 0;
+    let cancelled = false;
+    let attempts = 0;
+
+    const waitForAppShell = () => {
+      if (cancelled) return;
+
+      if (hasVisibleOnboardingTarget()) {
+        setOpen(true);
+        return;
+      }
+
+      attempts += 1;
+      if (attempts < 80) {
+        timeoutId = window.setTimeout(waitForAppShell, 125);
+      }
+    };
+
+    waitForAppShell();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
   }, [authLoading, storageKey]);
 
   const dismiss = useCallback(() => {

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'refhub_onboarding_welcome_dismissed_v1';
+
+function hasDismissedOnboarding(): boolean {
+  if (typeof window === 'undefined') return true;
+
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return true;
+  }
+}
+
+function persistDismissed() {
+  try {
+    localStorage.setItem(STORAGE_KEY, 'true');
+  } catch {
+    // Ignore storage failures; the dialog still closes for this session.
+  }
+}
+
+export function useOnboarding() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!hasDismissedOnboarding()) {
+      setOpen(true);
+    }
+  }, []);
+
+  const dismiss = useCallback(() => {
+    persistDismissed();
+    setOpen(false);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (value: boolean) => {
+      if (!value) {
+        dismiss();
+        return;
+      }
+      setOpen(value);
+    },
+    [dismiss],
+  );
+
+  return { open, onOpenChange: handleOpenChange, dismiss };
+}

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -1,38 +1,51 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
 
-const STORAGE_KEY = 'refhub_onboarding_welcome_dismissed_v1';
+const STORAGE_KEY_PREFIX = 'refhub_onboarding_welcome_dismissed_v1';
 
-function hasDismissedOnboarding(): boolean {
+function getStorageKey(userId: string): string {
+  return `${STORAGE_KEY_PREFIX}:${userId}`;
+}
+
+function hasDismissedOnboarding(storageKey: string): boolean {
   if (typeof window === 'undefined') return true;
 
   try {
-    return localStorage.getItem(STORAGE_KEY) === 'true';
+    return localStorage.getItem(storageKey) === 'true';
   } catch {
     return true;
   }
 }
 
-function persistDismissed() {
+function persistDismissed(storageKey: string) {
   try {
-    localStorage.setItem(STORAGE_KEY, 'true');
+    localStorage.setItem(storageKey, 'true');
   } catch {
     // Ignore storage failures; the dialog still closes for this session.
   }
 }
 
-export function useOnboarding() {
+export function useOnboarding(user: User | null, authLoading: boolean) {
   const [open, setOpen] = useState(false);
+  const storageKey = useMemo(() => (user ? getStorageKey(user.id) : null), [user]);
 
   useEffect(() => {
-    if (!hasDismissedOnboarding()) {
-      setOpen(true);
+    if (authLoading) return;
+
+    if (!storageKey) {
+      setOpen(false);
+      return;
     }
-  }, []);
+
+    setOpen(!hasDismissedOnboarding(storageKey));
+  }, [authLoading, storageKey]);
 
   const dismiss = useCallback(() => {
-    persistDismissed();
+    if (storageKey) {
+      persistDismissed(storageKey);
+    }
     setOpen(false);
-  }, []);
+  }, [storageKey]);
 
   const handleOpenChange = useCallback(
     (value: boolean) => {

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 
+export const ONBOARDING_COMPLETED_EVENT = 'refhub:onboarding-completed';
 const STORAGE_KEY_PREFIX = 'refhub_onboarding_welcome_dismissed_v1';
 
-function getStorageKey(userId: string): string {
+export function getOnboardingStorageKey(userId: string): string {
   return `${STORAGE_KEY_PREFIX}:${userId}`;
 }
 
@@ -25,9 +26,18 @@ function persistDismissed(storageKey: string) {
   }
 }
 
+export function hasUserDismissedOnboarding(userId: string): boolean {
+  return hasDismissedOnboarding(getOnboardingStorageKey(userId));
+}
+
+function emitOnboardingCompleted() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(ONBOARDING_COMPLETED_EVENT));
+}
+
 export function useOnboarding(user: User | null, authLoading: boolean) {
   const [open, setOpen] = useState(false);
-  const storageKey = useMemo(() => (user ? getStorageKey(user.id) : null), [user]);
+  const storageKey = useMemo(() => (user ? getOnboardingStorageKey(user.id) : null), [user]);
 
   useEffect(() => {
     if (authLoading) return;
@@ -45,6 +55,7 @@ export function useOnboarding(user: User | null, authLoading: boolean) {
       persistDismissed(storageKey);
     }
     setOpen(false);
+    emitOnboardingCompleted();
   }, [storageKey]);
 
   const handleOpenChange = useCallback(

--- a/src/hooks/useWhatsNew.ts
+++ b/src/hooks/useWhatsNew.ts
@@ -1,5 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import changelog from '@/config/changelog';
+import { ONBOARDING_COMPLETED_EVENT, hasUserDismissedOnboarding } from '@/hooks/useOnboarding';
+import { useAuth } from '@/hooks/useAuth';
+import { useKeyboardContext } from '@/contexts/KeyboardContext';
 
 const STORAGE_KEY = 'refhub_whats_new_seen';
 
@@ -10,16 +13,35 @@ function getSeenId(): number {
 }
 
 export function useWhatsNew() {
+  const { user, loading } = useAuth();
+  const { helpOverlayOpen } = useKeyboardContext();
   const [open, setOpen] = useState(false);
   const [hasUnseen, setHasUnseen] = useState(false);
 
-  useEffect(() => {
+  const maybeOpenLatest = useCallback(() => {
+    if (loading || !user || helpOverlayOpen) return;
+
     const seen = getSeenId();
-    if (latest.id > seen) {
-      setHasUnseen(true);
-      setOpen(true);
-    }
-  }, []);
+    const unseen = latest.id > seen;
+    setHasUnseen(unseen);
+
+    if (!unseen) return;
+
+    // New users should see onboarding first, then whats_new after onboarding is dismissed.
+    if (!hasUserDismissedOnboarding(user.id)) return;
+
+    setOpen(true);
+  }, [helpOverlayOpen, loading, user]);
+
+  useEffect(() => {
+    maybeOpenLatest();
+  }, [maybeOpenLatest]);
+
+  useEffect(() => {
+    const handleOnboardingCompleted = () => maybeOpenLatest();
+    window.addEventListener(ONBOARDING_COMPLETED_EVENT, handleOnboardingCompleted);
+    return () => window.removeEventListener(ONBOARDING_COMPLETED_EVENT, handleOnboardingCompleted);
+  }, [maybeOpenLatest]);
 
   const handleOpenChange = (value: boolean) => {
     if (!value) {


### PR DESCRIPTION
## Summary
- expands the existing `?` keyboard overlay into a Help Center with Keyboard and Guide tabs
- adds a maintainable Markdown guide covering vaults, import, organization, Semantic Scholar, sharing, export, Codex, profile/settings, and API/external workflows
- adds a lightweight first-run welcome with Skip and Open Guide actions; dismissal persists in localStorage

## Validation
- `npm run lint` (passes with existing warnings in `Dashboard.tsx` and `VaultDetail.tsx` about unnecessary `syncDiffsByPublication` dependencies)
- `npm test -- --run`
- `npm run build` (passes; existing Browserslist staleness and large chunk warnings)

Closes #129
