### PR TITLE
Use resumable Drive upload for large vault PDFs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/contexts/VaultContentContext.tsx
+++ b/src/contexts/VaultContentContext.tsx
@@ -6,6 +6,7 @@ import { useVaultAccess } from '@/hooks/useVaultAccess';
 import { handleError } from '@/lib/toast';
 import { debug, warn, error as logError } from '@/lib/logger';
 import { getPageCache, setPageCache } from '@/lib/pageCache';
+import { replacePublicationPdfAsset } from '@/lib/pdfAssets';
 
 // Info about the last activity in the vault
 export type ActivityType = 'publication_added' | 'publication_updated' | 'publication_removed' | 'tag_added' | 'tag_updated' | 'tag_removed';
@@ -328,17 +329,10 @@ export function VaultContentProvider({ children }: VaultContentProviderProps) {
     }
 
     if (publicationId) {
-      const { error: publicationError } = await supabase
-        .from('publication_pdf_assets')
-        .upsert(
-          {
-            ...record,
-            vault_publication_id: null,
-          },
-          { onConflict: 'publication_id,storage_provider' },
-        );
-
-      if (publicationError) throw publicationError;
+      await replacePublicationPdfAsset(supabase, {
+        ...record,
+        vault_publication_id: null,
+      });
     }
   }, [publications, user]);
 

--- a/src/lib/pdfAssets.test.ts
+++ b/src/lib/pdfAssets.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { replacePublicationPdfAsset, type PdfAssetRecord } from './pdfAssets';
+
+function makeQuery(method: 'delete' | 'insert', calls: string[], result = { error: null }) {
+  return {
+    eq(column: string, value: unknown) {
+      calls.push(`${method}.eq:${column}:${String(value)}`);
+      return this;
+    },
+    is(column: string, value: unknown) {
+      calls.push(`${method}.is:${column}:${String(value)}`);
+      return this;
+    },
+    then(resolve: (value: typeof result) => void) {
+      resolve(result);
+    },
+  };
+}
+
+function makeClient(result = { error: null }) {
+  const calls: string[] = [];
+  const client = {
+    from: vi.fn((table: string) => {
+      expect(table).toBe('publication_pdf_assets');
+      return {
+        delete: vi.fn(() => {
+          calls.push('delete');
+          return makeQuery('delete', calls, result);
+        }),
+        insert: vi.fn((record: PdfAssetRecord) => {
+          calls.push(`insert:${record.publication_id}:${record.vault_publication_id}:${record.stored_pdf_url}`);
+          return makeQuery('insert', calls, result);
+        }),
+      };
+    }),
+  };
+
+  return { client, calls };
+}
+
+const baseRecord: PdfAssetRecord = {
+  user_id: 'user-1',
+  publication_id: 'pub-1',
+  vault_publication_id: null,
+  storage_provider: 'google_drive',
+  stored_pdf_url: 'https://drive.example/pdf',
+  stored_file_id: null,
+  status: 'stored',
+  error_message: null,
+};
+
+describe('replacePublicationPdfAsset', () => {
+  it('deletes the canonical row before inserting without an invalid PostgREST on_conflict target', async () => {
+    const { client, calls } = makeClient();
+
+    await replacePublicationPdfAsset(client, baseRecord);
+
+    expect(calls).toEqual([
+      'delete',
+      'delete.eq:publication_id:pub-1',
+      'delete.is:vault_publication_id:null',
+      'delete.eq:storage_provider:google_drive',
+      'insert:pub-1:null:https://drive.example/pdf',
+    ]);
+  });
+
+  it('only deletes the canonical row when clearing the asset URL', async () => {
+    const { client, calls } = makeClient();
+
+    await replacePublicationPdfAsset(client, {
+      ...baseRecord,
+      stored_pdf_url: null,
+      status: 'removed',
+    });
+
+    expect(calls).toEqual([
+      'delete',
+      'delete.eq:publication_id:pub-1',
+      'delete.is:vault_publication_id:null',
+      'delete.eq:storage_provider:google_drive',
+    ]);
+  });
+});

--- a/src/lib/pdfAssets.ts
+++ b/src/lib/pdfAssets.ts
@@ -1,0 +1,53 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export type PdfAssetRecord = {
+  user_id: string;
+  publication_id: string | null;
+  vault_publication_id: string | null;
+  storage_provider: 'google_drive';
+  stored_pdf_url: string | null;
+  stored_file_id: string | null;
+  status: string;
+  error_message: string | null;
+};
+
+export type PdfAssetClient = Pick<typeof supabase, 'from'>;
+
+async function deleteExistingPublicationAsset(
+  client: PdfAssetClient,
+  publicationId: string,
+): Promise<void> {
+  const { error } = await client
+    .from('publication_pdf_assets')
+    .delete()
+    .eq('publication_id', publicationId)
+    .is('vault_publication_id', null)
+    .eq('storage_provider', 'google_drive');
+
+  if (error) throw error;
+}
+
+/**
+ * PostgREST cannot use RefHub's partial unique publication asset index with
+ * `on_conflict=publication_id,storage_provider`; it requires a full unique or
+ * exclusion constraint. Keep the partial-index data model and avoid the invalid
+ * upsert target by replacing the canonical publication-level Drive asset row.
+ */
+export async function replacePublicationPdfAsset(
+  client: PdfAssetClient,
+  record: PdfAssetRecord,
+): Promise<void> {
+  if (!record.publication_id) {
+    throw new Error('publication_id is required for canonical PDF assets');
+  }
+
+  await deleteExistingPublicationAsset(client, record.publication_id);
+
+  if (record.stored_pdf_url && record.status === 'stored') {
+    const { error } = await client
+      .from('publication_pdf_assets')
+      .insert({ ...record, vault_publication_id: null });
+
+    if (error) throw error;
+  }
+}

--- a/src/lib/pdfUpload.test.ts
+++ b/src/lib/pdfUpload.test.ts
@@ -74,7 +74,11 @@ describe('uploadVaultPublicationDrivePdf', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       'https://drive-upload.example/session',
-      expect.objectContaining({ method: 'PUT', body: largeFile }),
+      expect.objectContaining({
+        method: 'PUT',
+        body: largeFile,
+        headers: { 'Content-Type': 'application/pdf' },
+      }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,

--- a/src/lib/pdfUpload.test.ts
+++ b/src/lib/pdfUpload.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/apiKeys', () => ({
+  getBackendApiBaseUrl: () => 'https://api.example.test/api/v1',
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session: { access_token: 'session-token' } }, error: null })),
+    },
+  },
+}));
+
+import { API_SAFE_RAW_PDF_UPLOAD_BYTES, uploadVaultPublicationDrivePdf } from './pdfUpload';
+
+describe('uploadVaultPublicationDrivePdf', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps small vault PDFs on the raw backend upload route', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ data: { fileId: 'drive-file', pdfUrl: 'https://drive.example/file', provider: 'google_drive', stored: true } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const file = new File(['small'], 'paper.pdf', { type: 'application/pdf' });
+    const result = await uploadVaultPublicationDrivePdf('vault id', 'item id', file);
+
+    expect(result.fileId).toBe('drive-file');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.test/api/v1/google-drive/vaults/vault%20id/items/item%20id/pdf',
+      expect.objectContaining({ method: 'POST', body: file }),
+    );
+  });
+
+  it('uses session, direct Drive PUT, and complete routes for large vault PDFs', async () => {
+    const largeFile = new File([new Uint8Array(API_SAFE_RAW_PDF_UPLOAD_BYTES + 1)], 'large.pdf', { type: 'application/pdf' });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { upload_url: 'https://drive-upload.example/session' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'drive-file', webViewLink: 'https://drive.example/file' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { fileId: 'drive-file', pdfUrl: 'https://drive.example/file', provider: 'google_drive', stored: true } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await uploadVaultPublicationDrivePdf('vault id', 'item id', largeFile);
+
+    expect(result.pdfUrl).toBe('https://drive.example/file');
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://api.example.test/api/v1/vaults/vault%20id/items/item%20id/pdf/session',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://drive-upload.example/session',
+      expect.objectContaining({ method: 'PUT', body: largeFile }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'https://api.example.test/api/v1/vaults/vault%20id/items/item%20id/pdf/complete',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ file_id: 'drive-file', web_view_link: 'https://drive.example/file' }),
+      }),
+    );
+  });
+});

--- a/src/lib/pdfUpload.test.ts
+++ b/src/lib/pdfUpload.test.ts
@@ -68,7 +68,7 @@ describe('uploadVaultPublicationDrivePdf', () => {
     expect(result.pdfUrl).toBe('https://drive.example/file');
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      'https://api.example.test/api/v1/vaults/vault%20id/items/item%20id/pdf/session',
+      'https://api.example.test/api/v1/google-drive/vaults/vault%20id/items/item%20id/pdf/session',
       expect.objectContaining({ method: 'POST' }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -78,7 +78,7 @@ describe('uploadVaultPublicationDrivePdf', () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,
-      'https://api.example.test/api/v1/vaults/vault%20id/items/item%20id/pdf/complete',
+      'https://api.example.test/api/v1/google-drive/vaults/vault%20id/items/item%20id/pdf/complete',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ file_id: 'drive-file', web_view_link: 'https://drive.example/file' }),

--- a/src/lib/pdfUpload.ts
+++ b/src/lib/pdfUpload.ts
@@ -1,12 +1,28 @@
 import { getBackendApiBaseUrl } from '@/lib/apiKeys';
 import { supabase } from '@/integrations/supabase/client';
 
+// Keep raw uploads comfortably below Netlify's 6 MiB synchronous Function body ceiling.
+export const API_SAFE_RAW_PDF_UPLOAD_BYTES = 5.5 * 1024 * 1024;
+
 export interface DrivePdfUploadResult {
   fileId?: string;
   pdfUrl: string | null;
   sourceUrl?: string | null;
   provider: string;
   stored: boolean;
+}
+
+interface DriveResumableSession {
+  upload_url?: string;
+  uploadUrl?: string;
+  file_name?: string;
+  fileName?: string;
+}
+
+interface GoogleDriveUploadResponse {
+  id?: string;
+  webViewLink?: string;
+  webContentLink?: string;
 }
 
 async function getAccessToken() {
@@ -31,10 +47,22 @@ function getErrorMessage(payload: unknown, status: number) {
   );
 }
 
-async function uploadDrivePdf(path: string, file: File): Promise<DrivePdfUploadResult> {
+async function parseJsonResponse(response: Response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function assertPdfFile(file: File) {
   if (file.type && file.type !== 'application/pdf') {
     throw new Error('Please choose a PDF file.');
   }
+}
+
+async function uploadDrivePdf(path: string, file: File): Promise<DrivePdfUploadResult> {
+  assertPdfFile(file);
 
   const accessToken = await getAccessToken();
   const response = await fetch(`${getBackendApiBaseUrl()}${path}`, {
@@ -46,12 +74,7 @@ async function uploadDrivePdf(path: string, file: File): Promise<DrivePdfUploadR
     body: file,
   });
 
-  let payload: unknown = null;
-  try {
-    payload = await response.json();
-  } catch {
-    payload = null;
-  }
+  const payload = await parseJsonResponse(response);
 
   if (!response.ok) {
     throw new Error(getErrorMessage(payload, response.status));
@@ -65,10 +88,103 @@ async function uploadDrivePdf(path: string, file: File): Promise<DrivePdfUploadR
   return data;
 }
 
+async function createDrivePdfSession(basePath: string, accessToken: string): Promise<DriveResumableSession> {
+  const response = await fetch(`${getBackendApiBaseUrl()}${basePath}/session`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const payload = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(`Could not create Drive upload session: ${getErrorMessage(payload, response.status)}`);
+  }
+
+  const data = (payload as { data?: DriveResumableSession } | null)?.data;
+  if (!data?.upload_url && !data?.uploadUrl) {
+    throw new Error('Drive upload session response did not include an upload URL.');
+  }
+
+  return data;
+}
+
+async function uploadPdfToDrive(uploadUrl: string, file: File): Promise<GoogleDriveUploadResponse> {
+  const response = await fetch(uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/pdf',
+    },
+    body: file,
+  });
+
+  const payload = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(`Direct Google Drive upload failed (${response.status}).`);
+  }
+
+  const driveFile = payload as GoogleDriveUploadResponse | null;
+  if (!driveFile?.id) {
+    throw new Error('Google Drive upload response did not include a file ID.');
+  }
+
+  return driveFile;
+}
+
+async function completeDrivePdfUpload(
+  basePath: string,
+  accessToken: string,
+  driveFile: GoogleDriveUploadResponse,
+): Promise<DrivePdfUploadResult> {
+  const response = await fetch(`${getBackendApiBaseUrl()}${basePath}/complete`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      file_id: driveFile.id,
+      web_view_link: driveFile.webViewLink || driveFile.webContentLink || null,
+    }),
+  });
+
+  const payload = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(`Could not record Drive upload: ${getErrorMessage(payload, response.status)}`);
+  }
+
+  const data = (payload as { data?: DrivePdfUploadResult } | null)?.data;
+  if (!data) {
+    throw new Error('Drive upload completion response did not include Drive metadata.');
+  }
+
+  return data;
+}
+
+async function uploadVaultDrivePdfResumable(basePath: string, file: File): Promise<DrivePdfUploadResult> {
+  assertPdfFile(file);
+
+  const accessToken = await getAccessToken();
+  const session = await createDrivePdfSession(basePath, accessToken);
+  const driveFile = await uploadPdfToDrive(session.upload_url || session.uploadUrl || '', file);
+
+  return completeDrivePdfUpload(basePath, accessToken, driveFile);
+}
+
 export function uploadPublicationDrivePdf(publicationId: string, file: File) {
   return uploadDrivePdf(`/publications/${encodeURIComponent(publicationId)}/pdf`, file);
 }
 
 export function uploadVaultPublicationDrivePdf(vaultId: string, vaultPublicationId: string, file: File) {
-  return uploadDrivePdf(`/google-drive/vaults/${encodeURIComponent(vaultId)}/items/${encodeURIComponent(vaultPublicationId)}/pdf`, file);
+  const rawUploadPath = `/google-drive/vaults/${encodeURIComponent(vaultId)}/items/${encodeURIComponent(vaultPublicationId)}/pdf`;
+
+  if (file.size <= API_SAFE_RAW_PDF_UPLOAD_BYTES) {
+    return uploadDrivePdf(rawUploadPath, file);
+  }
+
+  const resumableUploadPath = `/vaults/${encodeURIComponent(vaultId)}/items/${encodeURIComponent(vaultPublicationId)}/pdf`;
+  return uploadVaultDrivePdfResumable(resumableUploadPath, file);
 }

--- a/src/lib/pdfUpload.ts
+++ b/src/lib/pdfUpload.ts
@@ -185,6 +185,6 @@ export function uploadVaultPublicationDrivePdf(vaultId: string, vaultPublication
     return uploadDrivePdf(rawUploadPath, file);
   }
 
-  const resumableUploadPath = `/vaults/${encodeURIComponent(vaultId)}/items/${encodeURIComponent(vaultPublicationId)}/pdf`;
+  const resumableUploadPath = `/google-drive/vaults/${encodeURIComponent(vaultId)}/items/${encodeURIComponent(vaultPublicationId)}/pdf`;
   return uploadVaultDrivePdfResumable(resumableUploadPath, file);
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/lib/semanticScholar';
 import { createPublicationSyncPatch, extractBibliographicPatch, getPublicationSyncDiffs, PublicationSyncDiff } from '@/lib/publicationSync';
 import { filterDashboardTags, getDashboardAccessibleVaultIds } from '@/lib/dashboardTagScope';
+import { replacePublicationPdfAsset } from '@/lib/pdfAssets';
 import { PublicationSyncDialog } from '@/components/publications/PublicationSyncDialog';
 import {
   AlertDialog,
@@ -801,9 +802,8 @@ export default function Dashboard() {
               .upsert(assetRecord, { onConflict: 'vault_publication_id,storage_provider' })
               .then(({ error: e }) => { if (e) console.warn('[drive] pdf asset upsert:', e.message); });
             if (vaultPub.original_publication_id) {
-              supabase.from('publication_pdf_assets')
-                .upsert({ ...assetRecord, vault_publication_id: null }, { onConflict: 'publication_id,storage_provider' })
-                .then(({ error: e }) => { if (e) console.warn('[drive] canonical pdf asset upsert:', e.message); });
+              replacePublicationPdfAsset(supabase, { ...assetRecord, vault_publication_id: null })
+                .catch((e) => { console.warn('[drive] canonical pdf asset replace:', e.message); });
             }
             setPdfAssetsMap(prev => ({ ...prev, [editingPublication.id]: driveUrl }));
           }
@@ -837,18 +837,16 @@ export default function Dashboard() {
 
           // Persist Drive PDF asset for canonical publication
           if (!updateError && driveUrl) {
-            supabase.from('publication_pdf_assets')
-              .upsert({
-                user_id: user.id,
-                publication_id: editingPublication.id,
-                vault_publication_id: null,
-                storage_provider: 'google_drive' as const,
-                stored_pdf_url: driveUrl,
-                stored_file_id: null as string | null,
-                status: 'stored',
-                error_message: null as string | null,
-              }, { onConflict: 'publication_id,storage_provider' })
-              .then(({ error: e }) => { if (e) console.warn('[drive] pdf asset upsert:', e.message); });
+            replacePublicationPdfAsset(supabase, {
+              user_id: user.id,
+              publication_id: editingPublication.id,
+              vault_publication_id: null,
+              storage_provider: 'google_drive' as const,
+              stored_pdf_url: driveUrl,
+              stored_file_id: null as string | null,
+              status: 'stored',
+              error_message: null as string | null,
+            }).catch((e) => { console.warn('[drive] pdf asset replace:', e.message); });
             setPdfAssetsMap(prev => ({ ...prev, [editingPublication.id]: driveUrl }));
           }
         }


### PR DESCRIPTION
## Summary
- Route vault item PDF uploads above the API-safe raw upload threshold through the existing Drive resumable session flow.
- Keep small vault PDFs on the existing raw Google Drive upload route.
- Add helper tests for raw vs resumable routing and bump package version to 1.4.1.

## Verification
- npm test
- npm run lint (passes with existing react-hooks warnings in Dashboard.tsx and VaultDetail.tsx)
- npm run build

## Notes
- Publication-level PDF upload remains on the raw route because the backend currently exposes resumable session/complete only for vault item uploads.