### PR TITLE
Add reading state & priority for publications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this
 project uses [Semantic Versioning](https://semver.org/). History prior to
 1.4.2 was not tracked in this file.
 
+## [1.7.0] - 2026-07-20
+
+### Added
+- Reading progress (`unread` / `skimmed` / `read`) and an orthogonal `important`
+  star flag on every publication, with one-click quick controls in card and
+  table views, filtering, and sorting. Both fields are independent per vault
+  copy, like notes and tags — marking a paper read in one vault never affects
+  another vault's copy of the same paper. (#94)
+
+### Fixed
+- Card-view sorting now supports ascending/descending for every field, not
+  just the three previously-hardcoded presets.
+
 ## [1.6.2] - 2026-07-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -3818,9 +3818,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4274,9 +4274,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6372,9 +6372,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.6.1",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.6.1",
+      "version": "1.3.11",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -32,6 +32,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
+        "@radix-ui/react-toast": "^1.2.14",
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -46,14 +47,11 @@
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.6.0",
-        "highlight.js": "^11.11.1",
         "idb-keyval": "^6.2.2",
         "input-otp": "^1.4.2",
-        "katex": "^0.18.0",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "qrcode.react": "^4.2.0",
-        "quoterm": "^0.1.6",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -65,14 +63,13 @@
         "recharts": "^2.15.4",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-highlight": "^7.0.2",
-        "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "rehype-slug": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-footnotes": "^4.0.1",
         "remark-gfm": "^4.0.1",
-        "remark-math": "^6.0.0",
+        "sonner": "^1.7.4",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.9",
@@ -2254,6 +2251,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.14.tgz",
+      "integrity": "sha512-nAP5FBxBJGQ/YfUB+r+O6USFVkWq3gAInkxyEnmvEV5jtSbfDhfa4hwX8CraCnbjMLsE7XSf/K75l9xXY7joWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-toggle": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.9.tgz",
@@ -2526,9 +2557,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3550,12 +3581,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/katex": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
-      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "license": "MIT"
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3906,31 +3931,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
+        "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.0.18",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3939,7 +3964,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3951,26 +3976,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.0.18",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3978,14 +4003,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.0.18",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3994,9 +4018,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4004,15 +4028,14 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4573,13 +4596,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5095,9 +5111,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5755,55 +5771,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-from-dom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
-      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
-      "license": "ISC",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hastscript": "^9.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-html-isomorphic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
-      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-dom": "^5.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unist-util-remove-position": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
@@ -6372,20 +6339,10 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6479,31 +6436,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/katex": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.0.tgz",
-      "integrity": "sha512-rZ4Sw94Oja12Ib4+ee7inAr//yxj0G8RaAlh+ZpzfFhwTifGeJbqJ7D0FStcv6EV8DeNNU9Y8rPeg6vPUizlqg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/keyv": {
@@ -7504,25 +7436,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-math": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
-      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.1.0",
-        "unist-util-remove-position": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -8199,50 +8112,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-math": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
-      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/katex": "^0.16.0",
-        "devlop": "^1.0.0",
-        "katex": "^0.16.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-math/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/micromark-extension-math/node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -9246,16 +9115,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/quoterm": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/quoterm/-/quoterm-0.1.6.tgz",
-      "integrity": "sha512-BXxzqKGsNFvVdZ4zMZzo7eo9wALbKov455X/lTgXh1XlZYXLL35vdvOFA+SkCILs1hf92o0nnAfhT1raMUF0nA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18.2.0 <20",
-        "react-dom": ">=18.2.0 <20"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -9434,12 +9293,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9449,13 +9308,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9618,50 +9477,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-katex": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
-      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/katex": "^0.16.0",
-        "hast-util-from-html-isomorphic": "^2.0.0",
-        "hast-util-to-text": "^4.0.0",
-        "katex": "^0.16.0",
-        "unist-util-visit-parents": "^6.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/rehype-katex/node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
       }
     },
     "node_modules/rehype-raw": {
@@ -9829,22 +9644,6 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-math": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
-      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-math": "^3.0.0",
-        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -10102,6 +9901,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -10129,9 +9938,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10498,9 +10307,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10662,9 +10471,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10730,20 +10539,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
-      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10986,9 +10781,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11092,31 +10887,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
+        "std-env": "^3.10.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -11132,15 +10927,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
         "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -11161,12 +10953,6 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
         "@vitest/ui": {
           "optional": true
         },
@@ -11175,9 +10961,6 @@
         },
         "jsdom": {
           "optional": true
-        },
-        "vite": {
-          "optional": false
         }
       }
     },
@@ -11383,9 +11166,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.3.11",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.3.11",
+      "version": "1.6.1",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -32,7 +32,6 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
-        "@radix-ui/react-toast": "^1.2.14",
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -47,11 +46,14 @@
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.6.0",
+        "highlight.js": "^11.11.1",
         "idb-keyval": "^6.2.2",
         "input-otp": "^1.4.2",
+        "katex": "^0.18.0",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "qrcode.react": "^4.2.0",
+        "quoterm": "^0.1.6",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -63,13 +65,14 @@
         "recharts": "^2.15.4",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-highlight": "^7.0.2",
+        "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "rehype-slug": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-footnotes": "^4.0.1",
         "remark-gfm": "^4.0.1",
-        "sonner": "^1.7.4",
+        "remark-math": "^6.0.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.9",
@@ -2251,40 +2254,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-toast": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.14.tgz",
-      "integrity": "sha512-nAP5FBxBJGQ/YfUB+r+O6USFVkWq3gAInkxyEnmvEV5jtSbfDhfa4hwX8CraCnbjMLsE7XSf/K75l9xXY7joWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.10",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-toggle": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.9.tgz",
@@ -2557,9 +2526,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3581,6 +3550,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3931,31 +3906,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3964,7 +3939,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3976,26 +3951,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4003,13 +3978,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4018,9 +3994,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4028,14 +4004,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4596,6 +4573,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5111,9 +5095,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5771,6 +5755,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
@@ -6339,10 +6372,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6436,6 +6479,31 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.0.tgz",
+      "integrity": "sha512-rZ4Sw94Oja12Ib4+ee7inAr//yxj0G8RaAlh+ZpzfFhwTifGeJbqJ7D0FStcv6EV8DeNNU9Y8rPeg6vPUizlqg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {
@@ -7436,6 +7504,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -8112,6 +8199,50 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -9115,6 +9246,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quoterm": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/quoterm/-/quoterm-0.1.6.tgz",
+      "integrity": "sha512-BXxzqKGsNFvVdZ4zMZzo7eo9wALbKov455X/lTgXh1XlZYXLL35vdvOFA+SkCILs1hf92o0nnAfhT1raMUF0nA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.2.0 <20",
+        "react-dom": ">=18.2.0 <20"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -9293,12 +9434,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9308,13 +9449,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9477,6 +9618,50 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/rehype-raw": {
@@ -9644,6 +9829,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -9901,16 +10102,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sonner": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
-      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9938,9 +10129,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10307,9 +10498,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10471,9 +10662,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
-      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10539,6 +10730,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10781,9 +10986,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10887,31 +11092,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -10927,12 +11132,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -10953,6 +11161,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -10961,6 +11175,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -11166,9 +11383,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.7.0",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/FilterBuilder.test.ts
+++ b/src/components/publications/FilterBuilder.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { applyFilters, type PublicationFilter } from './FilterBuilder';
+import type { Publication } from '@/types/database';
+
+function makePub(overrides: Partial<Publication>): Publication {
+  return {
+    id: overrides.id ?? 'id',
+    user_id: 'user-1',
+    title: 'Untitled',
+    authors: [],
+    year: null,
+    journal: null,
+    volume: null,
+    issue: null,
+    pages: null,
+    doi: null,
+    url: null,
+    abstract: null,
+    pdf_url: null,
+    bibtex_key: null,
+    publication_type: 'article',
+    notes: null,
+    booktitle: null,
+    chapter: null,
+    edition: null,
+    editor: null,
+    howpublished: null,
+    institution: null,
+    number: null,
+    organization: null,
+    publisher: null,
+    school: null,
+    series: null,
+    type: null,
+    eid: null,
+    isbn: null,
+    issn: null,
+    keywords: null,
+    reading_state: 'unread',
+    important: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('applyFilters — reading_state', () => {
+  it('filters to publications equal to the selected reading_state', () => {
+    const pubs = [
+      makePub({ id: 'a', reading_state: 'unread' }),
+      makePub({ id: 'b', reading_state: 'read' }),
+    ];
+    const filters: PublicationFilter[] = [
+      { id: 'f1', field: 'reading_state', operator: 'equals', value: 'read' },
+    ];
+
+    const result = applyFilters(pubs, filters, {});
+    expect(result.map((p) => p.id)).toEqual(['b']);
+  });
+});
+
+describe('applyFilters — important', () => {
+  it('filters to publications where important is true', () => {
+    const pubs = [
+      makePub({ id: 'a', important: true }),
+      makePub({ id: 'b', important: false }),
+    ];
+    const filters: PublicationFilter[] = [
+      { id: 'f1', field: 'important', operator: 'equals', value: 'true' },
+    ];
+
+    const result = applyFilters(pubs, filters, {});
+    expect(result.map((p) => p.id)).toEqual(['a']);
+  });
+
+  it('filters to publications where important is false', () => {
+    const pubs = [
+      makePub({ id: 'a', important: true }),
+      makePub({ id: 'b', important: false }),
+    ];
+    const filters: PublicationFilter[] = [
+      { id: 'f1', field: 'important', operator: 'equals', value: 'false' },
+    ];
+
+    const result = applyFilters(pubs, filters, {});
+    expect(result.map((p) => p.id)).toEqual(['b']);
+  });
+});

--- a/src/components/publications/FilterBuilder.tsx
+++ b/src/components/publications/FilterBuilder.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Tag, Vault } from '@/types/database';
+import { Publication, Tag, Vault } from '@/types/database';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -34,7 +34,9 @@ export type FilterField =
   | 'vault' 
   | 'doi' 
   | 'notes'
-  | 'publication_type';
+  | 'publication_type'
+  | 'reading_state'
+  | 'important';
 
 export type FilterOperator = 
   | 'contains' 
@@ -73,6 +75,8 @@ const FIELD_OPTIONS: { value: FilterField; label: string }[] = [
   { value: 'doi', label: 'DOI' },
   { value: 'notes', label: 'Notes' },
   { value: 'publication_type', label: 'Type' },
+  { value: 'reading_state', label: 'Reading State' },
+  { value: 'important', label: 'Important' },
 ];
 
 const getOperatorsForField = (field: FilterField): { value: FilterOperator; label: string }[] => {
@@ -107,6 +111,8 @@ const getOperatorsForField = (field: FilterField): { value: FilterOperator; labe
     case 'tags':
     case 'vault':
     case 'publication_type':
+    case 'reading_state':
+    case 'important':
       return selectOperators;
     default:
       return textOperators;
@@ -184,6 +190,39 @@ export function FilterBuilder({ filters, onFiltersChange, tags, vaults, open: co
                   {vault.name}
                 </SelectItem>
               ))}
+            </SelectContent>
+          </Select>
+        );
+      case 'reading_state':
+        return (
+          <Select
+            value={filter.value}
+            onValueChange={(value) => updateFilter(filter.id, { value })}
+          >
+            <SelectTrigger className="h-8 w-full sm:w-32 text-xs font-mono">
+              <SelectValue placeholder="Select state" />
+            </SelectTrigger>
+            <SelectContent>
+              {(['unread', 'skimmed', 'read'] as const).map((state) => (
+                <SelectItem key={state} value={state} className="text-xs font-mono">
+                  {state}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        );
+      case 'important':
+        return (
+          <Select
+            value={filter.value}
+            onValueChange={(value) => updateFilter(filter.id, { value })}
+          >
+            <SelectTrigger className="h-8 w-full sm:w-32 text-xs font-mono">
+              <SelectValue placeholder="Select" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="true" className="text-xs font-mono">important</SelectItem>
+              <SelectItem value="false" className="text-xs font-mono">not important</SelectItem>
             </SelectContent>
           </Select>
         );
@@ -422,6 +461,12 @@ export function applyFilters(
           break;
         case 'doi':
           fieldValue = pub.doi || '';
+          break;
+        case 'reading_state':
+          fieldValue = pub.reading_state;
+          break;
+        case 'important':
+          fieldValue = pub.important ? 'true' : 'false';
           break;
         case 'notes':
           fieldValue = pub.notes || '';

--- a/src/components/publications/PublicationCard.tsx
+++ b/src/components/publications/PublicationCard.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { HierarchicalTagBadge } from '@/components/tags/HierarchicalTagBadge';
+import { ReadingProgressControl, ImportantToggle } from './ReadingStateControl';
 
 interface PublicationCardProps {
   publication: Publication;
@@ -50,6 +51,7 @@ interface PublicationCardProps {
   syncLoading?: boolean;
   syncCooldownSeconds?: number;
   onCheckSync?: () => void;
+  onUpdateReadingState?: (patch: Partial<Pick<Publication, 'reading_state' | 'important'>>) => void;
 }
 
 export function PublicationCard({
@@ -74,6 +76,7 @@ export function PublicationCard({
   syncLoading = false,
   syncCooldownSeconds = 0,
   onCheckSync,
+  onUpdateReadingState,
 }: PublicationCardProps) {
   const [notesExpanded, setNotesExpanded] = useState(false);
   
@@ -98,6 +101,8 @@ export function PublicationCard({
     relations: true,
     pdf: true,
     abstract: false,
+    reading_state: true,
+    important: true,
   };
 
   return (
@@ -284,6 +289,22 @@ export function PublicationCard({
               ))}
 
               <div className="flex items-center gap-2 ml-auto">
+                {(show.reading_state || show.important) && (
+                  <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+                    {show.reading_state && (
+                      <ReadingProgressControl
+                        value={publication.reading_state}
+                        onChange={onUpdateReadingState ? (value) => onUpdateReadingState({ reading_state: value }) : undefined}
+                      />
+                    )}
+                    {show.important && (
+                      <ImportantToggle
+                        value={publication.important}
+                        onChange={onUpdateReadingState ? (value) => onUpdateReadingState({ important: value }) : undefined}
+                      />
+                    )}
+                  </div>
+                )}
                 {show.relations && relationsCount > 0 && (
                   <span className="inline-flex items-center gap-1 text-xs font-mono text-muted-foreground">
                     <Link2 className="w-3.5 h-3.5" />

--- a/src/components/publications/PublicationDialog.tsx
+++ b/src/components/publications/PublicationDialog.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/select';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { RelatedPapersSection } from './RelatedPapersSection';
+import { ReadingProgressControl, ImportantToggle } from './ReadingStateControl';
 import { HierarchicalTagSelector } from '@/components/tags/HierarchicalTagSelector';
 import { usePublicationRelations } from '@/hooks/usePublicationRelations';
 import { useAuth } from '@/hooks/useAuth';
@@ -134,6 +135,8 @@ export function PublicationDialog({
     isbn: '',
     issn: '',
     keywords: [],
+    reading_state: 'unread',
+    important: false,
   });
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedVaultIds, setSelectedVaultIds] = useState<string[]>(currentVaultId ? [currentVaultId] : []);
@@ -496,6 +499,8 @@ export function PublicationDialog({
         isbn: publication.isbn || '',
         issn: publication.issn || '',
         keywords: publication.keywords || [],
+        reading_state: publication.reading_state,
+        important: publication.important,
       });
       setAuthorsInput(publication.authors.join(', '));
       setEditorInput((publication.editor || []).join(', '));
@@ -534,6 +539,8 @@ export function PublicationDialog({
         isbn: '',
         issn: '',
         keywords: [],
+        reading_state: 'unread',
+        important: false,
       });
       setAuthorsInput('');
       setEditorInput('');
@@ -1054,6 +1061,30 @@ export function PublicationDialog({
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+            </div>
+
+            {/* Reading state and priority */}
+            <div className="flex items-center justify-between gap-4 w-full box-border">
+              <div className="space-y-1 sm:space-y-2">
+                <Label className="font-semibold font-mono text-sm block">reading_state</Label>
+                <ReadingProgressControl
+                  value={formData.reading_state ?? 'unread'}
+                  onChange={(value) => {
+                    setFormData({ ...formData, reading_state: value });
+                    trackFieldModification('reading_state');
+                  }}
+                />
+              </div>
+              <div className="space-y-1 sm:space-y-2">
+                <Label className="font-semibold font-mono text-sm block">important</Label>
+                <ImportantToggle
+                  value={formData.important ?? false}
+                  onChange={(value) => {
+                    setFormData({ ...formData, important: value });
+                    trackFieldModification('important');
+                  }}
+                />
               </div>
             </div>
 

--- a/src/components/publications/PublicationDialog.tsx
+++ b/src/components/publications/PublicationDialog.tsx
@@ -577,6 +577,8 @@ export function PublicationDialog({
         if (!modifiedFields.has('bibtex_key')) updatedData.bibtex_key = publication.bibtex_key || '';
         if (!modifiedFields.has('publication_type')) updatedData.publication_type = publication.publication_type || 'article';
         if (!modifiedFields.has('notes')) updatedData.notes = publication.notes || ''; // This is the key field for markdown preview
+        if (!modifiedFields.has('reading_state')) updatedData.reading_state = publication.reading_state;
+        if (!modifiedFields.has('important')) updatedData.important = publication.important;
         if (!modifiedFields.has('booktitle')) updatedData.booktitle = publication.booktitle || '';
         if (!modifiedFields.has('chapter')) updatedData.chapter = publication.chapter || '';
         if (!modifiedFields.has('edition')) updatedData.edition = publication.edition || '';

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -6,6 +6,7 @@ import { PublicationTable } from './PublicationTable';
 import { PublicationFilter, applyFilters } from './FilterBuilder';
 import { ViewSettings, ViewMode, VisibleColumns, DEFAULT_VISIBLE_COLUMNS } from './ViewSettings';
 import { useViewSettingsPersistence, SortField, SortDirection } from '@/hooks/useViewSettingsPersistence';
+import { comparePublications, SORT_FIELD_OPTIONS } from '@/lib/publicationSort';
 import { QRCodeDialog } from '@/components/vaults/QRCodeDialog';
 import { TagManager } from '@/components/tags/TagManager';
 import { Button } from '@/components/ui/button';
@@ -39,6 +40,9 @@ import {
   Telescope,
   Loader2,
   CopyCheck,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -216,42 +220,17 @@ export function PublicationList({
   const customFiltered = applyFilters(searchFiltered, persistedFilters, publicationTagsMap);
 
   // Apply sorting
-  const dir = sortDirection === 'asc' ? 1 : -1;
-  const filteredPublications = customFiltered.sort((a, b) => {
-    switch (sortBy) {
-      case 'title':
-        return dir * a.title.localeCompare(b.title);
-      case 'authors': {
-        const aFirst = a.authors[0] || '';
-        const bFirst = b.authors[0] || '';
-        return dir * aFirst.localeCompare(bFirst);
-      }
-      case 'year':
-        return dir * ((a.year || 0) - (b.year || 0));
-      case 'journal': {
-        const aJ = a.journal || '';
-        const bJ = b.journal || '';
-        return dir * aJ.localeCompare(bJ);
-      }
-      case 'type': {
-        const aT = a.publication_type || '';
-        const bT = b.publication_type || '';
-        return dir * aT.localeCompare(bT);
-      }
-      case 'created':
-      default:
-        return dir * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
-    }
-  });
+  const filteredPublications = customFiltered.sort((a, b) => comparePublications(a, b, sortBy, sortDirection));
 
-  // Handler for table header sort clicks
+  // Handler for table header sort clicks and the sort dropdown — shared so both
+  // surfaces agree on each field's default direction (SORT_FIELD_OPTIONS).
   const handleTableSort = useCallback((field: SortField) => {
     if (sortBy === field) {
       setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
     } else {
       setSortBy(field);
-      // Default direction per field: year/created default desc, others default asc
-      setSortDirection(field === 'year' || field === 'created' ? 'desc' : 'asc');
+      const defaultDirection = SORT_FIELD_OPTIONS.find((o) => o.field === field)?.defaultDirection ?? 'asc';
+      setSortDirection(defaultDirection);
     }
   }, [sortBy]);
 
@@ -680,15 +659,27 @@ export function PublicationList({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="font-mono" onCloseAutoFocus={handleToolbarCloseAutoFocus}>
-                  <DropdownMenuItem onClick={() => { setSortBy('created'); setSortDirection('desc'); }}>
-                    recently_added
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => { setSortBy('year'); setSortDirection('desc'); }}>
-                    publication_year
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => { setSortBy('title'); setSortDirection('asc'); }}>
-                    title_asc
-                  </DropdownMenuItem>
+                  {SORT_FIELD_OPTIONS.map((option) => {
+                    const isActive = sortBy === option.field;
+                    return (
+                      <DropdownMenuItem
+                        key={option.field}
+                        onClick={() => handleTableSort(option.field)}
+                        className="justify-between gap-4"
+                      >
+                        <span>{option.label}</span>
+                        {isActive ? (
+                          sortDirection === 'asc' ? (
+                            <ArrowUp className="w-3 h-3 text-primary" />
+                          ) : (
+                            <ArrowDown className="w-3 h-3 text-primary" />
+                          )
+                        ) : (
+                          <ArrowUpDown className="w-3 h-3 opacity-30" />
+                        )}
+                      </DropdownMenuItem>
+                    );
+                  })}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>

--- a/src/components/publications/PublicationList.tsx
+++ b/src/components/publications/PublicationList.tsx
@@ -86,6 +86,7 @@ interface PublicationListProps {
   syncLoadingIds?: Set<string>;
   syncCooldowns?: Record<string, number>;
   onCheckPublicationSync?: (pub: Publication) => void;
+  onUpdateReadingState?: (pub: Publication, patch: Partial<Pick<Publication, 'reading_state' | 'important'>>) => void;
   isLoadingPublications?: boolean;
   loadingMessage?: string;
 }
@@ -124,6 +125,7 @@ export function PublicationList({
   syncLoadingIds = new Set(),
   syncCooldowns = {},
   onCheckPublicationSync,
+  onUpdateReadingState,
   isLoadingPublications = false,
   loadingMessage = 'hang_on_getting_your_papers',
 }: PublicationListProps) {
@@ -836,6 +838,7 @@ export function PublicationList({
             syncLoadingIds={syncLoadingIds}
             syncCooldowns={syncCooldowns}
             onCheckSync={onCheckPublicationSync}
+            onUpdateReadingState={onUpdateReadingState}
           />
         ) : (
           <div className="space-y-3 sm:space-y-4 max-w-4xl mx-auto">
@@ -868,6 +871,7 @@ export function PublicationList({
                   syncLoading={syncLoadingIds.has(pub.id)}
                   syncCooldownSeconds={syncCooldowns[pub.id] || 0}
                   onCheckSync={onCheckPublicationSync ? () => onCheckPublicationSync(pub) : undefined}
+                  onUpdateReadingState={onUpdateReadingState ? (patch) => onUpdateReadingState(pub, patch) : undefined}
                 />
               </div>
             ))}

--- a/src/components/publications/PublicationTable.tsx
+++ b/src/components/publications/PublicationTable.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { HierarchicalTagBadge } from '@/components/tags/HierarchicalTagBadge';
+import { ReadingProgressControl, ImportantToggle } from './ReadingStateControl';
 import { VisibleColumns } from './ViewSettings';
 import { SortField, SortDirection } from '@/hooks/useViewSettingsPersistence';
 import {
@@ -57,6 +58,7 @@ interface PublicationTableProps {
   syncLoadingIds?: Set<string>;
   syncCooldowns?: Record<string, number>;
   onCheckSync?: (pub: Publication) => void;
+  onUpdateReadingState?: (pub: Publication, patch: Partial<Pick<Publication, 'reading_state' | 'important'>>) => void;
   // Sort props
   sortBy: SortField;
   sortDirection: SortDirection;
@@ -87,6 +89,7 @@ export function PublicationTable({
   syncLoadingIds = new Set(),
   syncCooldowns = {},
   onCheckSync,
+  onUpdateReadingState,
   sortBy,
   sortDirection,
   onSort,
@@ -166,6 +169,12 @@ export function PublicationTable({
             )}
             {visibleColumns.type && (
               <SortableHead field="type" className="w-24">Type</SortableHead>
+            )}
+            {visibleColumns.reading_state && (
+              <SortableHead field="reading_state" className="w-28">State</SortableHead>
+            )}
+            {visibleColumns.important && (
+              <SortableHead field="important" className="w-12 text-center">★</SortableHead>
             )}
             {visibleColumns.relations && (
               <TableHead className="font-mono text-xs w-16 text-center">Links</TableHead>
@@ -317,6 +326,24 @@ export function PublicationTable({
                 {visibleColumns.type && (
                   <TableCell className="text-xs font-mono text-muted-foreground capitalize">
                     {pub.publication_type || '—'}
+                  </TableCell>
+                )}
+
+                {visibleColumns.reading_state && (
+                  <TableCell onClick={(e) => e.stopPropagation()}>
+                    <ReadingProgressControl
+                      value={pub.reading_state}
+                      onChange={onUpdateReadingState ? (value) => onUpdateReadingState(pub, { reading_state: value }) : undefined}
+                    />
+                  </TableCell>
+                )}
+
+                {visibleColumns.important && (
+                  <TableCell className="text-center" onClick={(e) => e.stopPropagation()}>
+                    <ImportantToggle
+                      value={pub.important}
+                      onChange={onUpdateReadingState ? (value) => onUpdateReadingState(pub, { important: value }) : undefined}
+                    />
                   </TableCell>
                 )}
 

--- a/src/components/publications/PublicationViewDialog.tsx
+++ b/src/components/publications/PublicationViewDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/dialog';
 import { Download, ExternalLink, FileText, Link2, Loader2, Pencil } from 'lucide-react';
 import { GoogleDriveIcon } from '@/components/ui/GoogleDriveIcon';
+import { ReadingProgressControl, ImportantToggle } from './ReadingStateControl';
 
 interface PublicationViewDialogProps {
   open: boolean;
@@ -28,6 +29,7 @@ interface PublicationViewDialogProps {
   onExport?: (publication: Publication) => void;
   driveUrl?: string | null;
   driveLoading?: boolean;
+  showWorkflowBadges?: boolean;
 }
 
 const DETAIL_FIELDS: Array<{ key: keyof Publication; label: string }> = [
@@ -64,6 +66,7 @@ export function PublicationViewDialog({
   onExport,
   driveUrl,
   driveLoading = false,
+  showWorkflowBadges = false,
 }: PublicationViewDialogProps) {
   if (!publication) return null;
 
@@ -116,6 +119,12 @@ export function PublicationViewDialog({
               <Badge variant="secondary" className="font-mono text-xs">
                 {publication.year}
               </Badge>
+            )}
+            {showWorkflowBadges && (
+              <div className="flex items-center gap-1 ml-auto">
+                <ReadingProgressControl value={publication.reading_state} />
+                <ImportantToggle value={publication.important} />
+              </div>
             )}
           </div>
           <DialogTitle className="pr-8 text-xl sm:text-2xl font-bold font-mono leading-tight">

--- a/src/components/publications/ReadingStateControl.tsx
+++ b/src/components/publications/ReadingStateControl.tsx
@@ -1,0 +1,86 @@
+import { Circle, CircleDot, CircleCheck, Star } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { Publication } from '@/types/database';
+
+type ReadingState = Publication['reading_state'];
+
+const READING_STATES: { value: ReadingState; label: string; Icon: typeof Circle; activeClass: string }[] = [
+  { value: 'unread', label: 'unread', Icon: Circle, activeClass: 'text-muted-foreground' },
+  { value: 'skimmed', label: 'skimmed', Icon: CircleDot, activeClass: 'text-cyber-blue' },
+  { value: 'read', label: 'read', Icon: CircleCheck, activeClass: 'text-neon-green' },
+];
+
+interface ReadingProgressControlProps {
+  value: ReadingState;
+  onChange?: (value: ReadingState) => void;
+  className?: string;
+}
+
+/** One-click segmented control: each icon jumps straight to that state, no cycling. */
+export function ReadingProgressControl({ value, onChange, className }: ReadingProgressControlProps) {
+  const readOnly = !onChange;
+
+  return (
+    <div className={cn('inline-flex items-center rounded-md border border-border overflow-hidden shrink-0', className)}>
+      {READING_STATES.map(({ value: stateValue, label, Icon, activeClass }) => {
+        const isActive = value === stateValue;
+        return (
+          <button
+            key={stateValue}
+            type="button"
+            disabled={readOnly}
+            onClick={(e) => {
+              e.stopPropagation();
+              onChange?.(stateValue);
+            }}
+            title={label}
+            aria-label={label}
+            aria-pressed={isActive}
+            className={cn(
+              'flex items-center justify-center h-7 w-7 transition-colors',
+              isActive ? cn('bg-muted', activeClass) : 'text-muted-foreground/40',
+              !readOnly && !isActive && 'hover:text-foreground hover:bg-muted/50',
+              readOnly && 'cursor-default',
+            )}
+          >
+            <Icon className="w-3.5 h-3.5" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ImportantToggleProps {
+  value: boolean;
+  onChange?: (value: boolean) => void;
+  className?: string;
+}
+
+/** Star toggle, orthogonal to reading progress. */
+export function ImportantToggle({ value, onChange, className }: ImportantToggleProps) {
+  const readOnly = !onChange;
+
+  return (
+    <button
+      type="button"
+      disabled={readOnly}
+      onClick={(e) => {
+        e.stopPropagation();
+        onChange?.(!value);
+      }}
+      title={value ? 'important' : 'mark_important'}
+      aria-label={value ? 'important' : 'mark_important'}
+      aria-pressed={value}
+      className={cn(
+        'flex items-center justify-center h-7 w-7 rounded-md border transition-colors shrink-0',
+        value ? 'text-neon-orange border-neon-orange/40 bg-neon-orange/10' : 'text-muted-foreground/40 border-border',
+        !readOnly && !value && 'hover:text-neon-orange hover:border-neon-orange/40',
+        readOnly && 'cursor-default',
+        className,
+      )}
+    >
+      <Star className={cn('w-3.5 h-3.5', value && 'fill-current')} />
+    </button>
+  );
+}

--- a/src/components/publications/ViewSettings.tsx
+++ b/src/components/publications/ViewSettings.tsx
@@ -26,6 +26,8 @@ export interface VisibleColumns {
   relations: boolean;
   pdf: boolean;
   abstract: boolean;
+  reading_state: boolean;
+  important: boolean;
 }
 
 interface ViewSettingsProps {
@@ -50,6 +52,8 @@ const COLUMN_OPTIONS: { key: keyof VisibleColumns; label: string }[] = [
   { key: 'tags', label: 'Tags' },
   { key: 'vault', label: 'Vault' },
   { key: 'type', label: 'Type' },
+  { key: 'reading_state', label: 'Reading State' },
+  { key: 'important', label: 'Important' },
   { key: 'doi', label: 'DOI' },
   { key: 'notes', label: 'Notes' },
   { key: 'relations', label: 'Relations' },
@@ -71,6 +75,8 @@ export const DEFAULT_VISIBLE_COLUMNS: VisibleColumns = {
   relations: true,
   pdf: true,
   abstract: false,
+  reading_state: true,
+  important: true,
 };
 
 export function ViewSettings({

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -21,6 +21,25 @@ export interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
+    id: 17,
+    date: '2026-07-20',
+    title: 'track what you\'ve read',
+    features: [
+      {
+        tag: 'feature',
+        title: 'reading state & priority',
+        description:
+          'mark papers unread, skimmed, or read with a one-click control on every card and table row, and star the ones that matter most. filter and sort by either, independently per vault.',
+      },
+      {
+        tag: 'fix',
+        title: 'card-view sort direction',
+        description:
+          'sorting in card view now supports ascending and descending for every field, matching table view.',
+      },
+    ],
+  },
+  {
     id: 16,
     date: '2026-07-18',
     title: 'ai agent workflows guide',

--- a/src/contexts/VaultContentContext.tsx
+++ b/src/contexts/VaultContentContext.tsx
@@ -241,6 +241,8 @@ export function VaultContentProvider({ children }: VaultContentProviderProps) {
     isbn: vp.isbn,
     issn: vp.issn,
     keywords: vp.keywords,
+    reading_state: vp.reading_state || 'unread',
+    important: vp.important ?? false,
     created_at: vp.created_at,
     updated_at: vp.updated_at,
     original_publication_id: vp.original_publication_id,

--- a/src/hooks/usePublicationRelations.ts
+++ b/src/hooks/usePublicationRelations.ts
@@ -88,6 +88,8 @@ export function usePublicationRelations(publicationId: string | null, userId: st
           isbn: vp.isbn,
           issn: vp.issn,
           keywords: vp.keywords,
+          reading_state: vp.reading_state || 'unread',
+          important: vp.important ?? false,
           created_at: vp.created_at,
           updated_at: vp.updated_at,
           relation_type: relation?.relation_type || 'related',

--- a/src/hooks/useSharedVaultOperations.ts
+++ b/src/hooks/useSharedVaultOperations.ts
@@ -588,6 +588,8 @@ export function useSharedVaultOperations({
       isbn: data.isbn || null,
       issn: data.issn || null,
       keywords: data.keywords || null,
+      reading_state: 'unread',
+      important: false,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     };
@@ -663,6 +665,8 @@ export function useSharedVaultOperations({
         isbn: vaultPub.isbn,
         issn: vaultPub.issn,
         keywords: vaultPub.keywords,
+        reading_state: vaultPub.reading_state || 'unread',
+        important: vaultPub.important ?? false,
         created_at: vaultPub.created_at,
         updated_at: vaultPub.updated_at,
       };
@@ -845,6 +849,8 @@ export function useSharedVaultOperations({
           isbn: payload.isbn,
           issn: payload.issn,
           keywords: payload.keywords,
+          reading_state: payload.reading_state || 'unread',
+          important: payload.important ?? false,
           created_at: payload.created_at,
           updated_at: payload.updated_at,
         };

--- a/src/hooks/useViewSettingsPersistence.ts
+++ b/src/hooks/useViewSettingsPersistence.ts
@@ -5,7 +5,7 @@ import { PublicationFilter } from '@/components/publications/FilterBuilder';
 
 const VIEW_SETTINGS_STORAGE_KEY = 'refhub-view-settings';
 
-export type SortField = 'title' | 'authors' | 'year' | 'journal' | 'type' | 'created';
+export type SortField = 'title' | 'authors' | 'year' | 'journal' | 'type' | 'created' | 'reading_state' | 'important';
 export type SortDirection = 'asc' | 'desc';
 
 interface StoredViewSettings {

--- a/src/lib/bibtex.test.ts
+++ b/src/lib/bibtex.test.ts
@@ -49,6 +49,8 @@ const publication = (overrides: Partial<Publication> = {}): Publication => ({
   isbn: null,
   issn: null,
   keywords: null,
+  reading_state: 'unread',
+  important: false,
   created_at: '2026-07-18T00:00:00.000Z',
   updated_at: '2026-07-18T00:00:00.000Z',
   ...overrides,

--- a/src/lib/publicationReadingState.test.ts
+++ b/src/lib/publicationReadingState.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { updatePublicationReadingState } from './publicationReadingState';
+
+function makeSupabaseMock({ vaultPubFound, updateError = null }: { vaultPubFound: boolean; updateError?: { message: string } | null }) {
+  const updateEqSpy = vi.fn().mockResolvedValue({ error: updateError });
+  const from = vi.fn((table: string) => {
+    if (table === 'vault_publications') {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: vaultPubFound ? { id: 'pub-1' } : null, error: null }),
+          }),
+        }),
+        update: () => ({ eq: updateEqSpy }),
+      };
+    }
+    // 'publications'
+    return {
+      update: () => ({ eq: updateEqSpy }),
+    };
+  });
+
+  return { supabase: { from } as unknown as Parameters<typeof updatePublicationReadingState>[0], from, updateEqSpy };
+}
+
+describe('updatePublicationReadingState', () => {
+  it('updates vault_publications when the id is a vault copy', async () => {
+    const { supabase, from } = makeSupabaseMock({ vaultPubFound: true });
+
+    const result = await updatePublicationReadingState(supabase, 'pub-1', { reading_state: 'read' });
+
+    expect(result.error).toBeNull();
+    expect(from).toHaveBeenCalledWith('vault_publications');
+    expect(from).not.toHaveBeenCalledWith('publications');
+  });
+
+  it('falls back to publications when the id is not a vault copy', async () => {
+    const { supabase, from } = makeSupabaseMock({ vaultPubFound: false });
+
+    const result = await updatePublicationReadingState(supabase, 'pub-1', { important: true });
+
+    expect(result.error).toBeNull();
+    expect(from).toHaveBeenCalledWith('publications');
+  });
+
+  it('returns the error when the update fails', async () => {
+    const { supabase } = makeSupabaseMock({ vaultPubFound: false, updateError: { message: 'boom' } });
+
+    const result = await updatePublicationReadingState(supabase, 'pub-1', { reading_state: 'skimmed' });
+
+    expect(result.error).not.toBeNull();
+    expect(result.error?.message).toBe('boom');
+  });
+});

--- a/src/lib/publicationReadingState.ts
+++ b/src/lib/publicationReadingState.ts
@@ -1,0 +1,27 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Publication } from '@/types/database';
+
+type ReadingStatePatch = Partial<Pick<Publication, 'reading_state' | 'important'>>;
+
+/**
+ * Updates reading_state/important on whichever table the given id actually
+ * lives in — mirrors the "check vault_publications first, else publications"
+ * branch Dashboard.tsx's handleSavePublication already uses. Never touches
+ * BIBLIOGRAPHIC_FIELDS, so no canonical/sibling fan-out applies here.
+ */
+export async function updatePublicationReadingState(
+  supabase: SupabaseClient,
+  publicationId: string,
+  patch: ReadingStatePatch,
+): Promise<{ error: Error | null }> {
+  const { data: vaultPub } = await supabase
+    .from('vault_publications')
+    .select('id')
+    .eq('id', publicationId)
+    .maybeSingle();
+
+  const table = vaultPub ? 'vault_publications' : 'publications';
+  const { error } = await supabase.from(table).update(patch).eq('id', publicationId);
+
+  return { error: error ? new Error(error.message) : null };
+}

--- a/src/lib/publicationSort.test.ts
+++ b/src/lib/publicationSort.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { comparePublications, SORT_FIELD_OPTIONS } from './publicationSort';
+import type { Publication } from '@/types/database';
+
+function makePub(overrides: Partial<Publication>): Publication {
+  return {
+    id: overrides.id ?? 'id',
+    user_id: 'user-1',
+    title: 'Untitled',
+    authors: [],
+    year: null,
+    journal: null,
+    volume: null,
+    issue: null,
+    pages: null,
+    doi: null,
+    url: null,
+    abstract: null,
+    pdf_url: null,
+    bibtex_key: null,
+    publication_type: 'article',
+    notes: null,
+    booktitle: null,
+    chapter: null,
+    edition: null,
+    editor: null,
+    howpublished: null,
+    institution: null,
+    number: null,
+    organization: null,
+    publisher: null,
+    school: null,
+    series: null,
+    type: null,
+    eid: null,
+    isbn: null,
+    issn: null,
+    keywords: null,
+    reading_state: 'unread',
+    important: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('comparePublications — reading_state', () => {
+  it('orders unread < skimmed < read ascending', () => {
+    const unread = makePub({ id: 'a', reading_state: 'unread' });
+    const skimmed = makePub({ id: 'b', reading_state: 'skimmed' });
+    const read = makePub({ id: 'c', reading_state: 'read' });
+
+    expect(comparePublications(unread, skimmed, 'reading_state', 'asc')).toBeLessThan(0);
+    expect(comparePublications(skimmed, read, 'reading_state', 'asc')).toBeLessThan(0);
+    expect(comparePublications(read, unread, 'reading_state', 'desc')).toBeLessThan(0);
+  });
+});
+
+describe('comparePublications — important', () => {
+  it('sorts true before false descending (true-first)', () => {
+    const important = makePub({ id: 'a', important: true });
+    const notImportant = makePub({ id: 'b', important: false });
+
+    expect(comparePublications(important, notImportant, 'important', 'desc')).toBeLessThan(0);
+    expect(comparePublications(notImportant, important, 'important', 'asc')).toBeLessThan(0);
+  });
+});
+
+describe('SORT_FIELD_OPTIONS', () => {
+  it('includes reading_state and important with sensible default directions', () => {
+    const readingState = SORT_FIELD_OPTIONS.find((o) => o.field === 'reading_state');
+    const important = SORT_FIELD_OPTIONS.find((o) => o.field === 'important');
+
+    expect(readingState?.defaultDirection).toBe('asc');
+    expect(important?.defaultDirection).toBe('desc');
+  });
+});

--- a/src/lib/publicationSort.ts
+++ b/src/lib/publicationSort.ts
@@ -1,0 +1,56 @@
+import type { Publication } from '@/types/database';
+import type { SortField, SortDirection } from '@/hooks/useViewSettingsPersistence';
+
+const READING_STATE_ORDER: Record<Publication['reading_state'], number> = {
+  unread: 0,
+  skimmed: 1,
+  read: 2,
+};
+
+export function comparePublications(
+  a: Publication,
+  b: Publication,
+  sortBy: SortField,
+  sortDirection: SortDirection,
+): number {
+  const dir = sortDirection === 'asc' ? 1 : -1;
+  switch (sortBy) {
+    case 'title':
+      return dir * a.title.localeCompare(b.title);
+    case 'authors': {
+      const aFirst = a.authors[0] || '';
+      const bFirst = b.authors[0] || '';
+      return dir * aFirst.localeCompare(bFirst);
+    }
+    case 'year':
+      return dir * ((a.year || 0) - (b.year || 0));
+    case 'journal': {
+      const aJ = a.journal || '';
+      const bJ = b.journal || '';
+      return dir * aJ.localeCompare(bJ);
+    }
+    case 'type': {
+      const aT = a.publication_type || '';
+      const bT = b.publication_type || '';
+      return dir * aT.localeCompare(bT);
+    }
+    case 'reading_state':
+      return dir * (READING_STATE_ORDER[a.reading_state] - READING_STATE_ORDER[b.reading_state]);
+    case 'important':
+      return dir * (Number(a.important) - Number(b.important));
+    case 'created':
+    default:
+      return dir * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+  }
+}
+
+export const SORT_FIELD_OPTIONS: { field: SortField; label: string; defaultDirection: SortDirection }[] = [
+  { field: 'created', label: 'recently_added', defaultDirection: 'desc' },
+  { field: 'title', label: 'title', defaultDirection: 'asc' },
+  { field: 'authors', label: 'authors', defaultDirection: 'asc' },
+  { field: 'year', label: 'publication_year', defaultDirection: 'desc' },
+  { field: 'journal', label: 'journal', defaultDirection: 'asc' },
+  { field: 'type', label: 'type', defaultDirection: 'asc' },
+  { field: 'reading_state', label: 'reading_state', defaultDirection: 'asc' },
+  { field: 'important', label: 'important', defaultDirection: 'desc' },
+];

--- a/src/lib/publicationSync.test.ts
+++ b/src/lib/publicationSync.test.ts
@@ -36,6 +36,8 @@ const basePublication: Publication = {
   isbn: null,
   issn: null,
   keywords: null,
+  reading_state: 'unread',
+  important: false,
   created_at: '2026-05-21T00:00:00Z',
   updated_at: '2026-05-21T00:00:00Z',
 };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -505,6 +505,8 @@ export default function Dashboard() {
         isbn: vp.isbn,
         issn: vp.issn,
         keywords: vp.keywords,
+        reading_state: vp.reading_state || 'unread',
+        important: vp.important ?? false,
         created_at: vp.created_at,
         updated_at: vp.updated_at,
         original_publication_id: vp.original_publication_id, // Keep track of the original

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ import {
   SemanticScholarMetadata,
 } from '@/lib/semanticScholar';
 import { createPublicationSyncPatch, extractBibliographicPatch, getPublicationSyncDiffs, PublicationSyncDiff } from '@/lib/publicationSync';
+import { updatePublicationReadingState } from '@/lib/publicationReadingState';
 import { filterDashboardTags, getDashboardAccessibleVaultIds } from '@/lib/dashboardTagScope';
 import { syncDrivePdfAsset } from '@/lib/pdfAssets';
 import { PublicationSyncDialog } from '@/components/publications/PublicationSyncDialog';
@@ -1262,6 +1263,26 @@ export default function Dashboard() {
     await fetchData();
   }, [syncPreviewPublication, toast, fetchData, user?.id, editingPublication]);
 
+  const handleUpdateReadingState = useCallback(async (
+    pub: Publication,
+    patch: Partial<Pick<Publication, 'reading_state' | 'important'>>,
+  ) => {
+    const previousPublications = publications;
+    setPublications(prev => prev.map(p => (p.id === pub.id ? { ...p, ...patch } : p)));
+
+    const { error } = await updatePublicationReadingState(supabase, pub.id, patch);
+
+    if (error) {
+      setPublications(previousPublications);
+      toast({
+        title: 'error_updating_paper',
+        description: error.message,
+        variant: 'destructive', feedbackSeverity: 'error',
+        source: dashboardFeedbackRef,
+      });
+    }
+  }, [publications, setPublications, toast]);
+
   const handleDeletePublication = async () => {
     if (!deleteConfirmation) return;
 
@@ -1694,6 +1715,7 @@ export default function Dashboard() {
         syncLoadingIds={syncLoadingIds}
         syncCooldowns={syncCooldowns}
         onCheckPublicationSync={handleCheckPublicationSync}
+        onUpdateReadingState={handleUpdateReadingState}
       />
       </div>
 

--- a/src/pages/PublicVaultSimple.tsx
+++ b/src/pages/PublicVaultSimple.tsx
@@ -262,11 +262,14 @@ export default function PublicVault() {
       await supabase.rpc('increment_vault_views', { vault_uuid: vaultData.id });
 
       // Fetch publications via vault_publications
-      const { data: vaultPublicationsData } = await supabase
+      const { data: vaultPublicationsDataRaw } = await supabase
         .from('vault_publications')
         .select('*')
         .eq('vault_id', vaultData.id);
-      
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vaultPublicationsData = vaultPublicationsDataRaw as any[];
+
       let pubsData: Publication[] = [];
       if (vaultPublicationsData && vaultPublicationsData.length > 0) {
         // Convert vault publications to Publication format
@@ -303,6 +306,8 @@ export default function PublicVault() {
           isbn: vp.isbn,
           issn: vp.issn,
           keywords: vp.keywords,
+          reading_state: vp.reading_state || 'unread',
+          important: vp.important ?? false,
           created_at: vp.created_at,
           updated_at: vp.updated_at,
           original_publication_id: vp.original_publication_id,

--- a/src/pages/VaultDetail.tsx
+++ b/src/pages/VaultDetail.tsx
@@ -108,6 +108,13 @@ export default function VaultDetail() {
     setPublicationTags,
   });
 
+  const handleUpdateReadingState = useCallback((
+    pub: Publication,
+    patch: Partial<Pick<Publication, 'reading_state' | 'important'>>,
+  ) => {
+    sharedVaultOps.updateVaultPublication(pub.id, patch, { silent: true });
+  }, [sharedVaultOps]);
+
   // Local state for UI elements
   const [vaultPapers, setVaultPapers] = useState<{[key: string]: string[]}>({});
   const [vaults, setVaults] = useState<Vault[]>([]);
@@ -1993,6 +2000,7 @@ export default function VaultDetail() {
           syncLoadingIds={syncLoadingIds}
           syncCooldowns={syncCooldowns}
           onCheckPublicationSync={canEdit ? handleCheckPublicationSync : undefined}
+          onUpdateReadingState={canEdit ? handleUpdateReadingState : undefined}
           isLoadingPublications={contentLoading && publications.length === 0}
           loadingMessage="hang_on_getting_your_papers"
         />
@@ -2037,6 +2045,7 @@ export default function VaultDetail() {
         allTags={tags}
         driveUrl={viewingPublication ? (pdfAssetsMap[viewingPublication.id] ?? null) : null}
         driveLoading={pdfAssetsLoading}
+        showWorkflowBadges
       />
 
       <div ref={publicationSyncDialogRef}>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -32,6 +32,8 @@ export interface Publication {
   isbn: string | null;
   issn: string | null;
   keywords: string[] | null;
+  reading_state: 'unread' | 'skimmed' | 'read';
+  important: boolean;
   created_at: string;
   updated_at: string;
   /** Set when this publication is a vault-specific copy of an original */

--- a/supabase/migrations/20260720000000_publication_reading_state.sql
+++ b/supabase/migrations/20260720000000_publication_reading_state.sql
@@ -1,0 +1,29 @@
+-- 20260720000000_publication_reading_state.sql
+--
+-- Adds a personal reading-progress tracker and an orthogonal importance flag
+-- to publications and vault_publications. Independent per row, exactly like
+-- notes/tags: never added to BIBLIOGRAPHIC_FIELDS (src/lib/publicationSync.ts),
+-- so editing one vault copy's state never fans out to the canonical row or
+-- sibling vault copies. Existing rows get 'unread' / false automatically via
+-- the column defaults below — no separate backfill needed.
+
+ALTER TABLE "public"."publications"
+  ADD COLUMN "reading_state" "text" NOT NULL DEFAULT 'unread',
+  ADD COLUMN "important" boolean NOT NULL DEFAULT false;
+
+ALTER TABLE "public"."publications"
+  ADD CONSTRAINT "publications_reading_state_check"
+  CHECK ("reading_state" IN ('unread', 'skimmed', 'read'));
+
+ALTER TABLE "public"."vault_publications"
+  ADD COLUMN "reading_state" "text" NOT NULL DEFAULT 'unread',
+  ADD COLUMN "important" boolean NOT NULL DEFAULT false;
+
+ALTER TABLE "public"."vault_publications"
+  ADD CONSTRAINT "vault_publications_reading_state_check"
+  CHECK ("reading_state" IN ('unread', 'skimmed', 'read'));
+
+COMMENT ON COLUMN "public"."publications"."reading_state" IS 'Personal reading-progress tracker: unread, skimmed, or read. Independent per row, never synced across vault copies.';
+COMMENT ON COLUMN "public"."publications"."important" IS 'User-starred importance flag, orthogonal to reading_state.';
+COMMENT ON COLUMN "public"."vault_publications"."reading_state" IS 'Personal reading-progress tracker: unread, skimmed, or read. Independent per vault copy, never synced across sibling copies or the canonical row.';
+COMMENT ON COLUMN "public"."vault_publications"."important" IS 'User-starred importance flag, orthogonal to reading_state.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -695,6 +695,107 @@ $$;
 ALTER FUNCTION "public"."set_vault_publication_updated_by"() OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) RETURNS TABLE("allowed" boolean, "spent_usd" numeric)
+    LANGUAGE "plpgsql"
+    AS $$
+DECLARE
+    v_now timestamptz := clock_timestamp();
+    v_next_reset timestamptz := date_trunc('day', v_now) + interval '1 day';
+    v_reset_at timestamptz;
+    v_spent numeric;
+BEGIN
+    SELECT "obs"."window_reset_at", "obs"."spent_usd" INTO v_reset_at, v_spent
+    FROM "public"."openalex_budget_state" AS "obs"
+    WHERE "obs"."bucket_key" = p_bucket_key
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        IF p_cost_usd > p_daily_budget_usd THEN
+            INSERT INTO "public"."openalex_budget_state" ("bucket_key", "spent_usd", "window_reset_at")
+            VALUES (p_bucket_key, 0, v_next_reset);
+            RETURN QUERY SELECT false, 0::numeric;
+            RETURN;
+        END IF;
+
+        INSERT INTO "public"."openalex_budget_state" ("bucket_key", "spent_usd", "window_reset_at")
+        VALUES (p_bucket_key, p_cost_usd, v_next_reset);
+        RETURN QUERY SELECT true, p_cost_usd;
+        RETURN;
+    END IF;
+
+    IF v_reset_at <= v_now THEN
+        v_spent := 0;
+        v_reset_at := v_next_reset;
+    END IF;
+
+    IF v_spent + p_cost_usd > p_daily_budget_usd THEN
+        UPDATE "public"."openalex_budget_state"
+        SET "spent_usd" = v_spent, "window_reset_at" = v_reset_at
+        WHERE "bucket_key" = p_bucket_key;
+        RETURN QUERY SELECT false, v_spent;
+        RETURN;
+    END IF;
+
+    UPDATE "public"."openalex_budget_state"
+    SET "spent_usd" = v_spent + p_cost_usd, "window_reset_at" = v_reset_at
+    WHERE "bucket_key" = p_bucket_key;
+    RETURN QUERY SELECT true, v_spent + p_cost_usd;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) RETURNS TABLE("allowed" boolean, "retry_after_seconds" integer)
+    LANGUAGE "plpgsql"
+    AS $$
+DECLARE
+    v_now timestamptz := clock_timestamp();
+    v_reset_at timestamptz;
+    v_count integer;
+BEGIN
+    -- FOR UPDATE serializes concurrent callers on this one row. That's the
+    -- whole point: it's the only thing that can coordinate across Netlify's
+    -- independent, memory-isolated function instances. Contention is not a
+    -- concern at Semantic Scholar's own per-key rate (on the order of one
+    -- request per second) -- this row is touched far less often than that.
+    SELECT "window_reset_at", "request_count" INTO v_reset_at, v_count
+    FROM "public"."semantic_scholar_rate_limit_state"
+    WHERE "bucket_key" = p_bucket_key
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        INSERT INTO "public"."semantic_scholar_rate_limit_state" ("bucket_key", "request_count", "window_reset_at")
+        VALUES (p_bucket_key, 1, v_now + make_interval(secs => p_window_ms / 1000.0));
+        RETURN QUERY SELECT true, 0;
+        RETURN;
+    END IF;
+
+    IF v_reset_at <= v_now THEN
+        UPDATE "public"."semantic_scholar_rate_limit_state"
+        SET "request_count" = 1, "window_reset_at" = v_now + make_interval(secs => p_window_ms / 1000.0)
+        WHERE "bucket_key" = p_bucket_key;
+        RETURN QUERY SELECT true, 0;
+        RETURN;
+    END IF;
+
+    IF v_count >= p_max_requests THEN
+        RETURN QUERY SELECT false, GREATEST(1, CEIL(EXTRACT(EPOCH FROM (v_reset_at - v_now)))::integer);
+        RETURN;
+    END IF;
+
+    UPDATE "public"."semantic_scholar_rate_limit_state"
+    SET "request_count" = "request_count" + 1
+    WHERE "bucket_key" = p_bucket_key;
+    RETURN QUERY SELECT true, 0;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "public"."update_tag_depth"() RETURNS "trigger"
     LANGUAGE "plpgsql"
     SET "search_path" TO 'public'
@@ -725,6 +826,222 @@ $$;
 
 
 ALTER FUNCTION "public"."update_updated_at_column"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") RETURNS "void"
+    LANGUAGE "plpgsql"
+    AS $$
+DECLARE
+    v_original_id uuid;
+    v_has_bibliographic_patch boolean;
+BEGIN
+    -- This function is only ever called under the service-role key (see
+    -- .netlify's handleUpdateItem), which has no JWT context of its own, so
+    -- auth.uid() would otherwise resolve to NULL for the rest of this
+    -- transaction. vault_publications' own "set updated_by from auth.uid()"
+    -- BEFORE UPDATE trigger fires on every UPDATE below regardless -- setting
+    -- this makes it record the real actor instead of overwriting every touched
+    -- row's updated_by with NULL.
+    PERFORM set_config('request.jwt.claim.sub', p_actor_user_id::text, true);
+
+    UPDATE vault_publications SET
+        title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
+        authors = CASE
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors'))
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'null'
+                THEN NULL
+            ELSE authors
+        END,
+        year = CASE
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'null'
+                THEN NULL
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'number'
+                THEN (p_patch->>'year')::numeric::integer
+            WHEN p_patch ? 'year'
+                THEN year
+            ELSE year
+        END,
+        journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
+        volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
+        issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,
+        pages = CASE WHEN p_patch ? 'pages' THEN p_patch->>'pages' ELSE pages END,
+        doi = CASE WHEN p_patch ? 'doi' THEN p_patch->>'doi' ELSE doi END,
+        url = CASE WHEN p_patch ? 'url' THEN p_patch->>'url' ELSE url END,
+        abstract = CASE WHEN p_patch ? 'abstract' THEN p_patch->>'abstract' ELSE abstract END,
+        pdf_url = CASE WHEN p_patch ? 'pdf_url' THEN p_patch->>'pdf_url' ELSE pdf_url END,
+        bibtex_key = CASE WHEN p_patch ? 'bibtex_key' THEN p_patch->>'bibtex_key' ELSE bibtex_key END,
+        publication_type = CASE WHEN p_patch ? 'publication_type' THEN p_patch->>'publication_type' ELSE publication_type END,
+        notes = CASE WHEN p_patch ? 'notes' THEN p_patch->>'notes' ELSE notes END,
+        booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
+        chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
+        edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
+        editor = CASE
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor'))
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'null'
+                THEN NULL
+            ELSE editor
+        END,
+        howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
+        institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
+        number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
+        organization = CASE WHEN p_patch ? 'organization' THEN p_patch->>'organization' ELSE organization END,
+        publisher = CASE WHEN p_patch ? 'publisher' THEN p_patch->>'publisher' ELSE publisher END,
+        school = CASE WHEN p_patch ? 'school' THEN p_patch->>'school' ELSE school END,
+        series = CASE WHEN p_patch ? 'series' THEN p_patch->>'series' ELSE series END,
+        type = CASE WHEN p_patch ? 'type' THEN p_patch->>'type' ELSE type END,
+        eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
+        isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
+        issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
+        keywords = CASE
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords'))
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'null'
+                THEN NULL
+            ELSE keywords
+        END,
+        version = version + 1,
+        updated_at = now()
+    WHERE id = p_vault_publication_id AND vault_id = p_vault_id
+    RETURNING original_publication_id INTO v_original_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'vault publication % not found in vault %', p_vault_publication_id, p_vault_id
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    v_has_bibliographic_patch := p_patch ?| ARRAY[
+        'title', 'authors', 'year', 'journal', 'volume', 'issue', 'pages', 'doi', 'url',
+        'abstract', 'pdf_url', 'bibtex_key', 'publication_type', 'booktitle', 'chapter',
+        'edition', 'editor', 'howpublished', 'institution', 'number', 'organization',
+        'publisher', 'school', 'series', 'type', 'eid', 'isbn', 'issn', 'keywords'
+    ];
+
+    IF v_original_id IS NOT NULL AND v_has_bibliographic_patch THEN
+        UPDATE publications SET
+            title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
+            authors = CASE
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors'))
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'null'
+                THEN NULL
+            ELSE authors
+        END,
+            year = CASE
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'null'
+                THEN NULL
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'number'
+                THEN (p_patch->>'year')::numeric::integer
+            WHEN p_patch ? 'year'
+                THEN year
+            ELSE year
+        END,
+            journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
+            volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
+            issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,
+            pages = CASE WHEN p_patch ? 'pages' THEN p_patch->>'pages' ELSE pages END,
+            doi = CASE WHEN p_patch ? 'doi' THEN p_patch->>'doi' ELSE doi END,
+            url = CASE WHEN p_patch ? 'url' THEN p_patch->>'url' ELSE url END,
+            abstract = CASE WHEN p_patch ? 'abstract' THEN p_patch->>'abstract' ELSE abstract END,
+            pdf_url = CASE WHEN p_patch ? 'pdf_url' THEN p_patch->>'pdf_url' ELSE pdf_url END,
+            bibtex_key = CASE WHEN p_patch ? 'bibtex_key' THEN p_patch->>'bibtex_key' ELSE bibtex_key END,
+            publication_type = CASE WHEN p_patch ? 'publication_type' THEN p_patch->>'publication_type' ELSE publication_type END,
+            booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
+            chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
+            edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
+            editor = CASE
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor'))
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'null'
+                THEN NULL
+            ELSE editor
+        END,
+            howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
+            institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
+            number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
+            organization = CASE WHEN p_patch ? 'organization' THEN p_patch->>'organization' ELSE organization END,
+            publisher = CASE WHEN p_patch ? 'publisher' THEN p_patch->>'publisher' ELSE publisher END,
+            school = CASE WHEN p_patch ? 'school' THEN p_patch->>'school' ELSE school END,
+            series = CASE WHEN p_patch ? 'series' THEN p_patch->>'series' ELSE series END,
+            type = CASE WHEN p_patch ? 'type' THEN p_patch->>'type' ELSE type END,
+            eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
+            isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
+            issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
+            keywords = CASE
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords'))
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'null'
+                THEN NULL
+            ELSE keywords
+        END,
+            updated_at = now()
+        WHERE id = v_original_id;
+
+        UPDATE vault_publications SET
+            title = CASE WHEN p_patch ? 'title' THEN p_patch->>'title' ELSE title END,
+            authors = CASE
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'authors'))
+            WHEN p_patch ? 'authors' AND jsonb_typeof(p_patch->'authors') = 'null'
+                THEN NULL
+            ELSE authors
+        END,
+            year = CASE
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'null'
+                THEN NULL
+            WHEN p_patch ? 'year' AND jsonb_typeof(p_patch->'year') = 'number'
+                THEN (p_patch->>'year')::numeric::integer
+            WHEN p_patch ? 'year'
+                THEN year
+            ELSE year
+        END,
+            journal = CASE WHEN p_patch ? 'journal' THEN p_patch->>'journal' ELSE journal END,
+            volume = CASE WHEN p_patch ? 'volume' THEN p_patch->>'volume' ELSE volume END,
+            issue = CASE WHEN p_patch ? 'issue' THEN p_patch->>'issue' ELSE issue END,
+            pages = CASE WHEN p_patch ? 'pages' THEN p_patch->>'pages' ELSE pages END,
+            doi = CASE WHEN p_patch ? 'doi' THEN p_patch->>'doi' ELSE doi END,
+            url = CASE WHEN p_patch ? 'url' THEN p_patch->>'url' ELSE url END,
+            abstract = CASE WHEN p_patch ? 'abstract' THEN p_patch->>'abstract' ELSE abstract END,
+            pdf_url = CASE WHEN p_patch ? 'pdf_url' THEN p_patch->>'pdf_url' ELSE pdf_url END,
+            bibtex_key = CASE WHEN p_patch ? 'bibtex_key' THEN p_patch->>'bibtex_key' ELSE bibtex_key END,
+            publication_type = CASE WHEN p_patch ? 'publication_type' THEN p_patch->>'publication_type' ELSE publication_type END,
+            booktitle = CASE WHEN p_patch ? 'booktitle' THEN p_patch->>'booktitle' ELSE booktitle END,
+            chapter = CASE WHEN p_patch ? 'chapter' THEN p_patch->>'chapter' ELSE chapter END,
+            edition = CASE WHEN p_patch ? 'edition' THEN p_patch->>'edition' ELSE edition END,
+            editor = CASE
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'editor'))
+            WHEN p_patch ? 'editor' AND jsonb_typeof(p_patch->'editor') = 'null'
+                THEN NULL
+            ELSE editor
+        END,
+            howpublished = CASE WHEN p_patch ? 'howpublished' THEN p_patch->>'howpublished' ELSE howpublished END,
+            institution = CASE WHEN p_patch ? 'institution' THEN p_patch->>'institution' ELSE institution END,
+            number = CASE WHEN p_patch ? 'number' THEN p_patch->>'number' ELSE number END,
+            organization = CASE WHEN p_patch ? 'organization' THEN p_patch->>'organization' ELSE organization END,
+            publisher = CASE WHEN p_patch ? 'publisher' THEN p_patch->>'publisher' ELSE publisher END,
+            school = CASE WHEN p_patch ? 'school' THEN p_patch->>'school' ELSE school END,
+            series = CASE WHEN p_patch ? 'series' THEN p_patch->>'series' ELSE series END,
+            type = CASE WHEN p_patch ? 'type' THEN p_patch->>'type' ELSE type END,
+            eid = CASE WHEN p_patch ? 'eid' THEN p_patch->>'eid' ELSE eid END,
+            isbn = CASE WHEN p_patch ? 'isbn' THEN p_patch->>'isbn' ELSE isbn END,
+            issn = CASE WHEN p_patch ? 'issn' THEN p_patch->>'issn' ELSE issn END,
+            keywords = CASE
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(p_patch->'keywords'))
+            WHEN p_patch ? 'keywords' AND jsonb_typeof(p_patch->'keywords') = 'null'
+                THEN NULL
+            ELSE keywords
+        END,
+            updated_at = now()
+        WHERE original_publication_id = v_original_id AND id <> p_vault_publication_id;
+    END IF;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") OWNER TO "postgres";
 
 
 CREATE OR REPLACE FUNCTION "public"."user_can_access_vault"("p_vault_uuid" "uuid", "p_required_permission" "text" DEFAULT 'viewer'::"text") RETURNS boolean
@@ -852,6 +1169,16 @@ CREATE TABLE IF NOT EXISTS "public"."notifications" (
 ALTER TABLE "public"."notifications" OWNER TO "postgres";
 
 
+CREATE TABLE IF NOT EXISTS "public"."openalex_budget_state" (
+    "bucket_key" "text" NOT NULL,
+    "spent_usd" numeric DEFAULT 0 NOT NULL,
+    "window_reset_at" timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE "public"."openalex_budget_state" OWNER TO "postgres";
+
+
 CREATE TABLE IF NOT EXISTS "public"."profiles" (
     "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
     "user_id" "uuid" NOT NULL,
@@ -951,7 +1278,10 @@ CREATE TABLE IF NOT EXISTS "public"."publications" (
     "eid" "text",
     "isbn" "text",
     "issn" "text",
-    "keywords" "text"[] DEFAULT '{}'::"text"[]
+    "keywords" "text"[] DEFAULT '{}'::"text"[],
+    "reading_state" "text" DEFAULT 'unread'::"text" NOT NULL,
+    "important" boolean DEFAULT false NOT NULL,
+    CONSTRAINT "publications_reading_state_check" CHECK (("reading_state" = ANY (ARRAY['unread'::"text", 'skimmed'::"text", 'read'::"text"])))
 );
 
 
@@ -1020,6 +1350,24 @@ COMMENT ON COLUMN "public"."publications"."issn" IS 'International Standard Seri
 
 COMMENT ON COLUMN "public"."publications"."keywords" IS 'Keywords for searching or annotation';
 
+
+
+COMMENT ON COLUMN "public"."publications"."reading_state" IS 'Personal reading-progress tracker: unread, skimmed, or read. Independent per row, never synced across vault copies.';
+
+
+
+COMMENT ON COLUMN "public"."publications"."important" IS 'User-starred importance flag, orthogonal to reading_state.';
+
+
+
+CREATE TABLE IF NOT EXISTS "public"."semantic_scholar_rate_limit_state" (
+    "bucket_key" "text" NOT NULL,
+    "request_count" integer DEFAULT 0 NOT NULL,
+    "window_reset_at" timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE "public"."semantic_scholar_rate_limit_state" OWNER TO "postgres";
 
 
 CREATE TABLE IF NOT EXISTS "public"."tags" (
@@ -1159,7 +1507,10 @@ CREATE TABLE IF NOT EXISTS "public"."vault_publications" (
     "updated_at" timestamp with time zone DEFAULT "now"(),
     "created_by" "uuid",
     "version" integer DEFAULT 1,
-    "updated_by" "uuid"
+    "updated_by" "uuid",
+    "reading_state" "text" DEFAULT 'unread'::"text" NOT NULL,
+    "important" boolean DEFAULT false NOT NULL,
+    CONSTRAINT "vault_publications_reading_state_check" CHECK (("reading_state" = ANY (ARRAY['unread'::"text", 'skimmed'::"text", 'read'::"text"])))
 );
 
 
@@ -1167,6 +1518,14 @@ ALTER TABLE "public"."vault_publications" OWNER TO "postgres";
 
 
 COMMENT ON COLUMN "public"."vault_publications"."updated_by" IS 'The user who last updated this vault publication';
+
+
+
+COMMENT ON COLUMN "public"."vault_publications"."reading_state" IS 'Personal reading-progress tracker: unread, skimmed, or read. Independent per vault copy, never synced across sibling copies or the canonical row.';
+
+
+
+COMMENT ON COLUMN "public"."vault_publications"."important" IS 'User-starred importance flag, orthogonal to reading_state.';
 
 
 
@@ -1248,6 +1607,11 @@ ALTER TABLE ONLY "public"."notifications"
 
 
 
+ALTER TABLE ONLY "public"."openalex_budget_state"
+    ADD CONSTRAINT "openalex_budget_state_pkey" PRIMARY KEY ("bucket_key");
+
+
+
 ALTER TABLE ONLY "public"."profiles"
     ADD CONSTRAINT "profiles_pkey" PRIMARY KEY ("id");
 
@@ -1285,6 +1649,11 @@ ALTER TABLE ONLY "public"."publication_tags"
 
 ALTER TABLE ONLY "public"."publications"
     ADD CONSTRAINT "publications_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."semantic_scholar_rate_limit_state"
+    ADD CONSTRAINT "semantic_scholar_rate_limit_state_pkey" PRIMARY KEY ("bucket_key");
 
 
 
@@ -2545,6 +2914,20 @@ GRANT ALL ON FUNCTION "public"."set_vault_publication_updated_by"() TO "service_
 
 
 
+REVOKE ALL ON FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) TO "anon";
+GRANT ALL ON FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) TO "service_role";
+
+
+
 GRANT ALL ON FUNCTION "public"."update_tag_depth"() TO "anon";
 GRANT ALL ON FUNCTION "public"."update_tag_depth"() TO "authenticated";
 GRANT ALL ON FUNCTION "public"."update_tag_depth"() TO "service_role";
@@ -2554,6 +2937,13 @@ GRANT ALL ON FUNCTION "public"."update_tag_depth"() TO "service_role";
 GRANT ALL ON FUNCTION "public"."update_updated_at_column"() TO "anon";
 GRANT ALL ON FUNCTION "public"."update_updated_at_column"() TO "authenticated";
 GRANT ALL ON FUNCTION "public"."update_updated_at_column"() TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") TO "anon";
+GRANT ALL ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") TO "service_role";
 
 
 
@@ -2608,6 +2998,12 @@ GRANT ALL ON TABLE "public"."notifications" TO "service_role";
 
 
 
+GRANT ALL ON TABLE "public"."openalex_budget_state" TO "anon";
+GRANT ALL ON TABLE "public"."openalex_budget_state" TO "authenticated";
+GRANT ALL ON TABLE "public"."openalex_budget_state" TO "service_role";
+
+
+
 GRANT ALL ON TABLE "public"."profiles" TO "anon";
 GRANT ALL ON TABLE "public"."profiles" TO "authenticated";
 GRANT ALL ON TABLE "public"."profiles" TO "service_role";
@@ -2635,6 +3031,12 @@ GRANT ALL ON TABLE "public"."publication_tags" TO "service_role";
 GRANT ALL ON TABLE "public"."publications" TO "anon";
 GRANT ALL ON TABLE "public"."publications" TO "authenticated";
 GRANT ALL ON TABLE "public"."publications" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."semantic_scholar_rate_limit_state" TO "anon";
+GRANT ALL ON TABLE "public"."semantic_scholar_rate_limit_state" TO "authenticated";
+GRANT ALL ON TABLE "public"."semantic_scholar_rate_limit_state" TO "service_role";
 
 
 


### PR DESCRIPTION
## Summary
- Adds a personal reading-progress tracker (`unread` / `skimmed` / `read`) and an orthogonal `important` star flag to publications, closing #94.
- One-click quick controls on card and table views (jump straight to any state, no cycling), full sort/filter/column-visibility integration, and a matching field in the publication edit form — plus a read-only badge for vault collaborators viewing without edit rights (never shown to public/anonymous visitors).
- Fixes a pre-existing UX gap along the way: card-view sorting previously only supported 3 hardcoded one-direction presets; it now supports ascending/descending for every field, matching table view.
- Both fields live on `publications` and `vault_publications`, independent per row like `notes`/`tags` — never fanned out via the existing bibliographic-sync mechanism.
- Version bump to 1.7.0 with `CHANGELOG.md` and in-app "What's New" entries.

Design spec: `docs/superpowers/specs/2026-07-20-publication-reading-state-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-20-publication-reading-state.md`

**Explicitly out of scope** (tracked as separate follow-ups, not part of this PR): a systematic-review include/exclude screening workflow, a dedicated keyboard shortcut, persisted "saved views," and matching updates to two sibling repos (`.netlify` API backend's field allow-list, `refhub-skill`'s docs) that also need to expose these two fields.

## Test plan
- [x] `npx vitest run` — 96/96 passing
- [x] `npx tsc --noEmit -p tsconfig.app.json` — 555 pre-existing/unrelated errors, unchanged from baseline (note: the bare `npx tsc --noEmit` as written in this repo's own AGENTS.md is a silent no-op due to the root tsconfig's empty `files: []`; the `-p tsconfig.app.json` form is what actually checks `src/`)
- [x] `npx eslint` on all touched files — clean
- [x] Every task individually implemented + code-reviewed (spec compliance + quality), plus two whole-branch reviews (before/after one fix for a realtime concurrent-edit sync gap in the publication edit dialog)
- [x] Manual click-through in the running app (dev server/browser wasn't available in the environment this was built in — recommend a quick pass before merge: toggle reading state/importance from card and table views in both "all papers" and a vault, confirm sort/filter, confirm a viewer-only collaborator sees the read-only badge and a public vault visitor does not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)