### PR TITLE
Fix theme sync, fullscreen notes save prompt, and mobile onboarding buttons

### DIFF
--- a/src/components/profile/GoogleDriveSettingsPanel.tsx
+++ b/src/components/profile/GoogleDriveSettingsPanel.tsx
@@ -104,7 +104,7 @@ export function GoogleDriveSettingsPanel({ accessToken }: GoogleDriveSettingsPan
 
   if (!accessToken) {
     return (
-      <Alert className="border-fuchsia-500/20 bg-[#171320] text-muted-foreground shadow-[0_0_0_1px_rgba(217,70,239,0.06)]">
+      <Alert className="border-fuchsia-500/20 bg-fuchsia-500/5 text-muted-foreground shadow-[0_0_0_1px_rgba(217,70,239,0.06)] dark:bg-[#171320]">
         <Shield className="h-4 w-4 text-fuchsia-300" />
         <AlertTitle className="font-mono">session_required</AlertTitle>
         <AlertDescription className="font-mono text-xs sm:text-sm">
@@ -116,10 +116,10 @@ export function GoogleDriveSettingsPanel({ accessToken }: GoogleDriveSettingsPan
 
   if (loading) {
     return (
-      <Card className="border border-fuchsia-500/20 bg-[#110d18] shadow-[0_0_30px_rgba(168,85,247,0.10)]">
+      <Card className="border border-fuchsia-500/20 bg-card dark:bg-[#110d18] dark:shadow-[0_0_30px_rgba(168,85,247,0.10)]">
         <CardHeader>
           <CardTitle className="font-mono text-xl">google_drive_storage</CardTitle>
-          <CardDescription className="font-mono text-xs tracking-[0.2em] text-fuchsia-200/70">
+          <CardDescription className="font-mono text-xs tracking-[0.2em] text-fuchsia-700/70 dark:text-fuchsia-200/70">
             loading drive link status...
           </CardDescription>
         </CardHeader>
@@ -144,12 +144,12 @@ export function GoogleDriveSettingsPanel({ accessToken }: GoogleDriveSettingsPan
 
   return (
     <div className="space-y-6">
-      <Card className="border border-fuchsia-500/20 bg-[radial-gradient(circle_at_top_left,rgba(217,70,239,0.12),transparent_34%),radial-gradient(circle_at_bottom_right,rgba(34,211,238,0.10),transparent_30%),#110d18] shadow-[0_0_36px_rgba(168,85,247,0.12)]">
+      <Card className="border border-fuchsia-500/20 bg-card shadow-none dark:bg-[radial-gradient(circle_at_top_left,rgba(217,70,239,0.12),transparent_34%),radial-gradient(circle_at_bottom_right,rgba(34,211,238,0.10),transparent_30%),#110d18] dark:shadow-[0_0_36px_rgba(168,85,247,0.12)]">
         <CardHeader>
           <CardTitle className="font-mono text-xl">google_drive_storage</CardTitle>
           <CardDescription className="font-mono text-sm text-muted-foreground">
             refhub keeps google credentials on the backend and writes pdfs into a managed drive folder named
-            <span className="text-fuchsia-200"> refhub</span>.
+            <span className="text-fuchsia-700 dark:text-fuchsia-200"> refhub</span>.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-5">
@@ -162,18 +162,18 @@ export function GoogleDriveSettingsPanel({ accessToken }: GoogleDriveSettingsPan
             </Badge>
           </div>
 
-          <Alert className="border-fuchsia-500/20 bg-[#171320] text-muted-foreground">
+          <Alert className="border-fuchsia-500/20 bg-fuchsia-500/5 text-muted-foreground dark:bg-[#171320]">
             <Shield className="h-4 w-4 text-cyan-300" />
             <AlertTitle className="font-mono">least_privilege_scope</AlertTitle>
             <AlertDescription className="font-mono text-xs sm:text-sm">
-              refhub requests <span className="text-fuchsia-200">drive.file</span> only. it can manage files it creates
+              refhub requests <span className="text-fuchsia-700 dark:text-fuchsia-200">drive.file</span> only. it can manage files it creates
               inside the linked folder, without exposing google tokens to the frontend or extension.
             </AlertDescription>
           </Alert>
 
           <div className="grid gap-4 md:grid-cols-2">
-            <div className="rounded-xl border border-fuchsia-500/15 bg-[#16111f] p-4">
-              <div className="mb-2 flex items-center gap-2 font-mono text-sm text-fuchsia-100">
+            <div className="rounded-xl border border-fuchsia-500/15 bg-muted/40 p-4 dark:bg-[#16111f]">
+              <div className="mb-2 flex items-center gap-2 font-mono text-sm text-fuchsia-900 dark:text-fuchsia-100">
                 <HardDrive className="h-4 w-4 text-fuchsia-300" />
                 link_status
               </div>
@@ -183,8 +183,8 @@ export function GoogleDriveSettingsPanel({ accessToken }: GoogleDriveSettingsPan
                   : 'connect google drive to enable backend-mediated pdf storage.'}
               </p>
             </div>
-            <div className="rounded-xl border border-cyan-500/15 bg-[#141320] p-4">
-              <div className="mb-2 flex items-center gap-2 font-mono text-sm text-cyan-100">
+            <div className="rounded-xl border border-cyan-500/15 bg-muted/40 p-4 dark:bg-[#141320]">
+              <div className="mb-2 flex items-center gap-2 font-mono text-sm text-cyan-900 dark:text-cyan-100">
                 <Link2 className="h-4 w-4 text-cyan-300" />
                 target_folder
               </div>
@@ -229,7 +229,7 @@ export function GoogleDriveSettingsPanel({ accessToken }: GoogleDriveSettingsPan
               <Button
                 type="button"
                 variant="outline"
-                className="border-fuchsia-500/30 bg-fuchsia-500/10 font-mono text-fuchsia-100 hover:bg-fuchsia-500/20 hover:text-fuchsia-50"
+                className="border-fuchsia-500/30 bg-fuchsia-500/10 font-mono text-fuchsia-900 hover:bg-fuchsia-500/20 hover:text-fuchsia-950 dark:text-fuchsia-100 dark:hover:text-fuchsia-50"
                 onClick={() => void handleEnsureFolder()}
                 disabled={!currentStatus.linked || action !== null}
               >
@@ -240,7 +240,7 @@ export function GoogleDriveSettingsPanel({ accessToken }: GoogleDriveSettingsPan
             <Button
               type="button"
               variant="ghost"
-              className="font-mono text-cyan-100 hover:bg-cyan-500/10 hover:text-cyan-50"
+              className="font-mono text-cyan-900 hover:bg-cyan-500/10 hover:text-cyan-950 dark:text-cyan-100 dark:hover:text-cyan-50"
               onClick={() => void handleDisconnect()}
               disabled={!currentStatus.linked || action !== null}
             >

--- a/src/components/publications/PublicationDialog.tsx
+++ b/src/components/publications/PublicationDialog.tsx
@@ -375,10 +375,11 @@ export function PublicationDialog({
       );
       setModifiedFields(new Set());
       setLastSavedAt(new Date());
+      fullscreenCleanNotesRef.current = formData.notes;
     } finally {
       setSaving(false);
     }
-  }, [onSave, publication, selectedVaultIds]);
+  }, [onSave, publication, selectedVaultIds, formData.notes]);
 
   // ─── Exit fullscreen helper ────────────────────────────────────────────────
   const handleExitFullscreen = useCallback(() => {

--- a/src/components/ui/OnboardingWelcomeDialog.tsx
+++ b/src/components/ui/OnboardingWelcomeDialog.tsx
@@ -158,7 +158,7 @@ export function OnboardingWelcomeDialog({ open, onOpenChange, onOpenGuide }: Onb
           <Button variant="ghost" className="font-mono" onClick={() => onOpenChange(false)}>
             skip
           </Button>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap justify-end gap-2">
             <Button
               variant="outline"
               className="font-mono"

--- a/src/components/ui/inline-feedback.tsx
+++ b/src/components/ui/inline-feedback.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import {
   QuotermHost,
   type QuotermHostProps,
@@ -11,10 +12,30 @@ export type InlineFeedbackHostProps = QuotermHostProps & {
   commandName?: string;
 };
 
-export function InlineFeedbackHost({ commandName, formatCommand, ...props }: InlineFeedbackHostProps) {
+// Theme lives as a `dark` class on <html> (see ThemeToggle.tsx / main.tsx), not
+// in any shared context, so quoterm needs its own observer to stay in sync.
+function useResolvedTheme(): "light" | "dark" {
+  const [isDark, setIsDark] = useState(
+    () => typeof document !== "undefined" && document.documentElement.classList.contains("dark")
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    setIsDark(root.classList.contains("dark"));
+    const observer = new MutationObserver(() => setIsDark(root.classList.contains("dark")));
+    observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark ? "dark" : "light";
+}
+
+export function InlineFeedbackHost({ commandName, formatCommand, theme, ...props }: InlineFeedbackHostProps) {
+  const resolvedTheme = useResolvedTheme();
   return (
     <QuotermHost
       {...props}
+      theme={theme ?? resolvedTheme}
       formatCommand={(variant: QuotermVariant, item: QuotermState) => {
         if (formatCommand) return formatCommand(variant, item);
         return item.command ?? (commandName ? `${commandName} --${item.variant}` : "");

--- a/src/index.css
+++ b/src/index.css
@@ -214,11 +214,27 @@
   }
 }
 
-@layer components {
-  .quoterm-fallback-root {
-    top: calc(env(safe-area-inset-top, 0px) + 1.5rem) !important;
-    left: calc(env(safe-area-inset-left, 0px) + 1.5rem) !important;
-  }
+/* No anchor source element to position against: center the fallback toast
+   horizontally and pick top vs. bottom by variant (success/info read as
+   ambient status, warning/error read as blocking and sit near the action).
+   Kept out of @layer components: Tailwind's content-based tree-shaking
+   silently drops sibling rules sharing this selector when layered. */
+.quoterm-fallback-root {
+  left: 50% !important;
+  right: auto !important;
+  transform: translateX(-50%);
+}
+
+.quoterm-fallback-root:has(.quoterm--success),
+.quoterm-fallback-root:has(.quoterm--info) {
+  top: calc(env(safe-area-inset-top, 0px) + 1.5rem) !important;
+  bottom: auto !important;
+}
+
+.quoterm-fallback-root:has(.quoterm--warning),
+.quoterm-fallback-root:has(.quoterm--error) {
+  top: auto !important;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 1.5rem) !important;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- Fixes #147: account settings storage tab (`GoogleDriveSettingsPanel`) now respects light/dark mode instead of always rendering dark; `InlineFeedbackHost` (quoterm toasts) now syncs with the app's theme toggle via a `dark` class observer. Also improves quoterm's fallback (no anchor element) positioning: success/info toasts render top-center, warning/error render bottom-center, each padded from the viewport edge.
- Fixes #141: saving notes in the fullscreen editor no longer leaves a stale "dirty" snapshot, which was causing a spurious "unsaved changes" prompt when exiting fullscreen right after a successful save.
- Fixes #138: the onboarding dialog's last-step button row (`back` / `open guide` / `next`) now wraps instead of overflowing on narrow mobile viewports.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint` on changed files — clean
- [x] Verified in a headless browser against the dev server: quoterm fallback toasts compute the expected `top`/`bottom`/centered `left` for all four variants (success/info/warning/error), and the landing page renders with no console errors
- [ ] Manual check of the storage tab in light mode and the notes-editor fullscreen save flow in a logged-in session (not exercised here — requires an authenticated account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)