### PR TITLE
Populate ai_workflows help tab with agent workflows guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this
 project uses [Semantic Versioning](https://semver.org/). History prior to
 1.4.2 was not tracked in this file.
 
+## [1.6.2] - 2026-07-18
+
+### Added
+- ai_workflows tab in the help center: a full agent-workflows guide covering
+  api key setup, cli install, per-harness skill install (claude code, codex,
+  gemini cli, opencode, generic harnesses), and worked use cases — importing
+  literature with notes and tags, vault administration, literature discovery,
+  and grounded paper drafting — plus prompting tips and a `copy_guide` header
+  action that copies the whole guide as markdown for agent contexts. (#161)
+- Copy button on every fenced code block rendered through the markdown
+  renderer; github.com links in the help-center tabs get a small GitHub icon.
+
+### Fixed
+- Fenced code blocks now get theme-aware syntax highlighting (token colors
+  derive from the design-system palette; cli entry points like `refhub` and
+  `claude` highlight as executable commands), no longer indent their first
+  line, and long lines scroll inside the block instead of stretching the
+  help dialog.
+
+### Changed
+- Resources tab: removed the empty `refhub-mcp` entry and renamed the
+  `.netlify` listing to `refhub-api` (display only; url unchanged).
+
 ## [1.6.0] - 2026-07-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.6.0",
+        "highlight.js": "^11.11.1",
         "idb-keyval": "^6.2.2",
         "input-otp": "^1.4.2",
         "katex": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.7.0",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",
@@ -55,6 +55,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",
+    "highlight.js": "^11.11.1",
     "idb-keyval": "^6.2.2",
     "input-otp": "^1.4.2",
     "katex": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.6.2",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/ui/KeyboardHelpOverlay.test.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.test.tsx
@@ -107,39 +107,48 @@ describe('KeyboardHelpOverlay new tabs', () => {
 
   it('shows a copy_guide button only on the ai-workflows tab that copies the guide markdown', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
     Object.defineProperty(navigator, 'clipboard', {
       value: { writeText },
       configurable: true,
     });
 
-    let keyboardTabRender: ReturnType<typeof render>;
-    await act(async () => {
-      keyboardTabRender = render(
-        <KeyboardProvider>
-          <Harness tab="keyboard" />
-        </KeyboardProvider>,
-      );
-    });
-    expect(screen.queryByRole('button', { name: /copy_guide/i })).not.toBeInTheDocument();
+    try {
+      let keyboardTabRender: ReturnType<typeof render>;
+      await act(async () => {
+        keyboardTabRender = render(
+          <KeyboardProvider>
+            <Harness tab="keyboard" />
+          </KeyboardProvider>,
+        );
+      });
+      expect(screen.queryByRole('button', { name: /copy_guide/i })).not.toBeInTheDocument();
 
-    await act(async () => {
-      keyboardTabRender.unmount();
-    });
+      await act(async () => {
+        keyboardTabRender.unmount();
+      });
 
-    await act(async () => {
-      render(
-        <KeyboardProvider>
-          <Harness tab="ai-workflows" />
-        </KeyboardProvider>,
-      );
-    });
+      await act(async () => {
+        render(
+          <KeyboardProvider>
+            <Harness tab="ai-workflows" />
+          </KeyboardProvider>,
+        );
+      });
 
-    const copyButton = await screen.findByRole('button', { name: /copy_guide/i });
-    await act(async () => {
-      copyButton.click();
-    });
+      const copyButton = await screen.findByRole('button', { name: /copy_guide/i });
+      await act(async () => {
+        copyButton.click();
+      });
 
-    expect(writeText).toHaveBeenCalledTimes(1);
-    expect(writeText.mock.calls[0][0]).toContain('# ai agent workflows');
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText.mock.calls[0][0]).toContain('# ai agent workflows');
+    } finally {
+      if (clipboardDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
+      } else {
+        delete (navigator as any).clipboard;
+      }
+    }
   });
 });

--- a/src/components/ui/KeyboardHelpOverlay.test.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.test.tsx
@@ -147,7 +147,7 @@ describe('KeyboardHelpOverlay new tabs', () => {
       if (clipboardDescriptor) {
         Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
       } else {
-        delete (navigator as any).clipboard;
+        Reflect.deleteProperty(navigator, 'clipboard');
       }
     }
   });

--- a/src/components/ui/KeyboardHelpOverlay.test.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.test.tsx
@@ -104,4 +104,42 @@ describe('KeyboardHelpOverlay new tabs', () => {
     expect(restartSpy).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
+
+  it('shows a copy_guide button only on the ai-workflows tab that copies the guide markdown', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    let keyboardTabRender: ReturnType<typeof render>;
+    await act(async () => {
+      keyboardTabRender = render(
+        <KeyboardProvider>
+          <Harness tab="keyboard" />
+        </KeyboardProvider>,
+      );
+    });
+    expect(screen.queryByRole('button', { name: /copy_guide/i })).not.toBeInTheDocument();
+
+    await act(async () => {
+      keyboardTabRender.unmount();
+    });
+
+    await act(async () => {
+      render(
+        <KeyboardProvider>
+          <Harness tab="ai-workflows" />
+        </KeyboardProvider>,
+      );
+    });
+
+    const copyButton = await screen.findByRole('button', { name: /copy_guide/i });
+    await act(async () => {
+      copyButton.click();
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain('# ai agent workflows');
+  });
 });

--- a/src/components/ui/KeyboardHelpOverlay.test.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.test.tsx
@@ -49,7 +49,7 @@ describe('KeyboardHelpOverlay new tabs', () => {
     }
   });
 
-  it('shows a coming-soon placeholder on the ai-workflows tab', async () => {
+  it('renders the ai agent workflows guide on the ai-workflows tab', async () => {
     await act(async () => {
       render(
         <KeyboardProvider>
@@ -62,7 +62,10 @@ describe('KeyboardHelpOverlay new tabs', () => {
       'data-state',
       'active',
     );
-    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: /ai agent workflows/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
   });
 
   it('shows a restart_tour button only on the guide tab, which closes the overlay and restarts onboarding', async () => {

--- a/src/components/ui/KeyboardHelpOverlay.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.tsx
@@ -38,6 +38,7 @@ export function KeyboardHelpOverlay() {
   } = useKeyboardContext();
   const { toast } = useToast();
   const [copied, setCopied] = useState(false);
+  const [guideCopied, setGuideCopied] = useState(false);
 
   // Register the ? shortcut globally to toggle the help center.
   useHotkeys(
@@ -79,6 +80,17 @@ export function KeyboardHelpOverlay() {
     restartOnboarding();
   }, [setHelpOverlayOpen]);
 
+  const handleCopyGuide = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(aiWorkflowsGuide);
+      setGuideCopied(true);
+      toast({ title: 'workflows guide copied to clipboard' });
+      setTimeout(() => setGuideCopied(false), 2000);
+    } catch {
+      toast({ title: 'failed to copy', variant: 'destructive', feedbackSeverity: 'error' });
+    }
+  }, [toast]);
+
   return (
     <Dialog open={helpOverlayOpen} onOpenChange={setHelpOverlayOpen}>
       <DialogContent className="dialog-mobile max-w-[100vw] flex flex-col overflow-hidden p-0 gap-0 border-primary/20 shadow-2xl shadow-primary/10 sm:rounded-2xl sm:max-w-3xl sm:h-[85vh] sm:max-h-[85vh]">
@@ -115,6 +127,21 @@ export function KeyboardHelpOverlay() {
               >
                 <RotateCcw className="w-3 h-3 mr-1" />
                 restart_tour
+              </Button>
+            )}
+            {helpOverlayTab === 'ai-workflows' && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleCopyGuide}
+                className="h-7 font-mono text-[10px] text-muted-foreground hover:text-foreground"
+              >
+                {guideCopied ? (
+                  <Check className="w-3 h-3 mr-1 text-accent" />
+                ) : (
+                  <Copy className="w-3 h-3 mr-1" />
+                )}
+                {guideCopied ? 'copied!' : 'copy_guide'}
               </Button>
             )}
           </div>

--- a/src/components/ui/KeyboardHelpOverlay.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.tsx
@@ -4,6 +4,7 @@ import { useHotkeys } from '@/hooks/useKeyboardNavigation';
 import { SHORTCUT_HELP, formatCombo } from '@/lib/keyboard';
 import { cn } from '@/lib/utils';
 import helpGuide from '@/content/help-guide.md?raw';
+import aiWorkflowsGuide from '@/content/ai-workflows.md?raw';
 import { resources } from '@/config/resources';
 import { restartOnboarding } from '@/hooks/useOnboarding';
 import {
@@ -232,15 +233,11 @@ export function KeyboardHelpOverlay() {
           </TabsContent>
 
           <TabsContent value="ai-workflows" className="m-0 min-h-0 flex-1 overflow-hidden data-[state=inactive]:hidden">
-            <div className="h-full flex flex-col items-center justify-center gap-3 px-6 text-center">
-              <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                <Bot className="h-5 w-5" />
-              </div>
-              <h3 className="font-mono text-base font-semibold">ai_workflow_guides()</h3>
-              <p className="text-sm text-muted-foreground max-w-sm">
-                guides for using refhub with ai agents and workflows are coming soon.
-              </p>
-            </div>
+            <ScrollArea className="h-full max-h-full">
+              <MarkdownRenderer compact className="px-6 py-5 prose-headings:font-mono prose-h1:mt-0 prose-h2:border-t prose-h2:border-border/60 prose-h2:pt-5">
+                {aiWorkflowsGuide}
+              </MarkdownRenderer>
+            </ScrollArea>
           </TabsContent>
         </Tabs>
 

--- a/src/components/ui/KeyboardHelpOverlay.tsx
+++ b/src/components/ui/KeyboardHelpOverlay.tsx
@@ -230,8 +230,10 @@ export function KeyboardHelpOverlay() {
           </TabsContent>
 
           <TabsContent value="guide" className="m-0 min-h-0 flex-1 overflow-hidden data-[state=inactive]:hidden">
-            <ScrollArea className="h-full max-h-full">
-              <MarkdownRenderer compact className="px-6 py-5 prose-headings:font-mono prose-h1:mt-0 prose-h2:border-t prose-h2:border-border/60 prose-h2:pt-5">
+            {/* Radix wraps viewport content in a display:table div that grows to the
+                widest code line; force it block so prose wraps and pre scrolls. */}
+            <ScrollArea className="h-full max-h-full [&_[data-radix-scroll-area-viewport]>div]:!block">
+              <MarkdownRenderer compact githubLinkIcons className="px-6 py-5 prose-headings:font-mono prose-h1:mt-0 prose-h2:border-t prose-h2:border-border/60 prose-h2:pt-5">
                 {helpGuide}
               </MarkdownRenderer>
             </ScrollArea>
@@ -260,8 +262,8 @@ export function KeyboardHelpOverlay() {
           </TabsContent>
 
           <TabsContent value="ai-workflows" className="m-0 min-h-0 flex-1 overflow-hidden data-[state=inactive]:hidden">
-            <ScrollArea className="h-full max-h-full">
-              <MarkdownRenderer compact className="px-6 py-5 prose-headings:font-mono prose-h1:mt-0 prose-h2:border-t prose-h2:border-border/60 prose-h2:pt-5">
+            <ScrollArea className="h-full max-h-full [&_[data-radix-scroll-area-viewport]>div]:!block">
+              <MarkdownRenderer compact githubLinkIcons className="px-6 py-5 prose-headings:font-mono prose-h1:mt-0 prose-h2:border-t prose-h2:border-border/60 prose-h2:pt-5">
                 {aiWorkflowsGuide}
               </MarkdownRenderer>
             </ScrollArea>

--- a/src/components/ui/MarkdownRenderer.test.tsx
+++ b/src/components/ui/MarkdownRenderer.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
 import { MarkdownRenderer } from './MarkdownRenderer';
 
 describe('MarkdownRenderer math support', () => {
@@ -49,5 +49,56 @@ describe('MarkdownRenderer math support', () => {
     );
     expect(container.querySelector('script')).toBeNull();
     expect(container.textContent).toContain('ok');
+  });
+});
+
+describe('MarkdownRenderer code blocks and links', () => {
+  it('renders a copy button on fenced code blocks that copies the code text', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const priorDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    try {
+      const { getByRole } = render(
+        <MarkdownRenderer>{'```bash\nrefhub vaults list\n```'}</MarkdownRenderer>,
+      );
+      fireEvent.click(getByRole('button', { name: /copy code/i }));
+      await vi.waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+      expect(writeText).toHaveBeenCalledWith('refhub vaults list');
+    } finally {
+      if (priorDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', priorDescriptor);
+      } else {
+        Reflect.deleteProperty(navigator, 'clipboard');
+      }
+    }
+  });
+
+  it('highlights cli entry points as built_in in bash blocks', () => {
+    const { container } = render(
+      <MarkdownRenderer>{'```bash\nrefhub vaults list\n```'}</MarkdownRenderer>,
+    );
+    const builtIns = [...container.querySelectorAll('pre code .hljs-built_in')].map(
+      (el) => el.textContent,
+    );
+    expect(builtIns).toContain('refhub');
+  });
+
+  it('prefixes github.com links with an icon only when githubLinkIcons is set', () => {
+    const md = '[refhub-cli](https://github.com/refhub-io/refhub-cli) and [docs](https://example.com)';
+    const { container: plain } = render(<MarkdownRenderer>{md}</MarkdownRenderer>);
+    expect(plain.querySelector('a svg')).toBeNull();
+
+    const { container: decorated } = render(
+      <MarkdownRenderer githubLinkIcons>{md}</MarkdownRenderer>,
+    );
+    const links = [...decorated.querySelectorAll('a')];
+    const github = links.find((a) => a.href.includes('github.com'));
+    const external = links.find((a) => a.href.includes('example.com'));
+    expect(github?.querySelector('svg')).not.toBeNull();
+    expect(external?.querySelector('svg')).toBeNull();
   });
 });

--- a/src/components/ui/MarkdownRenderer.tsx
+++ b/src/components/ui/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef, useState, type HTMLAttributes } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
@@ -8,9 +8,12 @@ import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeHighlight from 'rehype-highlight';
+import bash from 'highlight.js/lib/languages/bash';
+import type { HLJSApi, Language } from 'highlight.js';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
+import { Check, Copy, Github } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const SINGLE_LINE_DISPLAY_MATH = /^\s*\$\$([^\n]*?)\$\$\s*$/;
@@ -75,9 +78,67 @@ interface MarkdownRendererProps {
   className?: string;
   /** Use compact prose sizing (prose-sm) */
   compact?: boolean;
+  /** Prefix links to github.com with a small GitHub icon */
+  githubLinkIcons?: boolean;
 }
 
-export function MarkdownRenderer({ children, className, compact = false }: MarkdownRendererProps) {
+const GITHUB_LINK = /^https?:\/\/(www\.)?github\.com\//;
+
+/** bash grammar extended so CLI entry points (`refhub`, `claude`, …) read as
+ *  executable commands instead of unstyled text. */
+function bashWithCliTools(hljs: HLJSApi): Language {
+  const def = bash(hljs);
+  def.contains = [
+    {
+      scope: 'built_in',
+      begin: /\b(?:refhub|claude|codex|gemini|npm|npx|node|git|curl|jq)(?=\s|$)/,
+    },
+    ...(def.contains ?? []),
+  ];
+  return def;
+}
+
+/** Fenced code block with a hover copy button. Copies the rendered text
+ *  (post-highlight innerText), so what you copy is what you see. */
+function CodeBlock({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    const text = preRef.current?.textContent ?? '';
+    try {
+      await navigator.clipboard.writeText(text.replace(/\n$/, ''));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable (permissions/insecure context) — leave button as-is
+    }
+  }, []);
+
+  return (
+    <div className="relative group/code">
+      <pre ref={preRef} {...props}>
+        {children}
+      </pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label="copy code"
+        title="copy code"
+        className="absolute right-2 top-2 rounded-md border border-border/60 bg-background/80 p-1.5 text-muted-foreground opacity-60 backdrop-blur-sm transition-opacity hover:text-foreground group-hover/code:opacity-100 focus-visible:opacity-100"
+      >
+        {copied ? <Check className="h-3.5 w-3.5 text-accent" /> : <Copy className="h-3.5 w-3.5" />}
+      </button>
+    </div>
+  );
+}
+
+export function MarkdownRenderer({
+  children,
+  className,
+  compact = false,
+  githubLinkIcons = false,
+}: MarkdownRendererProps) {
   const normalizedChildren = useMemo(() => normalizeMathBlocks(children), [children]);
 
   return (
@@ -98,6 +159,9 @@ export function MarkdownRenderer({ children, className, compact = false }: Markd
         // Code
         'prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono',
         'prose-pre:bg-muted prose-pre:p-4 prose-pre:rounded-lg prose-pre:overflow-x-auto',
+        // prose-code padding also hits pre>code, where the inline code element
+        // indents only the first line — reset it inside pre blocks.
+        '[&_pre_code]:p-0 [&_pre_code]:bg-transparent',
         // Blockquotes
         'prose-blockquote:border-l-4 prose-blockquote:border-primary prose-blockquote:pl-4 prose-blockquote:italic prose-blockquote:my-3',
         // Tables
@@ -138,10 +202,11 @@ export function MarkdownRenderer({ children, className, compact = false }: Markd
               children: [{ type: 'text', value: '#' }],
             },
           }],
-          rehypeHighlight,
+          [rehypeHighlight, { languages: { bash: bashWithCliTools } }],
           [rehypeKatex, { errorColor: 'hsl(var(--destructive))', strict: false, throwOnError: false }],
         ]}
         components={{
+          pre: ({ node, ...props }) => <CodeBlock {...props} />,
           a: ({ node, children, href, ...props }) => (
             <a
               href={href}
@@ -149,6 +214,9 @@ export function MarkdownRenderer({ children, className, compact = false }: Markd
               rel={href?.startsWith('#') ? undefined : 'noopener noreferrer'}
               {...props}
             >
+              {githubLinkIcons && GITHUB_LINK.test(href ?? '') && (
+                <Github aria-hidden="true" className="inline-block h-3.5 w-3.5 mr-1 align-[-2px]" />
+              )}
               {children}
             </a>
           ),

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -21,6 +21,19 @@ export interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
+    id: 16,
+    date: '2026-07-18',
+    title: 'ai agent workflows guide',
+    features: [
+      {
+        tag: 'feature',
+        title: 'ai_workflows help tab',
+        description:
+          'the help center now walks you from zero to agent-operated refhub: api key setup, cli install, per-harness skill install, and worked use cases — importing literature with notes and tags, vault administration, literature discovery, and grounded paper drafting. copy_guide puts the whole guide on your clipboard for any agent session.',
+      },
+    ],
+  },
+  {
     id: 15,
     date: '2026-07-18',
     title: 'find duplicates, resolve them git-style',

--- a/src/config/resources.ts
+++ b/src/config/resources.ts
@@ -16,7 +16,7 @@ export const resources: RefHubResource[] = [
     url: 'https://github.com/refhub-io/refhub.io',
   },
   {
-    name: '.netlify',
+    name: 'refhub-api',
     description: 'serverless backend / api layer.',
     url: 'https://github.com/refhub-io/.netlify',
   },
@@ -24,11 +24,6 @@ export const resources: RefHubResource[] = [
     name: 'refhub-skill',
     description: 'mcp skill for agents to read, write, and manage refhub vaults.',
     url: 'https://github.com/refhub-io/refhub-skill',
-  },
-  {
-    name: 'refhub-mcp',
-    description: 'mcp server implementation backing the refhub agent integrations.',
-    url: 'https://github.com/refhub-io/refhub-mcp',
   },
   {
     name: 'refhub-extensions',

--- a/src/content/ai-workflows.md
+++ b/src/content/ai-workflows.md
@@ -1,0 +1,216 @@
+# ai agent workflows
+
+refhub is built to be operated by ai agents as well as humans. this guide unfolds from zero — creating an api key and setting up the environment — through worked use cases: importing literature with notes and tags, administrating vaults, running literature discovery, and drafting a paper section grounded in your vault.
+
+## the stack
+
+the pieces fit together like this:
+
+- **refhub api** — the canonical surface. everything below adapts it; nothing invents behavior the api does not support.
+- **api key** — created in profile/settings, scoped and optionally vault-restricted. this is how agents authenticate.
+- **[refhub cli](https://github.com/refhub-io/refhub-cli)** (`@refhub/cli`) — the execution layer. agents run `refhub ...` commands instead of raw http calls: consistent auth, json output, and error handling.
+- **[refhub-skill](https://github.com/refhub-io/refhub-skill)** — an agent skill that teaches claude code, codex, gemini cli, opencode, cursor, and other harnesses the refhub workflows and exact route contracts.
+- **[refhub-paper-drafter](https://github.com/refhub-io/refhub-paper-drafter)** — a skill on top of both for drafting hci/visualization research papers from a vault and local notes.
+
+the **resources** tab in this help center links every refhub repository.
+
+## setup
+
+### 1. create an api key
+
+open profile/settings from the sidebar user menu, then **api keys**. create a key with:
+
+- a clear label per workflow, for example `claude_literature_agent`.
+- only the scopes needed: `vaults:read` for retrieval, `vaults:write` for adding/updating papers, tags, and relations, `vaults:export` for export workflows, `vaults:admin` only for vault management.
+- an optional expiration and optional vault restrictions.
+
+copy the secret when it is created — refhub only shows the key prefix later. a lost secret should be revoked and replaced.
+
+### 2. install the cli
+
+requires node ≥ 18.
+
+```bash
+npm install -g @refhub/cli
+refhub --help
+```
+
+output is json by default (pipe-friendly, e.g. into `jq`); add `--table` for human-readable tables. every command and subcommand answers `--help`.
+
+### 3. give the key to the environment — not the chat
+
+store the key in a local env file and let tools read `REFHUB_API_KEY` from the environment. never paste live keys into prompts, notes, or repositories.
+
+```bash
+mkdir -p ~/.config/refhub
+cat > ~/.config/refhub/env <<'EOF'
+export REFHUB_API_KEY='rhk_REPLACE_ME'
+EOF
+chmod 600 ~/.config/refhub/env
+```
+
+optional: wrap your agent launcher so the key loads automatically:
+
+```bash
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/claude-refhub <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+source "$HOME/.config/refhub/env"
+exec claude "$@"
+EOF
+chmod +x ~/.local/bin/claude-refhub
+```
+
+start the agent with `claude-refhub` (the same pattern works for `codex` or any other cli agent) and the key never appears in chat history.
+
+### 4. install the refhub skill
+
+[refhub-skill](https://github.com/refhub-io/refhub-skill) teaches the agent the workflows and route contracts.
+
+**claude code**
+
+```bash
+claude plugin marketplace add https://github.com/refhub-io/refhub-skill
+claude plugin install refhub-skill@refhub-skill
+```
+
+available in the next session; invoked automatically when you ask claude to work with refhub vaults or papers. the explicit https url matters: github shorthand clones over ssh, which fails on machines without a github ssh key.
+
+**codex** — add to `~/.agents/plugins/marketplace.json` (or the project-level `.agents/plugins/marketplace.json`):
+
+```json
+{
+  "name": "refhub-skill",
+  "source": { "source": "github", "repo": "refhub-io/refhub-skill" },
+  "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+  "category": "Productivity"
+}
+```
+
+**gemini cli / opencode** — download `SKILL.md` into the harness's skills directory:
+
+```bash
+mkdir -p ~/.gemini/skills/refhub-skill   # opencode: ~/.config/opencode/skills/refhub-skill
+curl -o ~/.gemini/skills/refhub-skill/SKILL.md \
+  https://raw.githubusercontent.com/refhub-io/refhub-skill/main/skills/refhub-skill/SKILL.md
+```
+
+**cursor, windsurf, and other generic harnesses** — copy the repo's `AGENTS.md` into your project root or your agent's rules/settings ui:
+
+```bash
+curl -O https://raw.githubusercontent.com/refhub-io/refhub-skill/main/AGENTS.md
+```
+
+### 5. verify
+
+```bash
+refhub vaults list
+```
+
+exit codes: `0` success · `1` api error · `2` bad arguments · `3` auth error. a `3` means the key is missing or invalid — check the env file and that your launcher sources it.
+
+## use case: add literature, notes, and tags
+
+ask the agent:
+
+> add these three dois to my visual-analytics vault, tag them evaluation > user-study, and note why each one matters for the related work section.
+
+with the skill installed, the agent resolves the vault and runs commands like:
+
+```bash
+refhub vaults list                                  # find the vault id
+refhub import doi --vault <id> --doi 10.1109/TVCG.2023.3327195
+refhub tags create --vault <id> --name evaluation
+refhub tags create --vault <id> --name user-study --parent <evaluationTagId>
+refhub tags attach --vault <id> --item <itemId> --tags <tagId>
+refhub items update --vault <id> <itemId> --notes "anchors the deep-dive comparison in related work"
+```
+
+bulk import works from bibtex or urls too: `refhub import bibtex --vault <id> --file refs.bib`.
+
+afterwards, fill metadata gaps from semantic scholar:
+
+```bash
+refhub enrich --vault <id> --dry-run   # preview what would change
+refhub enrich --vault <id>             # patch missing titles/authors/years/abstracts
+```
+
+**gotcha:** `items update --tags` fully replaces the item's tag list. use `tags attach` / `tags detach` to add or remove tags without clobbering the rest.
+
+## use case: create and administrate vaults
+
+> create a protected vault for the eurovis submission, invite my co-author as editor, and export the current bibliography.
+
+```bash
+refhub vaults create --name "eurovis-2027" --description "submission reading list" --visibility protected
+refhub vaults shares add <vaultId> --email coauthor@university.edu --role editor
+refhub export --vault <vaultId> --format bibtex > eurovis-2027.bib
+refhub audit --vault <vaultId> --since 2026-07-01T00:00:00Z   # who changed what, when
+```
+
+when the collection is ready for the codex:
+
+```bash
+refhub vaults visibility <vaultId> --visibility public --slug eurovis-2027
+```
+
+destructive commands are guarded: `vaults delete` and `items delete` require `--confirm` and are hard deletes with no undo.
+
+## use case: literature search and discovery
+
+semantic scholar discovery runs through refhub with just `vaults:read`:
+
+> find recent papers on progressive visual analytics, show me the ten most relevant, and add the ones i pick to my vault.
+
+```bash
+refhub discover search --query "progressive visual analytics" --limit 10
+refhub discover recommendations --paper DOI:10.1109/TVCG.2019.2934283 --limit 10
+refhub discover references --paper <paperId>     # what a paper cites
+refhub discover cited-by --paper <paperId>       # who cites it
+```
+
+results are json; save the picks and upsert them into the vault:
+
+```bash
+refhub discover search --query "progressive visual analytics" | jq .data > picks.json
+refhub discover add --vault <id> --file picks.json
+```
+
+open-access pdf links are mapped automatically where present. discovery requests may be queued or slowed — refhub stays within semantic scholar's rate limits, so this is normal. finish with `refhub enrich --vault <id>` to round out metadata.
+
+## use case: write my section / paper
+
+[refhub-paper-drafter](https://github.com/refhub-io/refhub-paper-drafter) drafts hci and visualization manuscripts from a refhub vault plus local notes. every claim traces to a source; nothing is invented.
+
+**prerequisites:** the cli and refhub-skill installed and authenticated (setup above). minimum scopes: `vaults:read`, plus `vaults:export` if using `refhub export`.
+
+**install (claude code):**
+
+```bash
+claude plugin marketplace add https://github.com/refhub-io/refhub-paper-drafter
+claude plugin install refhub-paper-drafter@refhub-paper-drafter
+```
+
+then invoke it:
+
+> /refhub-paper-drafter — draft the related work section for my eurovis paper from the eurovis-2027 vault and the notes in ./notes/.
+
+the skill works in phases:
+
+1. **collect** — reads local note files + queries the vault by tag hierarchy → builds a source map.
+2. **scaffold** — interactive back-and-forth to lock framing, contributions, and argument structure before writing.
+3. **draft** — prose from the source map only; ungrounded sentences are flagged `[NEEDS SOURCE: <claim>]`, never silently filled.
+4. **quality** — strips ai giveaways, hollow intensifiers, filler transitions, and vague claims.
+5. **review** — adversarial "reviewer 2" loop with severity-rated critiques (minor / major / fatal) and revision.
+6. **output** — markdown or functional latex → session, local file, or overleaf via git bridge.
+
+citations use each item's `bibtex_key`, and the exported `.bib` uses the same keys referenced by `\cite{}`. a manuscript is only marked submission-ready when the readiness gates pass: zero unresolved `[NEEDS SOURCE]` markers, no unresolved fatal reviewer findings, ethics/consent status, ai-use disclosure, reproducibility statement, and a figure/table inventory with alt text.
+
+## good practices
+
+- one dedicated key per workflow, minimal scopes, vault restrictions where possible. revoke and rotate from profile/settings when a workflow is retired or a secret may have leaked.
+- keep bibliographic fixes on the publication; tags, notes, and collection-specific context belong in the vault.
+- pdf upload (`refhub pdf upload --vault <id> --item <id> --file paper.pdf`) requires google drive connected in profile/settings → storage first; files up to 26 mb.
+- pipe json output for scripting: `refhub items search --vault <id> --q "attention" | jq '.data[].title'`.
+- see the **resources** tab for every refhub repository, and the **guide** tab's faq for api key and google drive setup details.

--- a/src/content/ai-workflows.md
+++ b/src/content/ai-workflows.md
@@ -207,6 +207,17 @@ the skill works in phases:
 
 citations use each item's `bibtex_key`, and the exported `.bib` uses the same keys referenced by `\cite{}`. a manuscript is only marked submission-ready when the readiness gates pass: zero unresolved `[NEEDS SOURCE]` markers, no unresolved fatal reviewer findings, ethics/consent status, ai-use disclosure, reproducibility statement, and a figure/table inventory with alt text.
 
+## prompting tips
+
+- **name the vault.** "add this to my `eurovis-2027` vault" beats "add this paper" — the agent skips a discovery round-trip and cannot guess wrong.
+- **ask for a preview before writes.** "show me what you'd import first" maps to `items preview`, `enrich --dry-run`, and reviewing `discover` results before `discover add`. cheap insurance against bulk mistakes.
+- **spell out tag hierarchies.** "tag as `evaluation > user-study`, creating missing parents" gets the structure you meant; "tag appropriately" gets whatever the agent invents.
+- **say why a paper matters.** notes written from "note that this anchors the related-work comparison" capture your framing; without it you get restated abstracts.
+- **work in small batches.** import → review → tag → next batch. easier to audit, and mistakes stay small.
+- **keep deletions in your hands.** ask the agent to print the exact `refhub ... delete --confirm` command for you to run instead of running it itself.
+- **end with an audit.** "summarize what you changed" plus `refhub audit --vault <id> --since <ISO date>` gives a reviewable trail of the session.
+- **no skill installed? paste this guide.** the copy_guide button above copies this whole page as markdown — drop it into any agent session as instant context.
+
 ## good practices
 
 - one dedicated key per workflow, minimal scopes, vault restrictions where possible. revoke and rotate from profile/settings when a workflow is retired or a secret may have leaked.

--- a/src/content/ai-workflows.md
+++ b/src/content/ai-workflows.md
@@ -159,7 +159,7 @@ destructive commands are guarded: `vaults delete` and `items delete` require `--
 
 ## use case: literature search and discovery
 
-semantic scholar discovery runs through refhub with just `vaults:read`:
+semantic scholar search and lookup run through refhub with just `vaults:read`; the final `discover add` step writes to the vault, so the key also needs `vaults:write`:
 
 > find recent papers on progressive visual analytics, show me the ten most relevant, and add the ones i pick to my vault.
 

--- a/src/content/help-guide.md
+++ b/src/content/help-guide.md
@@ -156,4 +156,6 @@ use api keys for external tools, local scripts, or agents. recommended setup:
 
 for agentic workflows, the refhub cli is the cleanest execution layer when available. install it with `npm i @refhub/cli`. it reads `REFHUB_API_KEY` from the environment, also supports a one-off `--api-key` flag, returns json by default, and exposes help through `refhub --help` and command-group help such as `refhub vaults --help`. use it before direct http calls so agents get consistent authentication, output, and error handling.
 
+for full setup and worked examples — importing literature with notes and tags, vault administration, literature discovery, and grounded paper drafting — open the **ai_workflows** tab in this help center.
+
 keep paper-level metadata separate from vault curation: bibliographic fixes belong on the publication; tags, notes, and collection-specific context belong in the vault.

--- a/src/index.css
+++ b/src/index.css
@@ -339,3 +339,50 @@
     fill: #ffffff;
   }
 }
+
+/* highlight.js token colors for fenced code blocks (rehype-highlight).
+   Kept out of @layer components: Tailwind's content-based tree-shaking
+   would drop these since hljs-* classes never appear in source files.
+   Uses theme tokens so light and dark modes both work. */
+.hljs-comment,
+.hljs-quote,
+.hljs-meta {
+  color: hsl(var(--muted-foreground));
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-doctag,
+.hljs-number,
+.hljs-attr {
+  color: hsl(var(--primary));
+}
+
+.hljs-string,
+.hljs-addition,
+.hljs-symbol,
+.hljs-bullet {
+  color: hsl(var(--accent));
+}
+
+.hljs-built_in,
+.hljs-title,
+.hljs-section,
+.hljs-name,
+.hljs-type {
+  color: hsl(var(--primary) / 0.8);
+  font-weight: 600;
+}
+
+.hljs-variable,
+.hljs-template-variable,
+.hljs-attribute,
+.hljs-subst {
+  color: hsl(var(--destructive) / 0.9);
+}
+
+.hljs-deletion {
+  color: hsl(var(--destructive));
+}


### PR DESCRIPTION
## Summary

Replaces the ai_workflows placeholder tab in the Help Center with a full agent-workflows guide, plus markdown-rendering polish it surfaced.

**Guide content** (`src/content/ai-workflows.md`, rendered like the guide tab):
- the stack: RefHub API → API key → `@refhub/cli` → `refhub-skill` → `refhub-paper-drafter`, with links to every repo
- setup from zero: API key scopes, CLI install, key-out-of-chat env/wrapper pattern, per-harness skill install (Claude Code, Codex, Gemini CLI, opencode, generic `AGENTS.md`), verify
- worked use cases: add literature/notes/tags, vault administration, literature search & discovery, grounded paper drafting via `/refhub-paper-drafter`
- prompting tips and good practices; cross-linked from the guide tab's FAQ
- `copy_guide` header button copies the whole guide as markdown for pasting into any agent session

**Markdown rendering fixes** (apply to all `MarkdownRenderer` consumers):
- theme-aware syntax highlighting (no hljs theme css existed, so fenced blocks were unstyled); `refhub`/`claude`/`npm`/… highlighted as executable commands via an extended bash grammar (`highlight.js` promoted to a direct dependency for the grammar import)
- first code line no longer indented (prose-code padding leaked into `pre > code`)
- long code lines scroll inside the block instead of stretching the dialog (Radix ScrollArea `display:table` viewport child forced to block in the help-center markdown tabs)
- copy button on every fenced code block
- github.com links get a small GitHub icon (opt-in, enabled in the help-center tabs)

**Resources tab:** removed the empty `refhub-mcp` entry; `.netlify` now displays as `refhub-api`.

Patch bump to v1.6.2 with entries in CHANGELOG.md and the in-app what's-new changelog.

## Review

Built via subagent-driven task loop with per-task spec/quality review and a final whole-branch review. The final review's one Important finding (discovery workflow claimed `vaults:read` sufficed although `discover add` writes to the vault) is fixed.

## Test plan
- [x] `npm test` — 87/87 (new: copy-button clipboard, bash built_in highlighting, GitHub-icon gating, ai-workflows tab render, copy_guide button)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] visual check: help center → ai_workflows tab (highlighting colors, no overflow, code copy buttons, GitHub icons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
