### PR TITLE
Fix fullscreen notes Ctrl+S saves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.6.1",
+      "version": "1.6.3",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/PublicationDialog.test.tsx
+++ b/src/components/publications/PublicationDialog.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { KeyboardProvider } from '@/contexts/KeyboardContext';
+import { Publication } from '@/types/database';
+import { PublicationDialog } from './PublicationDialog';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'user-1' },
+    session: null,
+  }),
+}));
+
+vi.mock('@/hooks/usePublicationRelations', () => ({
+  usePublicationRelations: () => ({
+    relations: [],
+    loading: false,
+    addRelation: vi.fn(),
+    removeRelation: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/googleDrive', () => ({
+  fetchGoogleDriveStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/pdfUpload', () => ({
+  uploadPublicationDrivePdf: vi.fn(),
+  uploadVaultPublicationDrivePdf: vi.fn(),
+}));
+
+const publication: Publication = {
+  id: 'pub-1',
+  user_id: 'user-1',
+  title: 'Saved Notes Paper',
+  authors: ['Ada Lovelace'],
+  year: 1843,
+  journal: 'Notes Journal',
+  volume: null,
+  issue: null,
+  pages: null,
+  doi: null,
+  url: null,
+  abstract: null,
+  pdf_url: null,
+  bibtex_key: null,
+  publication_type: 'article',
+  notes: 'old notes',
+  booktitle: null,
+  chapter: null,
+  edition: null,
+  editor: null,
+  howpublished: null,
+  institution: null,
+  number: null,
+  organization: null,
+  publisher: null,
+  school: null,
+  series: null,
+  type: null,
+  eid: null,
+  isbn: null,
+  issn: null,
+  keywords: null,
+  created_at: '2026-07-20T10:00:00.000Z',
+  updated_at: '2026-07-20T10:00:00.000Z',
+};
+
+describe('PublicationDialog fullscreen notes save', () => {
+  const renderDialog = (onSave: ReturnType<typeof vi.fn>) => render(
+    <KeyboardProvider>
+      <PublicationDialog
+        open
+        onOpenChange={vi.fn()}
+        publication={publication}
+        vaults={[]}
+        tags={[]}
+        publicationTags={[]}
+        allPublications={[publication]}
+        onSave={onSave}
+        onCreateTag={vi.fn()}
+      />
+    </KeyboardProvider>,
+  );
+
+  it('saves the live fullscreen textarea value on Ctrl+S', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    renderDialog(onSave);
+
+    fireEvent.click(screen.getByRole('button', { name: /fullscreen/i }));
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'latest notes still in the editor' } });
+    fireEvent.keyDown(window, { key: 's', code: 'KeyS', ctrlKey: true });
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0][0].notes).toBe('latest notes still in the editor');
+    expect(onSave.mock.calls[0][3]).toBe(true);
+  });
+
+  it('queues repeated Ctrl+S saves so the latest notes persist last', async () => {
+    let finishFirstSave: () => void = () => {};
+    const onSave = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<void>((resolve) => {
+        finishFirstSave = resolve;
+      }))
+      .mockResolvedValue(undefined);
+
+    renderDialog(onSave);
+
+    fireEvent.click(screen.getByRole('button', { name: /fullscreen/i }));
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'first save notes' } });
+    fireEvent.keyDown(window, { key: 's', code: 'KeyS', ctrlKey: true });
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(textarea, { target: { value: 'second save notes' } });
+    fireEvent.keyDown(window, { key: 's', code: 'KeyS', ctrlKey: true });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    finishFirstSave();
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2));
+    expect(onSave.mock.calls[0][0].notes).toBe('first save notes');
+    expect(onSave.mock.calls[1][0].notes).toBe('second save notes');
+  });
+});

--- a/src/components/publications/PublicationDialog.tsx
+++ b/src/components/publications/PublicationDialog.tsx
@@ -95,6 +95,8 @@ export function PublicationDialog({
   const saveButtonRef = useRef<HTMLButtonElement | null>(null);
   const fullscreenSaveFeedbackRef = useRef<HTMLDivElement | null>(null);
   const footerSaveFeedbackRef = useRef<HTMLDivElement | null>(null);
+  const notesTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fullscreenNotesTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const syncButtonRef = useRef<HTMLButtonElement | null>(null);
   const {
     relations,
@@ -186,8 +188,12 @@ export function PublicationDialog({
   const openRef = useRef(open);
   const formDataRef = useRef(formData);
   const authorsInputRef = useRef(authorsInput);
+  const editorInputRef2 = useRef(editorInput);
+  const keywordsInputRef2 = useRef(keywordsInput);
   const selectedTagsRef = useRef(selectedTags);
   const lastPublicationIdRef = useRef<string | null>(null);
+  const autosaveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const notesFullscreenRef = useRef(notesFullscreen);
 
   // ─── Keyboard context for dialog ────────────────────────────────────────────
   const kbCtx = useKeyboardContext();
@@ -204,6 +210,66 @@ export function PublicationDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
+  const getCurrentFormDataForSave = useCallback(() => {
+    const liveNotes = notesFullscreenRef.current
+      ? fullscreenNotesTextareaRef.current?.value
+      : notesTextareaRef.current?.value;
+    const currentData = { ...formDataRef.current };
+
+    if (liveNotes !== undefined) {
+      currentData.notes = liveNotes;
+    }
+
+    formDataRef.current = currentData;
+    return currentData;
+  }, []);
+
+  const buildSaveDataFromRefs = useCallback(() => {
+    const authors = authorsInputRef.current
+      .split(',')
+      .map((a) => a.trim())
+      .filter((a) => a.length > 0);
+    const editor = editorInputRef2.current
+      .split(',')
+      .map((e) => e.trim())
+      .filter((e) => e.length > 0);
+    const keywords = keywordsInputRef2.current
+      .split(',')
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0);
+
+    return { ...getCurrentFormDataForSave(), authors, editor, keywords };
+  }, [getCurrentFormDataForSave]);
+
+  const runAutosaveFromRefs = useCallback((feedbackSource: RefObject<Element | null>) => {
+    setSaving(true);
+    const previousSave = autosaveQueueRef.current.catch(() => undefined);
+    const queuedSave = previousSave.then(async () => {
+      const dataToSave = buildSaveDataFromRefs();
+      await onSave(
+        dataToSave,
+        selectedTagsRef.current,
+        publication ? undefined : selectedVaultIds,
+        true,
+        undefined,
+        feedbackSource,
+      );
+      setModifiedFields(new Set());
+      setLastSavedAt(new Date());
+      if (notesFullscreenRef.current) {
+        fullscreenCleanNotesRef.current = dataToSave.notes ?? '';
+      }
+    });
+    const trackedSave = queuedSave.finally(() => {
+      if (autosaveQueueRef.current === trackedSave) {
+        setSaving(false);
+      }
+    });
+
+    autosaveQueueRef.current = trackedSave;
+    return trackedSave;
+  }, [buildSaveDataFromRefs, onSave, publication, selectedVaultIds]);
+
   // Ctrl+S save without closing
   useHotkeys(
     'dialog',
@@ -215,55 +281,22 @@ export function PublicationDialog({
           if (!open) return false;
           e.preventDefault();
           // Trigger form save without closing
-          const doSave = async () => {
-            setSaving(true);
-            try {
-              const authors = authorsInputRef.current
-                .split(',')
-                .map((a) => a.trim())
-                .filter((a) => a.length > 0);
-              const editor = editorInputRef2.current
-                .split(',')
-                .map((e) => e.trim())
-                .filter((e) => e.length > 0);
-              const kw = keywordsInputRef2.current
-                .split(',')
-                .map((k) => k.trim())
-                .filter((k) => k.length > 0);
-              await onSave(
-                { ...formDataRef.current, authors, editor, keywords: kw },
-                selectedTagsRef.current,
-                publication ? undefined : selectedVaultIds,
-                true, // isAutoSave
-                undefined,
-                notesFullscreen ? fullscreenSaveFeedbackRef : footerSaveFeedbackRef,
-              );
-              setModifiedFields(new Set());
-              setLastSavedAt(new Date());
-              if (notesFullscreen) {
-                fullscreenCleanNotesRef.current = formDataRef.current.notes ?? '';
-              }
-            } finally {
-              setSaving(false);
-            }
-          };
-          doSave();
+          void runAutosaveFromRefs(notesFullscreenRef.current ? fullscreenSaveFeedbackRef : footerSaveFeedbackRef);
           return true;
         },
         allowInInput: true,
       },
     ],
-    [open, publication, selectedVaultIds, onSave, notesFullscreen],
+    [open, runAutosaveFromRefs],
   );
 
   // Keep refs in sync for the hotkey handler
-  const editorInputRef2 = useRef(editorInput);
-  const keywordsInputRef2 = useRef(keywordsInput);
   useEffect(() => { authorsInputRef.current = authorsInput; }, [authorsInput]);
   useEffect(() => { editorInputRef2.current = editorInput; }, [editorInput]);
   useEffect(() => { keywordsInputRef2.current = keywordsInput; }, [keywordsInput]);
   useEffect(() => { formDataRef.current = formData; }, [formData]);
   useEffect(() => { selectedTagsRef.current = selectedTags; }, [selectedTags]);
+  useEffect(() => { notesFullscreenRef.current = notesFullscreen; }, [notesFullscreen]);
   useEffect(() => { setDrivePdfInput(driveUrl ?? ''); }, [driveUrl]);
 
   useEffect(() => {
@@ -354,35 +387,8 @@ export function PublicationDialog({
 
   // ─── Fullscreen notes save handler ─────────────────────────────────────────
   const handleFullscreenSave = useCallback(async () => {
-    setSaving(true);
-    try {
-      const authors = authorsInputRef.current
-        .split(',')
-        .map((a: string) => a.trim())
-        .filter((a: string) => a.length > 0);
-      const editor = editorInputRef2.current
-        .split(',')
-        .map((e: string) => e.trim())
-        .filter((e: string) => e.length > 0);
-      const kw = keywordsInputRef2.current
-        .split(',')
-        .map((k: string) => k.trim())
-        .filter((k: string) => k.length > 0);
-      await onSave(
-        { ...formDataRef.current, authors, editor, keywords: kw },
-        selectedTagsRef.current,
-        publication ? undefined : selectedVaultIds,
-        true,
-        undefined,
-        fullscreenSaveFeedbackRef,
-      );
-      setModifiedFields(new Set());
-      setLastSavedAt(new Date());
-      fullscreenCleanNotesRef.current = formData.notes;
-    } finally {
-      setSaving(false);
-    }
-  }, [onSave, publication, selectedVaultIds, formData.notes]);
+    await runAutosaveFromRefs(fullscreenSaveFeedbackRef);
+  }, [runAutosaveFromRefs]);
 
   // ─── Exit fullscreen helper ────────────────────────────────────────────────
   const handleExitFullscreen = useCallback(() => {
@@ -392,6 +398,7 @@ export function PublicationDialog({
       setPendingExitFullscreen(true);
       setShowUnsavedDialog(true);
     } else {
+      notesFullscreenRef.current = false;
       setNotesFullscreen(false);
     }
   }, [formData.notes]);
@@ -738,6 +745,7 @@ export function PublicationDialog({
         return next;
       });
       setPendingExitFullscreen(false);
+      notesFullscreenRef.current = false;
       setNotesFullscreen(false);
     } else {
       setModifiedFields(new Set());
@@ -773,6 +781,7 @@ export function PublicationDialog({
         // Save succeeded — update snapshot and exit fullscreen, keep dialog open
         fullscreenCleanNotesRef.current = formData.notes;
         setPendingExitFullscreen(false);
+        notesFullscreenRef.current = false;
         setNotesFullscreen(false);
       } else {
         setPendingClose(false);
@@ -893,9 +902,15 @@ export function PublicationDialog({
                 <div className="flex-1 px-4 sm:px-6 py-3 sm:py-4 overflow-hidden min-h-0">
                   <textarea
                     id="fullscreen-notes-textarea"
+                    ref={fullscreenNotesTextareaRef}
                     value={formData.notes}
                     onChange={(e) => {
-                      setFormData({ ...formData, notes: e.target.value });
+                      const notes = e.target.value;
+                      setFormData(prev => {
+                        const next = { ...prev, notes };
+                        formDataRef.current = next;
+                        return next;
+                      });
                       trackFieldModification('notes');
                     }}
                     autoFocus
@@ -1631,6 +1646,7 @@ export function PublicationDialog({
                   size="sm"
                   onClick={() => {
                     fullscreenCleanNotesRef.current = formData.notes; // snapshot for dirty check
+                    notesFullscreenRef.current = true;
                     setNotesFullscreen(true);
                   }}
                   className="h-7 font-mono text-xs"
@@ -1647,9 +1663,15 @@ export function PublicationDialog({
                 <TabsContent value="write" className="mt-2 min-w-0">
                   <Textarea
                     id="notes"
+                    ref={notesTextareaRef}
                     value={formData.notes}
                     onChange={(e) => {
-                      setFormData({ ...formData, notes: e.target.value });
+                      const notes = e.target.value;
+                      setFormData(prev => {
+                        const next = { ...prev, notes };
+                        formDataRef.current = next;
+                        return next;
+                      });
                       trackFieldModification('notes');
                     }}
                     placeholder="// your_personal_notes...\n\n**Bold text**, *italic*, `code`, [links](url)\n\n- bullet points\n- supported"


### PR DESCRIPTION
## Summary
- make fullscreen notes Ctrl+S save read from the active textarea instead of effect-synced form refs that can lag
- keep fullscreen mode itself in a ref so the first shortcut after entering fullscreen targets the fullscreen editor and feedback anchor
- serialize shortcut/fullscreen autosaves so repeated Ctrl+S saves finish in request order, with the latest notes saved last
- add regression coverage for fullscreen Ctrl+S and repeated save ordering

## Root cause
The fullscreen notes editor reused the dialog-wide Ctrl+S handler. That handler assembled the save payload from refs synchronized by React effects and from a notesFullscreen value captured when the keyboard shortcut was registered. Immediately after typing or entering fullscreen, those values can lag the actual textarea/current mode. Repeated Ctrl+S could also start overlapping save requests, allowing an older notes payload to finish after a newer one.

## Verification
- npm test -- PublicationDialog.test.tsx
- npm run lint
- npm run build

Note: a full npm test run in the fresh worktree still has existing environment/setup failures unrelated to this patch: dupeMerge.test.ts imports the Supabase client without dummy Vite env, and useOnboarding.test.ts sees localStorage.clear missing under the runner shim.