### PR TITLE
Fix realtime updates wiping unrelated vault_publications fields (notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this
 project uses [Semantic Versioning](https://semver.org/). History prior to
 1.4.2 was not tracked in this file.
 
+## [1.7.1] - 2026-07-21
+
+### Fixed
+- Editing a publication inside a vault (e.g. toggling reading state or
+  importance) could make its notes disappear from the screen until a page
+  reload. Root cause: Postgres's logical replication omits unchanged
+  large/TOASTed columns (like `notes`) from realtime update payloads unless
+  the table's replica identity is `FULL`; the notes were never actually
+  lost from the database, but the live view rebuilt itself from an
+  incomplete payload. Fixed at both layers: `vault_publications` now has
+  `REPLICA IDENTITY FULL` set, and the realtime update handler merges onto
+  the existing record before applying a payload, so a field missing from
+  one update can no longer clobber it locally either way.
+
 ## [1.7.0] - 2026-07-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/contexts/VaultContentContext.tsx
+++ b/src/contexts/VaultContentContext.tsx
@@ -7,6 +7,7 @@ import { handleError } from '@/lib/toast';
 import { debug, warn, error as logError } from '@/lib/logger';
 import { getPageCache, setPageCache } from '@/lib/pageCache';
 import { syncDrivePdfAsset } from '@/lib/pdfAssets';
+import { formatVaultPublication } from '@/lib/formatVaultPublication';
 
 // Info about the last activity in the vault
 export type ActivityType = 'publication_added' | 'publication_updated' | 'publication_removed' | 'tag_added' | 'tag_updated' | 'tag_removed';
@@ -206,47 +207,6 @@ export function VaultContentProvider({ children }: VaultContentProviderProps) {
     });
   }, [getUserDisplayName]);
 
-  // Helper to convert vault publication to Publication format
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const formatVaultPublication = useCallback((vp: any): Publication => ({
-    id: vp.id,
-    user_id: vp.created_by,
-    title: vp.title,
-    authors: vp.authors || [],
-    year: vp.year,
-    journal: vp.journal,
-    volume: vp.volume,
-    issue: vp.issue,
-    pages: vp.pages,
-    doi: vp.doi,
-    url: vp.url,
-    abstract: vp.abstract,
-    pdf_url: vp.pdf_url,
-    bibtex_key: vp.bibtex_key,
-    publication_type: vp.publication_type || 'article',
-    notes: vp.notes,
-    booktitle: vp.booktitle,
-    chapter: vp.chapter,
-    edition: vp.edition,
-    editor: vp.editor,
-    howpublished: vp.howpublished,
-    institution: vp.institution,
-    number: vp.number,
-    organization: vp.organization,
-    publisher: vp.publisher,
-    school: vp.school,
-    series: vp.series,
-    type: vp.type,
-    eid: vp.eid,
-    isbn: vp.isbn,
-    issn: vp.issn,
-    keywords: vp.keywords,
-    reading_state: vp.reading_state || 'unread',
-    important: vp.important ?? false,
-    created_at: vp.created_at,
-    updated_at: vp.updated_at,
-    original_publication_id: vp.original_publication_id,
-  }), []);
 
   const fetchPdfAssets = useCallback(async (vaultPublications: Publication[]) => {
     if (vaultPublications.length === 0) {
@@ -628,11 +588,15 @@ export function VaultContentProvider({ children }: VaultContentProviderProps) {
             // Track activity (from realtime)
             updateLastActivity('publication_added', newRecord.created_by, newRecord.created_at, true);
           } else if (eventType === 'UPDATE') {
-            // Update existing publication
+            // Update existing publication. Merge onto the existing record before
+            // formatting: Postgres's logical replication can omit unchanged
+            // TOASTed columns (e.g. large `notes`) from the payload when a
+            // different column is updated, and formatting the raw payload alone
+            // would wipe those fields locally until the next full fetch.
             setPublications(prev =>
               prev.map(pub =>
                 pub.id === newRecord.id
-                  ? formatVaultPublication(newRecord)
+                  ? formatVaultPublication({ ...pub, ...newRecord })
                   : pub
               )
             );

--- a/src/lib/formatVaultPublication.test.ts
+++ b/src/lib/formatVaultPublication.test.ts
@@ -56,4 +56,26 @@ describe('formatVaultPublication', () => {
     expect(merged.notes).toBe('long notes that would get TOASTed');
     expect(merged.reading_state).toBe('read');
   });
+
+  it('the same merge preserves notes when the update instead touches important (reported symptom: important toggle also wiped notes)', () => {
+    // important and reading_state go through the exact same onUpdateReadingState
+    // handler and DB write path (see PublicationCard.tsx), so an update that only
+    // touches `important` is just as capable of omitting unchanged, TOASTed
+    // `notes` from the realtime payload as one that touches `reading_state`.
+    const existing = formatVaultPublication({
+      id: 'vp-1',
+      created_by: 'user-1',
+      title: 'T',
+      notes: 'long notes that would get TOASTed',
+      important: false,
+    });
+
+    // Realtime payload for an update that only touched important — no `notes` key at all.
+    const incompletePayload = { id: 'vp-1', created_by: 'user-1', title: 'T', important: true };
+
+    const merged = formatVaultPublication({ ...existing, ...incompletePayload });
+
+    expect(merged.notes).toBe('long notes that would get TOASTed');
+    expect(merged.important).toBe(true);
+  });
 });

--- a/src/lib/formatVaultPublication.test.ts
+++ b/src/lib/formatVaultPublication.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { formatVaultPublication } from './formatVaultPublication';
+
+describe('formatVaultPublication', () => {
+  it('maps a raw vault_publications row to a Publication', () => {
+    const result = formatVaultPublication({
+      id: 'vp-1',
+      created_by: 'user-1',
+      title: 'A Paper',
+      authors: ['Ada'],
+      year: 2024,
+      notes: 'some notes',
+      reading_state: 'read',
+      important: true,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(result.id).toBe('vp-1');
+    expect(result.user_id).toBe('user-1');
+    expect(result.notes).toBe('some notes');
+    expect(result.reading_state).toBe('read');
+    expect(result.important).toBe(true);
+  });
+
+  it('defaults reading_state to unread and important to false when absent', () => {
+    const result = formatVaultPublication({ id: 'vp-1', created_by: 'user-1', title: 'T' });
+    expect(result.reading_state).toBe('unread');
+    expect(result.important).toBe(false);
+  });
+
+  it('passes through notes as undefined when the raw row omits it (matches current buggy realtime payload shape)', () => {
+    const result = formatVaultPublication({ id: 'vp-1', created_by: 'user-1', title: 'T' });
+    expect(result.notes).toBeUndefined();
+  });
+
+  it('merging the existing Publication under an incomplete realtime payload before formatting preserves fields the payload omits', () => {
+    // Simulates VaultContentContext's realtime UPDATE handler: Postgres can omit
+    // unchanged TOASTed columns (e.g. large `notes`) from the payload when a
+    // different column is updated. `{ ...existing, ...incompletePayload }` before
+    // formatting must fall back to the existing value for anything the payload
+    // doesn't actually include, while still applying genuinely changed fields.
+    const existing = formatVaultPublication({
+      id: 'vp-1',
+      created_by: 'user-1',
+      title: 'T',
+      notes: 'long notes that would get TOASTed',
+      reading_state: 'unread',
+    });
+
+    // Realtime payload for an update that only touched reading_state — no `notes` key at all.
+    const incompletePayload = { id: 'vp-1', created_by: 'user-1', title: 'T', reading_state: 'read' };
+
+    const merged = formatVaultPublication({ ...existing, ...incompletePayload });
+
+    expect(merged.notes).toBe('long notes that would get TOASTed');
+    expect(merged.reading_state).toBe('read');
+  });
+});

--- a/src/lib/formatVaultPublication.ts
+++ b/src/lib/formatVaultPublication.ts
@@ -1,0 +1,45 @@
+import type { Publication } from '@/types/database';
+
+/** Converts a raw vault_publications row (DB shape or realtime payload) to a Publication. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function formatVaultPublication(vp: any): Publication {
+  return {
+    id: vp.id,
+    user_id: vp.created_by,
+    title: vp.title,
+    authors: vp.authors || [],
+    year: vp.year,
+    journal: vp.journal,
+    volume: vp.volume,
+    issue: vp.issue,
+    pages: vp.pages,
+    doi: vp.doi,
+    url: vp.url,
+    abstract: vp.abstract,
+    pdf_url: vp.pdf_url,
+    bibtex_key: vp.bibtex_key,
+    publication_type: vp.publication_type || 'article',
+    notes: vp.notes,
+    booktitle: vp.booktitle,
+    chapter: vp.chapter,
+    edition: vp.edition,
+    editor: vp.editor,
+    howpublished: vp.howpublished,
+    institution: vp.institution,
+    number: vp.number,
+    organization: vp.organization,
+    publisher: vp.publisher,
+    school: vp.school,
+    series: vp.series,
+    type: vp.type,
+    eid: vp.eid,
+    isbn: vp.isbn,
+    issn: vp.issn,
+    keywords: vp.keywords,
+    reading_state: vp.reading_state || 'unread',
+    important: vp.important ?? false,
+    created_at: vp.created_at,
+    updated_at: vp.updated_at,
+    original_publication_id: vp.original_publication_id,
+  };
+}

--- a/supabase/migrations/20260721000000_vault_publications_replica_identity_full.sql
+++ b/supabase/migrations/20260721000000_vault_publications_replica_identity_full.sql
@@ -1,0 +1,30 @@
+-- 20260721000000_vault_publications_replica_identity_full.sql
+--
+-- Fixes a bug where toggling a single field on a vault_publications row
+-- (e.g. reading_state/important) could make large/unchanged columns like
+-- `notes` disappear from the live UI until a page reload.
+--
+-- Root cause: with the default REPLICA IDENTITY, Postgres's logical
+-- replication (what Supabase Realtime consumes) omits unchanged TOASTed
+-- (out-of-line, large) column values from the WAL stream for UPDATEs.
+-- `notes` is the one column on this row long enough to actually get
+-- TOASTed; short fields (title, doi, etc.) are never affected. When an
+-- UPDATE only touches a different column, Realtime's payload.new can
+-- arrive with `notes` missing, and VaultContentContext.tsx's realtime
+-- handler fully replaces the local publication object from that payload
+-- (formatVaultPublication(newRecord)), wiping notes client-side until the
+-- next full fetch (which reads the real row directly, bypassing Realtime,
+-- and is why a reload "brings it back").
+--
+-- REPLICA IDENTITY FULL forces Postgres to always include the complete
+-- row image in the replication stream, eliminating this whole class of
+-- "randomly missing large columns in realtime payloads" bugs, not just
+-- this one manifestation (e.g. it also protects `abstract`). This is
+-- Supabase's own documented fix for this exact symptom.
+--
+-- Only vault_publications needs this: it's the only table that is both
+-- realtime-subscribed (VaultContentContext.tsx) and uses a full-replace
+-- pattern on UPDATE. The canonical `publications` table has no realtime
+-- subscription anywhere in the codebase.
+
+ALTER TABLE "public"."vault_publications" REPLICA IDENTITY FULL;


### PR DESCRIPTION
## Summary

Bug report from live testing of PR #163 (reading state & priority): toggling reading state/importance on a card or table row inside a vault could make that paper's **notes disappear from the screen until a page reload**. Reload always brought them back — which was the key clue that this was never a real data-loss bug.

**Root cause:** `vault_publications` uses Postgres's default replica identity. Postgres's logical replication (what Supabase Realtime consumes) omits *unchanged* large/TOASTed column values from the WAL stream for `UPDATE`s unless replica identity is `FULL`. `notes` is the one column on this row long enough to actually get TOASTed — short fields (`title`, `doi`, etc.) are never affected, which is exactly why only notes was ever reported missing. When an update touches a *different* column (like `reading_state`) while `notes` stays unchanged, Supabase Realtime's `payload.new` can arrive with `notes` missing entirely. `VaultContentContext.tsx`'s realtime `UPDATE` handler then fully rebuilt the local publication object from that incomplete payload (`formatVaultPublication(newRecord)`), wiping `notes` client-side. A reload re-fetches the row directly (`.select('*')`), bypassing Realtime, and gets the real, complete data — hence "reload brings them back."

This is a **pre-existing bug**, not something introduced by the reading-state feature (confirmed: `useSharedVaultOperations.ts` and the Dashboard/VaultDetail handlers are untouched between the reviewed branch and main). The reading-state quick-toggle is simply the first common, high-frequency workflow that updates a single different column on this row while leaving notes untouched — so it's the first thing to reliably expose it. Only `vault_publications` is affected: it's the only table that's both realtime-subscribed *and* uses this full-replace-on-update pattern (checked every `.channel()` subscription in the codebase).

## Fix (two layers, same root cause)

1. **Database**: `ALTER TABLE vault_publications REPLICA IDENTITY FULL` — forces Postgres to always include the complete row in the replication stream. This is Supabase's own documented fix for this exact symptom class, and it protects every large column on this table (e.g. `abstract` too), not just `notes`.
2. **Application**: `VaultContentContext.tsx`'s realtime `UPDATE` handler now merges onto the existing record (`formatVaultPublication({ ...pub, ...newRecord })`) before formatting, so a field missing from any future payload can't silently clobber local state either — defense in depth alongside the DB-level fix.
3. Extracted `formatVaultPublication` (previously an inline closure with no external callers) to its own module, `src/lib/formatVaultPublication.ts`, so this merge behavior is directly unit-testable.

Patch version bump (1.7.0 → 1.7.1) per this repo's versioning policy.

## Test plan
- [x] `npx vitest run` — 102/102 passing (4 new: `formatVaultPublication` defaults, notes pass-through, and the merge-preserves-omitted-fields behavior that directly proves this fix)
- [x] `npx tsc --noEmit -p tsconfig.app.json` — 557, unchanged from main's baseline (all pre-existing/unrelated)
- [x] `npx eslint` on touched files — clean
- [ ] **Migration must be applied to the live Supabase project** (`supabase/migrations/20260721000000_vault_publications_replica_identity_full.sql`) — no project access from this environment, same as prior migrations in this repo
- [ ] Manual verification recommended before/after merge: toggle reading state on a paper with substantial notes inside a vault, confirm notes no longer disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)