### PR TITLE
Vault-augment race fix, v1.4.3 bump, discovery what's-new

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -381,6 +381,12 @@ export function VaultAugmentDialog({
 
   const fetchedTabs = useRef<Set<AugmentTab>>(new Set());
   const resolvedPaperIds = useRef<ResolvedPaper[]>([]);
+  // Guards against overlapping invocations of fetchRelated/fetchTabData/
+  // fetchTopicData for the same tab (e.g. a retry fired while the original
+  // fetch is still in flight). Each call captures its own generation number
+  // and checks it's still current before committing state, so a slower,
+  // superseded fetch can't silently overwrite a newer one's results.
+  const fetchGenerations = useRef<Record<AugmentTab, number>>({ related: 0, references: 0, citations: 0, topic: 0 });
 
   const updateTabStatus = useCallback((tab: AugmentTab, next: Partial<TabStatus>) => {
     setTabStatus((prev) => ({
@@ -456,9 +462,13 @@ export function VaultAugmentDialog({
     if (publications.length === 0) return;
     if (!force && fetchedTabs.current.has('related')) return;
 
+    const generation = ++fetchGenerations.current.related;
+    const isStale = () => fetchGenerations.current.related !== generation;
+
     updateTabStatus('related', { state: 'loading', progress: null, failures: [] });
 
     const { resolved, failures: lookupFailures } = await resolveSelectedPaperIds();
+    if (isStale()) return;
 
     if (resolved.length === 0) {
       setRelated([]);
@@ -495,6 +505,8 @@ export function VaultAugmentDialog({
       }
     }
 
+    if (isStale()) return;
+
     const map = new Map<string, DiscoveredPaper>();
     for (const paper of discoveredPapers) {
       map.set(paper.paperId, {
@@ -523,6 +535,9 @@ export function VaultAugmentDialog({
     const fetchKey = `topic:${query.toLowerCase()}`;
     if (!force && fetchedTabs.current.has(fetchKey)) return;
 
+    const generation = ++fetchGenerations.current.topic;
+    const isStale = () => fetchGenerations.current.topic !== generation;
+
     updateTabStatus('topic', { state: 'loading', progress: null, failures: [] });
     const results = await runSemanticScholarQueue(
       [query],
@@ -533,6 +548,7 @@ export function VaultAugmentDialog({
         onProgress: (progress) => updateTabStatus('topic', { progress, state: 'loading' }),
       },
     );
+    if (isStale()) return;
 
     const result = results[0];
     if (!result.ok) {
@@ -561,6 +577,9 @@ export function VaultAugmentDialog({
       return;
     }
 
+    const generation = ++fetchGenerations.current[tab];
+    const isStale = () => fetchGenerations.current[tab] !== generation;
+
     updateTabStatus(tab, { state: 'loading', progress: null, failures: [] });
 
     const results = await runSemanticScholarQueue(
@@ -572,6 +591,7 @@ export function VaultAugmentDialog({
         onProgress: (progress) => updateTabStatus(tab, { progress, state: 'loading' }),
       },
     );
+    if (isStale()) return;
 
     const map = new Map<string, DiscoveredPaper>();
     const failures: TabFailure[] = [];

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -27,33 +27,15 @@ const changelog: ChangelogEntry[] = [
     features: [
       {
         tag: 'improvement',
-        title: 'openalex-backed discovery',
+        title: 'smarter paper discovery',
         description:
-          'related papers, references, citations, and doi lookups now try openalex first, with automatic fallback to semantic scholar -- broader coverage and fewer rate-limit slowdowns across discovery and sync.',
-      },
-      {
-        tag: 'improvement',
-        title: 'batched related-paper discovery',
-        description:
-          'selecting multiple papers for vault augmentation now fetches recommendations in fewer, larger requests instead of one call per paper, so discovery finishes faster.',
+          'related papers, references, citations, doi lookups, and topic search now try openalex first with automatic fallback to semantic scholar, and vault augmentation fetches recommendations in fewer, larger batched requests -- broader coverage, faster results, and steadier topic discovery for new vaults.',
       },
       {
         tag: 'fix',
-        title: 'coordinated semantic scholar rate limiting',
+        title: 'coordinated rate limiting',
         description:
-          'semantic scholar requests now share one coordinated rate limit across the whole app instead of a per-session allowance, cutting down on unexpected slowdowns during heavy use.',
-      },
-      {
-        tag: 'fix',
-        title: 'steadier topic discovery for new vaults',
-        description:
-          'starting a new vault from a topic search is more resilient to partial failures and retries, so results no longer get overwritten by a slower, outdated request.',
-      },
-      {
-        tag: 'improvement',
-        title: 'more reliable paper sync',
-        description:
-          'checking a paper against semantic scholar for metadata updates now benefits from the same broader coverage and fallback as discovery.',
+          'semantic scholar requests now share one rate limit across the whole app instead of a per-session allowance, so discovery and paper sync see fewer unexpected slowdowns during heavy use.',
       },
     ],
   },

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -21,6 +21,43 @@ export interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
+    id: 12,
+    date: '2026-07-15',
+    title: 'faster, more resilient paper discovery',
+    features: [
+      {
+        tag: 'improvement',
+        title: 'openalex-backed discovery',
+        description:
+          'related papers, references, citations, and doi lookups now try openalex first, with automatic fallback to semantic scholar -- broader coverage and fewer rate-limit slowdowns across discovery and sync.',
+      },
+      {
+        tag: 'improvement',
+        title: 'batched related-paper discovery',
+        description:
+          'selecting multiple papers for vault augmentation now fetches recommendations in fewer, larger requests instead of one call per paper, so discovery finishes faster.',
+      },
+      {
+        tag: 'fix',
+        title: 'coordinated semantic scholar rate limiting',
+        description:
+          'semantic scholar requests now share one coordinated rate limit across the whole app instead of a per-session allowance, cutting down on unexpected slowdowns during heavy use.',
+      },
+      {
+        tag: 'fix',
+        title: 'steadier topic discovery for new vaults',
+        description:
+          'starting a new vault from a topic search is more resilient to partial failures and retries, so results no longer get overwritten by a slower, outdated request.',
+      },
+      {
+        tag: 'improvement',
+        title: 'more reliable paper sync',
+        description:
+          'checking a paper against semantic scholar for metadata updates now benefits from the same broader coverage and fallback as discovery.',
+      },
+    ],
+  },
+  {
     id: 11,
     date: '2026-06-19',
     title: 'semantic scholar queues and onboarding',


### PR DESCRIPTION
## Summary
- Fix a race condition in `VaultAugmentDialog` where a superseded discovery fetch (related/references/citations/topic) could overwrite a newer one's results if two invocations overlapped -- same class of bug as the vault-switching race fixed in PR #151's `VaultContentContext`.
- Bump `package.json` to 1.4.3.
- Add a consolidated "What's New" entry (`src/config/changelog.ts`, id 12) covering the OpenAlex-backed discovery fallback, batched related-paper requests, the coordinated global Semantic Scholar rate limit, and this fix.

Note: the what's-new entry mentions OpenAlex, which is still on `.netlify` PR #28 (not yet merged). Sequence deploys accordingly so the notification doesn't go out ahead of the feature.

## Test plan
- [x] `npm test` -- 31/31 passing
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [ ] Manually verify: rapidly retry/re-trigger vault-augment discovery (related tab) and confirm results never flicker back to a stale/emptier state
- [ ] Confirm "What's New" dialog surfaces the new entry for a test account after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)