### PR TITLE
Add update_vault_publication_with_rollup Postgres function

### DIFF
--- a/supabase/migrations/20260706000000_publication_bibliographic_rollup.sql
+++ b/supabase/migrations/20260706000000_publication_bibliographic_rollup.sql
@@ -34,7 +34,13 @@ BEGIN
 
     UPDATE vault_publications SET
         title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
-        authors = CASE WHEN p_patch ? 'authors' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors')) ELSE authors END,
+        authors = CASE
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors'))
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'null'
+                THEN NULL
+            ELSE authors
+        END,
         year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
         journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
         volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
@@ -50,7 +56,13 @@ BEGIN
         booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
         chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
         edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
-        editor = CASE WHEN p_patch ? 'editor' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor')) ELSE editor END,
+        editor = CASE
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor'))
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'null'
+                THEN NULL
+            ELSE editor
+        END,
         howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
         institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
         number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
@@ -62,7 +74,13 @@ BEGIN
         eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
         isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
         issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
-        keywords = CASE WHEN p_patch ? 'keywords' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords')) ELSE keywords END,
+        keywords = CASE
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords'))
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'null'
+                THEN NULL
+            ELSE keywords
+        END,
         version = version + 1,
         updated_at = now()
     WHERE id = p_vault_publication_id AND vault_id = p_vault_id
@@ -83,7 +101,13 @@ BEGIN
     IF v_original_id IS NOT NULL AND v_has_bibliographic_patch THEN
         UPDATE publications SET
             title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
-            authors = CASE WHEN p_patch ? 'authors' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors')) ELSE authors END,
+            authors = CASE
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors'))
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'null'
+                THEN NULL
+            ELSE authors
+        END,
             year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
             journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
             volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
@@ -98,7 +122,13 @@ BEGIN
             booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
             chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
             edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
-            editor = CASE WHEN p_patch ? 'editor' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor')) ELSE editor END,
+            editor = CASE
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor'))
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'null'
+                THEN NULL
+            ELSE editor
+        END,
             howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
             institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
             number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
@@ -110,13 +140,25 @@ BEGIN
             eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
             isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
             issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
-            keywords = CASE WHEN p_patch ? 'keywords' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords')) ELSE keywords END,
+            keywords = CASE
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords'))
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'null'
+                THEN NULL
+            ELSE keywords
+        END,
             updated_at = now()
         WHERE id = v_original_id;
 
         UPDATE vault_publications SET
             title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
-            authors = CASE WHEN p_patch ? 'authors' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors')) ELSE authors END,
+            authors = CASE
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors'))
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'null'
+                THEN NULL
+            ELSE authors
+        END,
             year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
             journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
             volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
@@ -131,7 +173,13 @@ BEGIN
             booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
             chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
             edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
-            editor = CASE WHEN p_patch ? 'editor' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor')) ELSE editor END,
+            editor = CASE
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor'))
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'null'
+                THEN NULL
+            ELSE editor
+        END,
             howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
             institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
             number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
@@ -143,7 +191,13 @@ BEGIN
             eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
             isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
             issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
-            keywords = CASE WHEN p_patch ? 'keywords' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords')) ELSE keywords END,
+            keywords = CASE
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords'))
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'null'
+                THEN NULL
+            ELSE keywords
+        END,
             updated_at = now()
         WHERE original_publication_id = v_original_id AND id <> p_vault_publication_id;
     END IF;

--- a/supabase/migrations/20260706000000_publication_bibliographic_rollup.sql
+++ b/supabase/migrations/20260706000000_publication_bibliographic_rollup.sql
@@ -1,0 +1,145 @@
+-- 20260706000000_publication_bibliographic_rollup.sql
+--
+-- Rolls up bibliographic-field edits from one vault_publications copy to the
+-- canonical publications row and every sibling vault_publications copy
+-- (same original_publication_id, different vault), atomically. Parameters
+-- are p_-prefixed to avoid the ambiguous-column-reference bug fixed in
+-- migration 006 (a bare `vault_id = vault_id` inside a function body is
+-- parsed as comparing the column to itself, not to the parameter, if the
+-- parameter shares the column's name).
+--
+-- notes is intentionally never part of the bibliographic field list below —
+-- it's vault-local and, like tag_ids, must never propagate.
+
+CREATE OR REPLACE FUNCTION "public"."update_vault_publication_with_rollup"(
+    "p_vault_publication_id" "uuid",
+    "p_vault_id" "uuid",
+    "p_patch" "jsonb",
+    "p_actor_user_id" "uuid"
+) RETURNS "void"
+    LANGUAGE "plpgsql"
+    AS $$
+DECLARE
+    v_original_id uuid;
+    v_has_bibliographic_patch boolean;
+BEGIN
+    UPDATE vault_publications SET
+        title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
+        authors = CASE WHEN p_patch ? 'authors' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors')) ELSE authors END,
+        year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
+        journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
+        volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
+        issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,
+        pages = CASE WHEN p_patch ? 'pages' THEN p_patch->>'pages' ELSE pages END,
+        doi = CASE WHEN p_patch ? 'doi' THEN p_patch->>'doi' ELSE doi END,
+        url = CASE WHEN p_patch ? 'url' THEN p_patch->>'url' ELSE url END,
+        abstract = CASE WHEN p_patch ? 'abstract' THEN p_patch->>'abstract' ELSE abstract END,
+        pdf_url = CASE WHEN p_patch ? 'pdf_url' THEN p_patch->>'pdf_url' ELSE pdf_url END,
+        bibtex_key = CASE WHEN p_patch ? 'bibtex_key' THEN p_patch->>'bibtex_key' ELSE bibtex_key END,
+        publication_type = CASE WHEN p_patch ? 'publication_type' THEN p_patch->>'publication_type' ELSE publication_type END,
+        notes = CASE WHEN p_patch ? 'notes' THEN p_patch->>'notes' ELSE notes END,
+        booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
+        chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
+        edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
+        editor = CASE WHEN p_patch ? 'editor' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor')) ELSE editor END,
+        howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
+        institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
+        number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
+        organization = CASE WHEN p_patch ? 'organization' THEN p_patch->>'organization' ELSE organization END,
+        publisher = CASE WHEN p_patch ? 'publisher' THEN p_patch->>'publisher' ELSE publisher END,
+        school = CASE WHEN p_patch ? 'school' THEN p_patch->>'school' ELSE school END,
+        series = CASE WHEN p_patch ? 'series' THEN p_patch->>'series' ELSE series END,
+        type = CASE WHEN p_patch ? 'type' THEN p_patch->>'type' ELSE type END,
+        eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
+        isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
+        issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
+        keywords = CASE WHEN p_patch ? 'keywords' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords')) ELSE keywords END,
+        version = version + 1,
+        updated_at = now()
+    WHERE id = p_vault_publication_id AND vault_id = p_vault_id
+    RETURNING original_publication_id INTO v_original_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'vault publication % not found in vault %', p_vault_publication_id, p_vault_id
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    v_has_bibliographic_patch := p_patch ?| ARRAY[
+        'title', 'authors', 'year', 'journal', 'volume', 'issue', 'pages', 'doi', 'url',
+        'abstract', 'pdf_url', 'bibtex_key', 'publication_type', 'booktitle', 'chapter',
+        'edition', 'editor', 'howpublished', 'institution', 'number', 'organization',
+        'publisher', 'school', 'series', 'type', 'eid', 'isbn', 'issn', 'keywords'
+    ];
+
+    IF v_original_id IS NOT NULL AND v_has_bibliographic_patch THEN
+        UPDATE publications SET
+            title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
+            authors = CASE WHEN p_patch ? 'authors' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors')) ELSE authors END,
+            year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
+            journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
+            volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
+            issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,
+            pages = CASE WHEN p_patch ? 'pages' THEN p_patch->>'pages' ELSE pages END,
+            doi = CASE WHEN p_patch ? 'doi' THEN p_patch->>'doi' ELSE doi END,
+            url = CASE WHEN p_patch ? 'url' THEN p_patch->>'url' ELSE url END,
+            abstract = CASE WHEN p_patch ? 'abstract' THEN p_patch->>'abstract' ELSE abstract END,
+            pdf_url = CASE WHEN p_patch ? 'pdf_url' THEN p_patch->>'pdf_url' ELSE pdf_url END,
+            bibtex_key = CASE WHEN p_patch ? 'bibtex_key' THEN p_patch->>'bibtex_key' ELSE bibtex_key END,
+            publication_type = CASE WHEN p_patch ? 'publication_type' THEN p_patch->>'publication_type' ELSE publication_type END,
+            booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
+            chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
+            edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
+            editor = CASE WHEN p_patch ? 'editor' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor')) ELSE editor END,
+            howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
+            institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
+            number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
+            organization = CASE WHEN p_patch ? 'organization' THEN p_patch->>'organization' ELSE organization END,
+            publisher = CASE WHEN p_patch ? 'publisher' THEN p_patch->>'publisher' ELSE publisher END,
+            school = CASE WHEN p_patch ? 'school' THEN p_patch->>'school' ELSE school END,
+            series = CASE WHEN p_patch ? 'series' THEN p_patch->>'series' ELSE series END,
+            type = CASE WHEN p_patch ? 'type' THEN p_patch->>'type' ELSE type END,
+            eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
+            isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
+            issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
+            keywords = CASE WHEN p_patch ? 'keywords' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords')) ELSE keywords END,
+            updated_at = now()
+        WHERE id = v_original_id;
+
+        UPDATE vault_publications SET
+            title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
+            authors = CASE WHEN p_patch ? 'authors' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors')) ELSE authors END,
+            year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
+            journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
+            volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
+            issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,
+            pages = CASE WHEN p_patch ? 'pages' THEN p_patch->>'pages' ELSE pages END,
+            doi = CASE WHEN p_patch ? 'doi' THEN p_patch->>'doi' ELSE doi END,
+            url = CASE WHEN p_patch ? 'url' THEN p_patch->>'url' ELSE url END,
+            abstract = CASE WHEN p_patch ? 'abstract' THEN p_patch->>'abstract' ELSE abstract END,
+            pdf_url = CASE WHEN p_patch ? 'pdf_url' THEN p_patch->>'pdf_url' ELSE pdf_url END,
+            bibtex_key = CASE WHEN p_patch ? 'bibtex_key' THEN p_patch->>'bibtex_key' ELSE bibtex_key END,
+            publication_type = CASE WHEN p_patch ? 'publication_type' THEN p_patch->>'publication_type' ELSE publication_type END,
+            booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
+            chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
+            edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
+            editor = CASE WHEN p_patch ? 'editor' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor')) ELSE editor END,
+            howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
+            institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
+            number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
+            organization = CASE WHEN p_patch ? 'organization' THEN p_patch->>'organization' ELSE organization END,
+            publisher = CASE WHEN p_patch ? 'publisher' THEN p_patch->>'publisher' ELSE publisher END,
+            school = CASE WHEN p_patch ? 'school' THEN p_patch->>'school' ELSE school END,
+            series = CASE WHEN p_patch ? 'series' THEN p_patch->>'series' ELSE series END,
+            type = CASE WHEN p_patch ? 'type' THEN p_patch->>'type' ELSE type END,
+            eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
+            isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
+            issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
+            keywords = CASE WHEN p_patch ? 'keywords' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords')) ELSE keywords END,
+            updated_at = now(),
+            updated_by = p_actor_user_id
+        WHERE original_publication_id = v_original_id AND id <> p_vault_publication_id;
+    END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") OWNER TO "postgres";

--- a/supabase/migrations/20260706000000_publication_bibliographic_rollup.sql
+++ b/supabase/migrations/20260706000000_publication_bibliographic_rollup.sql
@@ -41,7 +41,15 @@ BEGIN
                 THEN NULL
             ELSE authors
         END,
-        year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
+        year = CASE
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'null'
+                THEN NULL
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'number'
+                THEN (p_patch->>'year')::numeric::integer
+            WHEN p_patch ? 'year'
+                THEN year
+            ELSE year
+        END,
         journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
         volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
         issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,
@@ -108,7 +116,15 @@ BEGIN
                 THEN NULL
             ELSE authors
         END,
-            year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
+            year = CASE
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'null'
+                THEN NULL
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'number'
+                THEN (p_patch->>'year')::numeric::integer
+            WHEN p_patch ? 'year'
+                THEN year
+            ELSE year
+        END,
             journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
             volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
             issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,
@@ -159,7 +175,15 @@ BEGIN
                 THEN NULL
             ELSE authors
         END,
-            year = CASE WHEN p_patch ? 'year' THEN (p_patch->>'year')::integer ELSE year END,
+            year = CASE
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'null'
+                THEN NULL
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'number'
+                THEN (p_patch->>'year')::numeric::integer
+            WHEN p_patch ? 'year'
+                THEN year
+            ELSE year
+        END,
             journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
             volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
             issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,

--- a/supabase/migrations/20260706000000_publication_bibliographic_rollup.sql
+++ b/supabase/migrations/20260706000000_publication_bibliographic_rollup.sql
@@ -23,6 +23,15 @@ DECLARE
     v_original_id uuid;
     v_has_bibliographic_patch boolean;
 BEGIN
+    -- This function is only ever called under the service-role key (see
+    -- .netlify's handleUpdateItem), which has no JWT context of its own, so
+    -- auth.uid() would otherwise resolve to NULL for the rest of this
+    -- transaction. vault_publications' own "set updated_by from auth.uid()"
+    -- BEFORE UPDATE trigger fires on every UPDATE below regardless -- setting
+    -- this makes it record the real actor instead of overwriting every touched
+    -- row's updated_by with NULL.
+    PERFORM set_config('request.jwt.claim.sub', p_actor_user_id::text, true);
+
     UPDATE vault_publications SET
         title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
         authors = CASE WHEN p_patch ? 'authors' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors')) ELSE authors END,
@@ -135,11 +144,21 @@ BEGIN
             isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
             issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
             keywords = CASE WHEN p_patch ? 'keywords' THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords')) ELSE keywords END,
-            updated_at = now(),
-            updated_by = p_actor_user_id
+            updated_at = now()
         WHERE original_publication_id = v_original_id AND id <> p_vault_publication_id;
     END IF;
 END;
 $$;
 
 ALTER FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") OWNER TO "postgres";
+
+-- Unlike copy_publication_to_vault and most other functions in this schema
+-- (granted to anon/authenticated/service_role alike, since they're meant to
+-- be called by regular users), this function trusts its caller completely:
+-- it has no independent authorization of its own, no auth/scope/vault-access
+-- checks -- those already happened in .netlify's handleUpdateItem before the
+-- RPC call. Restricting EXECUTE to service_role only means the only caller
+-- that can ever invoke it is the one that already did those checks, and RLS
+-- (which service_role bypasses) never becomes a factor either way.
+REVOKE ALL ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") TO "service_role";


### PR DESCRIPTION
## Summary

New Postgres function, `update_vault_publication_with_rollup`, backing a companion `.netlify` API change (refhub-io/.netlify#24): atomically rolls up bibliographic-field edits from one vault's copy of a paper to the canonical `publications` row and every sibling `vault_publications` copy in other vaults, in a single transaction. `notes` is applied to the edited row only and never propagates; `tag_ids` is untouched by this function entirely.

## ⚠️ Requires manual verification before merge/deploy

This repo has no automated SQL test harness (no `supabase/config.toml`, no pgTAP) — same as every other migration here. The function was reviewed carefully for correctness (field-list transcription across all three UPDATE blocks independently verified via line count, not just eyeballed), but the actual runtime behavior against a live Postgres instance is still unverified. Run the verification script below against a **dev/staging** Supabase project (never production) before merging:

```sql
-- Setup: one canonical publication, two vault copies in two different vaults.
INSERT INTO vaults (id, user_id, name) VALUES
  ('11111111-1111-1111-1111-111111111111', '<TEST_USER_ID>', 'Rollup Test Vault A'),
  ('22222222-2222-2222-2222-222222222222', '<TEST_USER_ID>', 'Rollup Test Vault B');

INSERT INTO publications (id, user_id, title, doi) VALUES
  ('33333333-3333-3333-3333-333333333333', '<TEST_USER_ID>', 'Original Title', '10.1/original');

INSERT INTO vault_publications (id, vault_id, original_publication_id, title, doi, notes, version) VALUES
  ('44444444-4444-4444-4444-444444444444', '11111111-1111-1111-1111-111111111111',
   '33333333-3333-3333-3333-333333333333', 'Original Title', '10.1/original', 'vault A notes', 1),
  ('55555555-5555-5555-5555-555555555555', '22222222-2222-2222-2222-222222222222',
   '33333333-3333-3333-3333-333333333333', 'Original Title', '10.1/original', 'vault B notes', 1);

-- Edit vault A's copy: change doi and notes together.
SELECT update_vault_publication_with_rollup(
  '44444444-4444-4444-4444-444444444444'::uuid,
  '11111111-1111-1111-1111-111111111111'::uuid,
  '{"doi": "10.1/updated", "notes": "vault A notes, edited"}'::jsonb,
  '<TEST_USER_ID>'::uuid
);

-- Expect: vault A's own row has the new doi AND the new notes, version bumped to 2.
SELECT doi, notes, version FROM vault_publications WHERE id = '44444444-4444-4444-4444-444444444444';

-- Expect: canonical row has the new doi.
SELECT doi FROM publications WHERE id = '33333333-3333-3333-3333-333333333333';

-- Expect: vault B's sibling copy has the new doi, but its OWN notes are untouched, version still 1.
SELECT doi, notes, version, updated_by FROM vault_publications WHERE id = '55555555-5555-5555-5555-555555555555';

-- Not-found path: wrong vault_id for a real item id should raise, not silently no-op.
SELECT update_vault_publication_with_rollup(
  '44444444-4444-4444-4444-444444444444'::uuid,
  '22222222-2222-2222-2222-222222222222'::uuid,
  '{"doi": "10.1/should-not-apply"}'::jsonb,
  '<TEST_USER_ID>'::uuid
);
-- Expect: ERROR: vault publication ... not found in vault ...

-- Cleanup
DELETE FROM vault_publications WHERE id IN ('44444444-4444-4444-4444-444444444444', '55555555-5555-5555-5555-555555555555');
DELETE FROM publications WHERE id = '33333333-3333-3333-3333-333333333333';
DELETE FROM vaults WHERE id IN ('11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222');
```

Replace `<TEST_USER_ID>` with a real `auth.users.id` from that dev project.

**This migration must merge and be applied before refhub-io/.netlify#24 is deployed** — the API side calls this function directly with no fallback; until it exists, every `PATCH` touching a bibliographic field will fail with `502 publication_rollup_failed`.

Design doc + full plan: refhub-io/.netlify's `docs/superpowers/specs/2026-07-06-publication-bibliographic-rollup-design.md` and `docs/superpowers/plans/2026-07-06-publication-bibliographic-rollup.md`.

## Test plan
- [x] Went through subagent-driven development: implementer + task-scoped reviewer verified field-list transcription (29 fields for canonical/sibling rows, 30 including `notes` for the target row) via independent line counts, confirmed no stray exception handler breaks the implicit-transaction atomicity guarantee, confirmed `p_`-prefixed parameters avoid the ambiguous-column-reference bug class this repo hit before (migration `006`)
- [x] Cross-checked against the `.netlify` side's RPC call in the final whole-branch review — function name and all four parameter names match exactly
- [ ] **Manual SQL verification above — not yet run, needs a human with dev Supabase access**

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HrHAcfYF4s5vXWF1LrNMfL

---

**Update:** fixed an array-field crash risk flagged in review — `authors`/`editor`/`keywords` called `jsonb_array_elements_text` unguarded, which raises `cannot extract elements from a scalar` for a JSON `null` or any non-array value (e.g. `{"authors": null}`), turning that into an uncaught `502 publication_rollup_failed` instead of clearing the field. All three UPDATE blocks now guard with `jsonb_typeof(...) = 'array'` / `'null'`: a real array converts as before, JSON `null` clears the column to `NULL`, anything else is left unchanged. Add this to the manual verification script above:

```sql
-- Null/non-array guard: should clear authors to NULL, not raise.
SELECT update_vault_publication_with_rollup(
  '44444444-4444-4444-4444-444444444444'::uuid,
  '11111111-1111-1111-1111-111111111111'::uuid,
  '{"authors": null}'::jsonb,
  '<TEST_USER_ID>'::uuid
);
SELECT authors FROM vault_publications WHERE id = '44444444-4444-4444-4444-444444444444';
-- Expect: authors is NULL, no error raised.
```

---

**Update 2:** fixed the `year` cast crash flagged in the latest review — `(p_patch->>'year')::integer` raises `invalid input syntax for type integer` for a malformed value like `""` or `"abcd"`. Guarded all three UPDATE blocks the same way as the array fields: JSON `null` clears the column, a JSON number casts via `::numeric::integer` (so a decimal-looking value like `2020.5` rounds instead of crashing), anything else is left unchanged. Add this to the manual verification script:

```sql
-- Malformed year: should leave the column unchanged, not raise.
SELECT update_vault_publication_with_rollup(
  '44444444-4444-4444-4444-444444444444'::uuid,
  '11111111-1111-1111-1111-111111111111'::uuid,
  '{"year": "abcd"}'::jsonb,
  '<TEST_USER_ID>'::uuid
);
SELECT year FROM vault_publications WHERE id = '44444444-4444-4444-4444-444444444444';
-- Expect: year unchanged (no error).

-- Null year: should clear to NULL.
SELECT update_vault_publication_with_rollup(
  '44444444-4444-4444-4444-444444444444'::uuid,
  '11111111-1111-1111-1111-111111111111'::uuid,
  '{"year": null}'::jsonb,
  '<TEST_USER_ID>'::uuid
);
SELECT year FROM vault_publications WHERE id = '44444444-4444-4444-4444-444444444444';
-- Expect: year is NULL.
```