### PR TITLE
Scale vault-augment related-paper limit, fix cold-load repaint glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this
 project uses [Semantic Versioning](https://semver.org/). History prior to
 1.4.2 was not tracked in this file.
 
+## [1.4.5] - 2026-07-17
+
+### Fixed
+- Vault augmentation's "related" tab now requests a number of recommended
+  papers proportional to how many papers were selected (5 per seed paper)
+  instead of a fixed 20 regardless of batch size.
+- Worked around a rendering issue where, on a fresh page load, the first
+  vault-augment fetch could commit its results without the results pane
+  repainting (tab count showed the right number, but the list appeared
+  empty until switching tabs or refocusing the window). The pane now forces
+  a reflow as soon as new papers land.
+
 ## [1.4.4] - 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ project uses [Semantic Versioning](https://semver.org/). History prior to
 - Vault augmentation's "related" tab now requests a number of recommended
   papers proportional to how many papers were selected (5 per seed paper)
   instead of a fixed 20 regardless of batch size.
-- Worked around a rendering issue where, on a fresh page load, the first
-  vault-augment fetch could commit its results without the results pane
-  repainting (tab count showed the right number, but the list appeared
-  empty until switching tabs or refocusing the window). The pane now forces
-  a reflow as soon as new papers land.
+- Fixed the vault-augment dialog opening on its "topic" tab (with nothing
+  to show) on the very first run of a session, even though the "related"
+  tab already had results and its count was showing correctly. The active
+  tab is initialized before the vault's papers finish loading, so it never
+  got corrected once real seed papers arrived; the dialog now switches to
+  the "related" tab as soon as it has seed papers to work with.
 
 ## [1.4.4] - 2026-07-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.4.4",
+  "version": "1.4.5",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
 import { Publication } from '@/types/database';
 import {
   SSPaper,
@@ -31,6 +31,11 @@ import { SpinnerLoader } from '@/components/ui/loader';
 import { Plus, Check, ExternalLink, BookOpen, AlertCircle, RotateCcw, CheckCircle2, Search } from 'lucide-react';
 
 export type AugmentTab = 'references' | 'citations' | 'related' | 'topic';
+
+// How many recommended papers to request per seed paper in the vault's
+// selection, so the "related" result count scales with the batch instead of
+// staying fixed regardless of how many papers were selected.
+const RELATED_RESULTS_PER_SEED_PAPER = 5;
 
 export interface DiscoveredPaper {
   paper: SSPaper;
@@ -485,12 +490,15 @@ export function VaultAugmentDialog({
     // seed papers and returns a single deduplicated list. getRecommendationsForSet
     // chunks internally at 20 seeds per request, so vaults larger than that
     // still take more than one upstream call, just far fewer than one per paper.
+    // The result limit scales with how many seed papers went in, so a single
+    // selected paper isn't drowned in as many recommendations as a 10-paper set.
     const requestFailures = [...lookupFailures];
     const allSourcePubIds = resolved.map((r) => r.pubId);
     let discoveredPapers: SSPaper[] = [];
 
     try {
-      discoveredPapers = await getRecommendationsForSet(resolved.map((r) => r.ssId));
+      const limit = resolved.length * RELATED_RESULTS_PER_SEED_PAPER;
+      discoveredPapers = await getRecommendationsForSet(resolved.map((r) => r.ssId), limit);
     } catch (error) {
       // Push one TabFailure per resolved seed (not one for the whole batch) so
       // summarizeFailures' failures.length-based counting and pluralization
@@ -682,6 +690,17 @@ export function VaultAugmentDialog({
 
   const activePapers =
     activeTab === 'topic' ? topicResults : activeTab === 'related' ? related : activeTab === 'references' ? references : citations;
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // On a cold page load, this pane's first paint can land while the main
+  // thread is still busy with startup work, and some browsers commit the DOM
+  // update without repainting this backdrop-blurred, scrollable region --
+  // switching tabs or refocusing the window "fixes" it because those force a
+  // reflow. Reading offsetHeight right after new papers land forces that same
+  // reflow synchronously instead of waiting on an unrelated user action.
+  useLayoutEffect(() => {
+    void scrollContainerRef.current?.offsetHeight;
+  }, [activePapers]);
   const activeStatus = tabStatus[activeTab];
   const initialLoading = !isTopicDiscovery && tabStatus.related.state === 'loading' && related.length === 0;
   const acknowledgeTab = (tab: AugmentTab) => {
@@ -783,7 +802,7 @@ export function VaultAugmentDialog({
               }}
             />
 
-            <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden scrollbar-thin px-6 pb-4 pt-2">
+            <div ref={scrollContainerRef} className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden scrollbar-thin px-6 pb-4 pt-2">
               {activeStatus.state === 'loading' && activePapers.length === 0 ? (
                 <div className="flex items-center justify-center gap-3 text-muted-foreground py-8">
                   <SpinnerLoader className="w-4 h-4" />

--- a/src/components/publications/VaultAugmentDialog.tsx
+++ b/src/components/publications/VaultAugmentDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Publication } from '@/types/database';
 import {
   SSPaper,
@@ -649,6 +649,15 @@ export function VaultAugmentDialog({
     if (open && isTopicDiscovery) {
       setActiveTab('topic');
     }
+    // publications loads asynchronously, so isTopicDiscovery (and activeTab's
+    // useState initializer, which only runs once at mount) can both still say
+    // 'topic' from before real seed papers arrived. Once we know better, move
+    // off of it -- otherwise the dialog opens on a tab with no content while
+    // the related/references/citations tabs (which do have results) sit
+    // unselected.
+    if (open && !isTopicDiscovery && activeTab === 'topic') {
+      setActiveTab('related');
+    }
     if (!open) {
       fetchedTabs.current = new Set();
       resolvedPaperIds.current = [];
@@ -663,7 +672,7 @@ export function VaultAugmentDialog({
       setTabStatus(createIdleTabStatus());
       setAcknowledgedTabs(new Set());
     }
-  }, [open, fetchRelated, isTopicDiscovery]);
+  }, [open, fetchRelated, isTopicDiscovery, activeTab]);
 
   // Switch tab → lazy-load refs/citations if not yet fetched
   const handleTabChange = (tab: AugmentTab) => {
@@ -691,16 +700,6 @@ export function VaultAugmentDialog({
   const activePapers =
     activeTab === 'topic' ? topicResults : activeTab === 'related' ? related : activeTab === 'references' ? references : citations;
 
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  // On a cold page load, this pane's first paint can land while the main
-  // thread is still busy with startup work, and some browsers commit the DOM
-  // update without repainting this backdrop-blurred, scrollable region --
-  // switching tabs or refocusing the window "fixes" it because those force a
-  // reflow. Reading offsetHeight right after new papers land forces that same
-  // reflow synchronously instead of waiting on an unrelated user action.
-  useLayoutEffect(() => {
-    void scrollContainerRef.current?.offsetHeight;
-  }, [activePapers]);
   const activeStatus = tabStatus[activeTab];
   const initialLoading = !isTopicDiscovery && tabStatus.related.state === 'loading' && related.length === 0;
   const acknowledgeTab = (tab: AugmentTab) => {
@@ -802,7 +801,7 @@ export function VaultAugmentDialog({
               }}
             />
 
-            <div ref={scrollContainerRef} className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden scrollbar-thin px-6 pb-4 pt-2">
+            <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden scrollbar-thin px-6 pb-4 pt-2">
               {activeStatus.state === 'loading' && activePapers.length === 0 ? (
                 <div className="flex items-center justify-center gap-3 text-muted-foreground py-8">
                   <SpinnerLoader className="w-4 h-4" />

--- a/src/lib/semanticScholar.test.ts
+++ b/src/lib/semanticScholar.test.ts
@@ -128,6 +128,22 @@ describe('semanticScholar', () => {
     expect(papers).toEqual([expect.objectContaining({ paperId: 'rec-1' })]);
   });
 
+  it('honors a custom limit for recommendations across a seed set', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ paper_id: 'rec-1', title: 'Recommended' }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    await getRecommendationsForSet(['p1', 'p2'], 10);
+
+    expect(fetch).toHaveBeenCalledWith('https://refhub.test/recommendations', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ paper_ids: ['p1', 'p2'], limit: 10 }),
+    }));
+  });
+
   it('chunks recommendation requests once the seed set exceeds the batch cap', async () => {
     vi.mocked(fetch).mockResolvedValue(
       new Response(

--- a/src/lib/semanticScholar.ts
+++ b/src/lib/semanticScholar.ts
@@ -518,11 +518,11 @@ export async function getRecommendations(paperId: string): Promise<SSPaper[]> {
   return papers;
 }
 
-export async function getRecommendationsForSet(paperIds: string[]): Promise<SSPaper[]> {
+export async function getRecommendationsForSet(paperIds: string[], limit = 20): Promise<SSPaper[]> {
   if (paperIds.length === 0) return [];
 
   const dedupedPaperIds = [...new Set(paperIds)].filter(Boolean);
-  const cacheKey = `recs-set:${[...dedupedPaperIds].sort().join(',')}`;
+  const cacheKey = `recs-set:${[...dedupedPaperIds].sort().join(',')}:${limit}`;
   if (paperCache.has(cacheKey)) return paperCache.get(cacheKey)!;
 
   // The backend caps a single batch at MAX_RECOMMENDATION_SEED_IDS_PER_REQUEST
@@ -531,7 +531,7 @@ export async function getRecommendationsForSet(paperIds: string[]): Promise<SSPa
   const seedChunks = chunk(dedupedPaperIds, MAX_RECOMMENDATION_SEED_IDS_PER_REQUEST);
   const recommendationSets = await runSemanticScholarQueue(
     seedChunks,
-    (seedChunk) => fetchRecommendationsFromBackend(seedChunk, 20),
+    (seedChunk) => fetchRecommendationsFromBackend(seedChunk, limit),
     // Each request already batches up to 20 seeds and the backend enforces
     // its own global rate limit, so the queue's default inter-request delay
     // (meant for the old one-request-per-paper pattern) is unnecessary here.


### PR DESCRIPTION
## Summary
- `getRecommendationsForSet` now accepts a `limit` param; the vault-augment "related" tab requests 5 recommended papers per selected seed paper instead of a fixed 20 regardless of how many papers are in the batch.
- Fixed the actual root cause of the "tab count is right but the body says `// no_results_found`" bug, root-caused with the help of temporary console logging: `activeTab`'s `useState` initializer runs once at mount, before the vault's `publications` prop finishes loading, so on the first run of a session it can get stuck on `'topic'` even after real seed papers arrive and the "related" tab has results. The dialog now switches off of `'topic'` as soon as it has seed papers to work with. This replaces the previous commit's speculative reflow/repaint workaround, which wasn't the real cause and has been removed.
- Patch version bump to 1.4.5 + CHANGELOG entry per this repo's versioning policy.

## Test plan
- [x] `npx vitest run` — 44/44 passing (added a test for the new `limit` param on `getRecommendationsForSet`)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] Root-caused via console logging (`activeTab` stuck on `'topic'` while `related.length` was already 15) and confirmed the fix addresses that exact sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)