### PR TITLE
Fix Supabase Security Advisor errors and warnings

### DIFF
--- a/supabase/migrations/20260721010000_security_advisor_fixes.sql
+++ b/supabase/migrations/20260721010000_security_advisor_fixes.sql
@@ -136,6 +136,37 @@ REVOKE EXECUTE ON FUNCTION "public"."delete_user"() FROM "anon";
 REVOKE EXECUTE ON FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") FROM "anon";
 
 -- ---------------------------------------------------------------------------
+-- CRITICAL, found while auditing the above (not from the linter -- it only
+-- flags SECURITY DEFINER functions, and this one isn't).
+--
+-- update_vault_publication_with_rollup runs as SECURITY INVOKER (the
+-- caller's own RLS applies), but it does
+-- `PERFORM set_config('request.jwt.claim.sub', p_actor_user_id::text, true)`
+-- before its UPDATEs -- spoofing auth.uid() to an arbitrary caller-supplied
+-- value for the rest of the transaction. Its own source migration
+-- (20260706000000_publication_bibliographic_rollup.sql) already revokes
+-- PUBLIC and grants only service_role for exactly this reason ("this
+-- function trusts its caller completely... must only be reachable through
+-- .netlify's own auth/scope/vault-access checks"), but a live grant check
+-- against production (information_schema.role_routine_grants) confirmed
+-- anon and authenticated both currently also hold EXECUTE.
+--
+-- Impact: any authenticated user can call this RPC directly, pass an
+-- arbitrary victim's user id as p_actor_user_id, and have "Users can manage
+-- vault publications in editable vaults" (TO authenticated, checks
+-- auth.uid() against vault ownership/share role) evaluate against the
+-- *spoofed* auth.uid() instead of the real caller -- gaining unauthorized
+-- write access to any vault_publication the impersonated victim can edit,
+-- which then fans out into the canonical publications row and every sibling
+-- vault_publication. (anon is not exploitable here: that policy is scoped
+-- TO authenticated only, so an anon-role connection has no applicable
+-- UPDATE policy regardless of the spoofed value.)
+--
+-- Re-issuing the revoke to restore the function's intended service_role-only
+-- reachability.
+REVOKE EXECUTE ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") FROM "anon", "authenticated";
+
+-- ---------------------------------------------------------------------------
 -- Hardening found while auditing the above: create_user_profile is SECURITY
 -- DEFINER (bypasses RLS) and trusted its p_user_id argument outright, so any
 -- authenticated caller could create/attach a profile row for someone else's

--- a/supabase/migrations/20260721010000_security_advisor_fixes.sql
+++ b/supabase/migrations/20260721010000_security_advisor_fixes.sql
@@ -12,9 +12,9 @@
 -- the "any future permissive GRANT is immediately exploitable" exposure the
 -- linter flags on any public-schema table without RLS enabled.
 -- ---------------------------------------------------------------------------
-
-ALTER TABLE "public"."semantic_scholar_rate_limit_state" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "public"."openalex_budget_state" ENABLE ROW LEVEL SECURITY;
+-- DONE
+-- ALTER TABLE "public"."semantic_scholar_rate_limit_state" ENABLE ROW LEVEL SECURITY;
+-- ALTER TABLE "public"."openalex_budget_state" ENABLE ROW LEVEL SECURITY;
 
 -- ---------------------------------------------------------------------------
 -- WARN: rls_policy_always_true on public.vault_papers

--- a/supabase/migrations/20260721010000_security_advisor_fixes.sql
+++ b/supabase/migrations/20260721010000_security_advisor_fixes.sql
@@ -1,0 +1,171 @@
+-- 20260721010000_security_advisor_fixes.sql
+--
+-- Addresses Supabase Security Advisor findings.
+
+-- ---------------------------------------------------------------------------
+-- ERRORS: rls_disabled_in_public
+--
+-- Both tables already REVOKE ALL FROM PUBLIC and GRANT only to service_role
+-- (see 20260709120000/20260709130000), so anon/authenticated have no table
+-- privileges regardless. service_role bypasses RLS entirely, so enabling RLS
+-- here with no policies changes no application behavior -- it just removes
+-- the "any future permissive GRANT is immediately exploitable" exposure the
+-- linter flags on any public-schema table without RLS enabled.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."semantic_scholar_rate_limit_state" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."openalex_budget_state" ENABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- WARN: rls_policy_always_true on public.vault_papers
+--
+-- "Users can manage vault papers" was created with only a WITH CHECK clause,
+-- no USING clause, no FOR, and no TO. That means: FOR ALL (every command),
+-- TO public (every role, including anon -- which also holds GRANT ALL on
+-- this table), and USING defaults to `true` since WITH CHECK doesn't backfill
+-- it. WITH CHECK is never consulted for DELETE, so the net effect was that
+-- *any* role could delete *any* row in vault_papers, and USING(true) also let
+-- UPDATE/SELECT target rows outside the intended ownership/share checks
+-- before WITH CHECK (or the separate SELECT policy) ever got a say.
+--
+-- Fix: give it an explicit USING clause identical to the WITH CHECK logic,
+-- and scope it to authenticated (matching every other vault policy in this
+-- schema -- vault_papers has no legitimate anon write path).
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Users can manage vault papers" ON "public"."vault_papers";
+
+CREATE POLICY "Users can manage vault papers" ON "public"."vault_papers"
+    FOR ALL TO "authenticated"
+    USING (
+        ("auth"."uid"() = "added_by")
+        OR (EXISTS (
+            SELECT 1 FROM "public"."vaults" "v"
+            WHERE ("v"."id" = "vault_papers"."vault_id")
+              AND (
+                ("v"."user_id" = "auth"."uid"())
+                OR (EXISTS (
+                    SELECT 1 FROM "public"."vault_shares" "vs"
+                    WHERE ("vs"."vault_id" = "v"."id")
+                      AND ("vs"."shared_with_user_id" = "auth"."uid"())
+                      AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"]))
+                ))
+              )
+        ))
+    )
+    WITH CHECK (
+        ("auth"."uid"() = "added_by")
+        OR (EXISTS (
+            SELECT 1 FROM "public"."vaults" "v"
+            WHERE ("v"."id" = "vault_papers"."vault_id")
+              AND (
+                ("v"."user_id" = "auth"."uid"())
+                OR (EXISTS (
+                    SELECT 1 FROM "public"."vault_shares" "vs"
+                    WHERE ("vs"."vault_id" = "v"."id")
+                      AND ("vs"."shared_with_user_id" = "auth"."uid"())
+                      AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"]))
+                ))
+              )
+        ))
+    );
+
+-- ---------------------------------------------------------------------------
+-- WARN: function_search_path_mutable
+--
+-- These functions had no SET search_path, so an attacker able to create
+-- objects earlier in a caller's search_path (e.g. a same-named function/table
+-- in a schema that precedes "public") could hijack unqualified references at
+-- call time. Pin each to the schema it actually needs.
+-- ---------------------------------------------------------------------------
+
+ALTER FUNCTION "public"."enforce_forked_vaults_public"() SET "search_path" TO 'public';
+ALTER FUNCTION "public"."set_updated_at"() SET "search_path" TO 'public';
+ALTER FUNCTION "public"."copy_publication_to_vault"("pub_id" "uuid", "target_vault_id" "uuid", "user_id" "uuid") SET "search_path" TO 'public';
+ALTER FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") SET "search_path" TO 'public';
+ALTER FUNCTION "public"."has_vault_access"("p_user_id" "uuid", "p_vault_id" "uuid", "p_required_role" "text") SET "search_path" TO 'public';
+ALTER FUNCTION "public"."user_can_access_vault"("p_vault_uuid" "uuid", "p_required_permission" "text") SET "search_path" TO 'public';
+ALTER FUNCTION "public"."get_researcher_stats"("p_user_ids" "uuid"[]) SET "search_path" TO 'public';
+ALTER FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") SET "search_path" TO 'public';
+ALTER FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) SET "search_path" TO 'public';
+ALTER FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) SET "search_path" TO 'public';
+
+-- ---------------------------------------------------------------------------
+-- WARN: anon/authenticated_security_definer_function_executable
+--
+-- Every function in "public" gets EXECUTE granted to anon/authenticated by
+-- default (ALTER DEFAULT PRIVILEGES in schema.sql). That's wrong for
+-- SECURITY DEFINER functions meant only to fire as triggers, or that aren't
+-- called by the app at all -- both cases mean the function is exposed at
+-- /rest/v1/rpc/<name> for no reason, which is unnecessary attack surface for
+-- code that bypasses RLS by design.
+--
+-- Trigger-only functions: revoking anon/authenticated EXECUTE does not stop
+-- them from firing as triggers (trigger invocation isn't gated by the
+-- invoking role's EXECUTE privilege), it only removes the direct RPC path.
+-- ---------------------------------------------------------------------------
+
+REVOKE EXECUTE ON FUNCTION "public"."handle_new_user"() FROM "anon", "authenticated";
+REVOKE EXECUTE ON FUNCTION "public"."notify_vault_access_requested"() FROM "anon", "authenticated";
+REVOKE EXECUTE ON FUNCTION "public"."notify_vault_access_status_changed"() FROM "anon", "authenticated";
+REVOKE EXECUTE ON FUNCTION "public"."notify_vault_favorited"() FROM "anon", "authenticated";
+REVOKE EXECUTE ON FUNCTION "public"."notify_vault_forked"() FROM "anon", "authenticated";
+REVOKE EXECUTE ON FUNCTION "public"."notify_vault_shared"() FROM "anon", "authenticated";
+REVOKE EXECUTE ON FUNCTION "public"."set_vault_publication_updated_by"() FROM "anon", "authenticated";
+REVOKE EXECUTE ON FUNCTION "public"."validate_username"() FROM "anon", "authenticated";
+
+-- has_vault_access has no callers anywhere in the schema or app (superseded
+-- by user_can_access_vault) and is SECURITY DEFINER, so leaving it publicly
+-- executable would let anon probe arbitrary user/vault access relationships
+-- for free. Lock it down to service_role like the other internal-only
+-- SECURITY DEFINER helpers in this schema.
+REVOKE EXECUTE ON FUNCTION "public"."has_vault_access"("p_user_id" "uuid", "p_vault_id" "uuid", "p_required_role" "text") FROM "anon", "authenticated";
+
+-- user_can_access_vault is referenced from several RLS policies scoped
+-- `TO authenticated`, so authenticated still needs EXECUTE for those policies
+-- to evaluate. Nothing calls it as anon (no `TO public`/`TO anon` policy
+-- uses it, and the app never calls it directly via .rpc()).
+REVOKE EXECUTE ON FUNCTION "public"."user_can_access_vault"("p_vault_uuid" "uuid", "p_required_permission" "text") FROM "anon";
+
+-- delete_user requires auth.uid() internally and raises for an unauthenticated
+-- caller, but anon never has a legitimate reason to call it.
+REVOKE EXECUTE ON FUNCTION "public"."delete_user"() FROM "anon";
+
+-- create_user_profile is only ever called by the client with an active
+-- session (src/lib/profile.ts), never as anon.
+REVOKE EXECUTE ON FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") FROM "anon";
+
+-- ---------------------------------------------------------------------------
+-- Hardening found while auditing the above: create_user_profile is SECURITY
+-- DEFINER (bypasses RLS) and trusted its p_user_id argument outright, so any
+-- authenticated caller could create/attach a profile row for someone else's
+-- user_id. Restrict it to the caller's own uid, while still allowing the
+-- trigger-internal call from handle_new_user (which runs with no request JWT
+-- context, so auth.uid() is NULL there, not the new user's id).
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") RETURNS TABLE("id" "uuid", "user_id" "uuid", "display_name" "text", "email" "text", "avatar_url" "text", "username" "text", "bio" "text", "github_url" "text", "linkedin_url" "text", "bluesky_url" "text", "created_at" timestamp with time zone, "updated_at" timestamp with time zone, "is_setup" boolean)
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  IF "auth"."uid"() IS NOT NULL AND "auth"."uid"() <> p_user_id THEN
+    RAISE EXCEPTION 'Cannot create a profile for another user';
+  END IF;
+
+  INSERT INTO public.profiles (
+    user_id, email, display_name, username, bio, avatar_url,
+    github_url, linkedin_url, bluesky_url, is_setup
+  ) VALUES (
+    p_user_id, p_email, p_display_name, null, null, null,
+    null, null, null, false
+  )
+  ON CONFLICT ON CONSTRAINT "profiles_user_id_key" DO NOTHING;
+
+  RETURN QUERY
+  SELECT * FROM public.profiles p
+  WHERE p.user_id = p_user_id;
+END;
+$$;
+
+ALTER FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") OWNER TO "postgres";

--- a/supabase/migrations/20260721010000_security_advisor_fixes.sql
+++ b/supabase/migrations/20260721010000_security_advisor_fixes.sql
@@ -33,42 +33,43 @@
 -- schema -- vault_papers has no legitimate anon write path).
 -- ---------------------------------------------------------------------------
 
-DROP POLICY IF EXISTS "Users can manage vault papers" ON "public"."vault_papers";
+-- DONE
+--DROP POLICY IF EXISTS "Users can manage vault papers" ON "public"."vault_papers";
 
-CREATE POLICY "Users can manage vault papers" ON "public"."vault_papers"
-    FOR ALL TO "authenticated"
-    USING (
-        ("auth"."uid"() = "added_by")
-        OR (EXISTS (
-            SELECT 1 FROM "public"."vaults" "v"
-            WHERE ("v"."id" = "vault_papers"."vault_id")
-              AND (
-                ("v"."user_id" = "auth"."uid"())
-                OR (EXISTS (
-                    SELECT 1 FROM "public"."vault_shares" "vs"
-                    WHERE ("vs"."vault_id" = "v"."id")
-                      AND ("vs"."shared_with_user_id" = "auth"."uid"())
-                      AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"]))
-                ))
-              )
-        ))
-    )
-    WITH CHECK (
-        ("auth"."uid"() = "added_by")
-        OR (EXISTS (
-            SELECT 1 FROM "public"."vaults" "v"
-            WHERE ("v"."id" = "vault_papers"."vault_id")
-              AND (
-                ("v"."user_id" = "auth"."uid"())
-                OR (EXISTS (
-                    SELECT 1 FROM "public"."vault_shares" "vs"
-                    WHERE ("vs"."vault_id" = "v"."id")
-                      AND ("vs"."shared_with_user_id" = "auth"."uid"())
-                      AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"]))
-                ))
-              )
-        ))
-    );
+--CREATE POLICY "Users can manage vault papers" ON "public"."vault_papers"
+    -- FOR ALL TO "authenticated"
+    -- USING (
+    --     ("auth"."uid"() = "added_by")
+    --     OR (EXISTS (
+    --         SELECT 1 FROM "public"."vaults" "v"
+    --         WHERE ("v"."id" = "vault_papers"."vault_id")
+    --           AND (
+    --             ("v"."user_id" = "auth"."uid"())
+    --             OR (EXISTS (
+    --                 SELECT 1 FROM "public"."vault_shares" "vs"
+    --                 WHERE ("vs"."vault_id" = "v"."id")
+    --                   AND ("vs"."shared_with_user_id" = "auth"."uid"())
+    --                   AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"]))
+    --             ))
+    --           )
+    --     ))
+    -- )
+    -- WITH CHECK (
+    --     ("auth"."uid"() = "added_by")
+    --     OR (EXISTS (
+    --         SELECT 1 FROM "public"."vaults" "v"
+    --         WHERE ("v"."id" = "vault_papers"."vault_id")
+    --           AND (
+    --             ("v"."user_id" = "auth"."uid"())
+    --             OR (EXISTS (
+    --                 SELECT 1 FROM "public"."vault_shares" "vs"
+    --                 WHERE ("vs"."vault_id" = "v"."id")
+    --                   AND ("vs"."shared_with_user_id" = "auth"."uid"())
+    --                   AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"]))
+    --             ))
+    --           )
+    --     ))
+    -- );
 
 -- ---------------------------------------------------------------------------
 -- WARN: function_search_path_mutable
@@ -79,16 +80,17 @@ CREATE POLICY "Users can manage vault papers" ON "public"."vault_papers"
 -- call time. Pin each to the schema it actually needs.
 -- ---------------------------------------------------------------------------
 
-ALTER FUNCTION "public"."enforce_forked_vaults_public"() SET "search_path" TO 'public';
-ALTER FUNCTION "public"."set_updated_at"() SET "search_path" TO 'public';
-ALTER FUNCTION "public"."copy_publication_to_vault"("pub_id" "uuid", "target_vault_id" "uuid", "user_id" "uuid") SET "search_path" TO 'public';
-ALTER FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") SET "search_path" TO 'public';
-ALTER FUNCTION "public"."has_vault_access"("p_user_id" "uuid", "p_vault_id" "uuid", "p_required_role" "text") SET "search_path" TO 'public';
-ALTER FUNCTION "public"."user_can_access_vault"("p_vault_uuid" "uuid", "p_required_permission" "text") SET "search_path" TO 'public';
-ALTER FUNCTION "public"."get_researcher_stats"("p_user_ids" "uuid"[]) SET "search_path" TO 'public';
-ALTER FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") SET "search_path" TO 'public';
-ALTER FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) SET "search_path" TO 'public';
-ALTER FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) SET "search_path" TO 'public';
+-- DONE
+-- ALTER FUNCTION "public"."enforce_forked_vaults_public"() SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."set_updated_at"() SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."copy_publication_to_vault"("pub_id" "uuid", "target_vault_id" "uuid", "user_id" "uuid") SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."has_vault_access"("p_user_id" "uuid", "p_vault_id" "uuid", "p_required_role" "text") SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."user_can_access_vault"("p_vault_uuid" "uuid", "p_required_permission" "text") SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."get_researcher_stats"("p_user_ids" "uuid"[]) SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."take_semantic_scholar_rate_limit"("p_bucket_key" "text", "p_max_requests" integer, "p_window_ms" integer) SET "search_path" TO 'public';
+-- ALTER FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_usd" numeric, "p_daily_budget_usd" numeric) SET "search_path" TO 'public';
 
 -- ---------------------------------------------------------------------------
 -- WARN: anon/authenticated_security_definer_function_executable
@@ -105,35 +107,36 @@ ALTER FUNCTION "public"."take_openalex_budget"("p_bucket_key" "text", "p_cost_us
 -- invoking role's EXECUTE privilege), it only removes the direct RPC path.
 -- ---------------------------------------------------------------------------
 
-REVOKE EXECUTE ON FUNCTION "public"."handle_new_user"() FROM "anon", "authenticated";
-REVOKE EXECUTE ON FUNCTION "public"."notify_vault_access_requested"() FROM "anon", "authenticated";
-REVOKE EXECUTE ON FUNCTION "public"."notify_vault_access_status_changed"() FROM "anon", "authenticated";
-REVOKE EXECUTE ON FUNCTION "public"."notify_vault_favorited"() FROM "anon", "authenticated";
-REVOKE EXECUTE ON FUNCTION "public"."notify_vault_forked"() FROM "anon", "authenticated";
-REVOKE EXECUTE ON FUNCTION "public"."notify_vault_shared"() FROM "anon", "authenticated";
-REVOKE EXECUTE ON FUNCTION "public"."set_vault_publication_updated_by"() FROM "anon", "authenticated";
-REVOKE EXECUTE ON FUNCTION "public"."validate_username"() FROM "anon", "authenticated";
+-- DONE
+-- REVOKE EXECUTE ON FUNCTION "public"."handle_new_user"() FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."notify_vault_access_requested"() FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."notify_vault_access_status_changed"() FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."notify_vault_favorited"() FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."notify_vault_forked"() FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."notify_vault_shared"() FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."set_vault_publication_updated_by"() FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."validate_username"() FROM "anon", "authenticated";
 
 -- has_vault_access has no callers anywhere in the schema or app (superseded
 -- by user_can_access_vault) and is SECURITY DEFINER, so leaving it publicly
 -- executable would let anon probe arbitrary user/vault access relationships
 -- for free. Lock it down to service_role like the other internal-only
 -- SECURITY DEFINER helpers in this schema.
-REVOKE EXECUTE ON FUNCTION "public"."has_vault_access"("p_user_id" "uuid", "p_vault_id" "uuid", "p_required_role" "text") FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."has_vault_access"("p_user_id" "uuid", "p_vault_id" "uuid", "p_required_role" "text") FROM "anon", "authenticated";
 
 -- user_can_access_vault is referenced from several RLS policies scoped
 -- `TO authenticated`, so authenticated still needs EXECUTE for those policies
 -- to evaluate. Nothing calls it as anon (no `TO public`/`TO anon` policy
 -- uses it, and the app never calls it directly via .rpc()).
-REVOKE EXECUTE ON FUNCTION "public"."user_can_access_vault"("p_vault_uuid" "uuid", "p_required_permission" "text") FROM "anon";
+-- REVOKE EXECUTE ON FUNCTION "public"."user_can_access_vault"("p_vault_uuid" "uuid", "p_required_permission" "text") FROM "anon";
 
 -- delete_user requires auth.uid() internally and raises for an unauthenticated
 -- caller, but anon never has a legitimate reason to call it.
-REVOKE EXECUTE ON FUNCTION "public"."delete_user"() FROM "anon";
+-- REVOKE EXECUTE ON FUNCTION "public"."delete_user"() FROM "anon";
 
 -- create_user_profile is only ever called by the client with an active
 -- session (src/lib/profile.ts), never as anon.
-REVOKE EXECUTE ON FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") FROM "anon";
+-- REVOKE EXECUTE ON FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") FROM "anon";
 
 -- ---------------------------------------------------------------------------
 -- CRITICAL, found while auditing the above (not from the linter -- it only
@@ -164,7 +167,7 @@ REVOKE EXECUTE ON FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p
 --
 -- Re-issuing the revoke to restore the function's intended service_role-only
 -- reachability.
-REVOKE EXECUTE ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") FROM "anon", "authenticated";
+-- REVOKE EXECUTE ON FUNCTION "public"."update_vault_publication_with_rollup"("p_vault_publication_id" "uuid", "p_vault_id" "uuid", "p_patch" "jsonb", "p_actor_user_id" "uuid") FROM "anon", "authenticated";
 
 -- ---------------------------------------------------------------------------
 -- Hardening found while auditing the above: create_user_profile is SECURITY
@@ -174,29 +177,29 @@ REVOKE EXECUTE ON FUNCTION "public"."update_vault_publication_with_rollup"("p_va
 -- trigger-internal call from handle_new_user (which runs with no request JWT
 -- context, so auth.uid() is NULL there, not the new user's id).
 -- ---------------------------------------------------------------------------
+-- DONE
+-- CREATE OR REPLACE FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") RETURNS TABLE("id" "uuid", "user_id" "uuid", "display_name" "text", "email" "text", "avatar_url" "text", "username" "text", "bio" "text", "github_url" "text", "linkedin_url" "text", "bluesky_url" "text", "created_at" timestamp with time zone, "updated_at" timestamp with time zone, "is_setup" boolean)
+--     LANGUAGE "plpgsql" SECURITY DEFINER
+--     SET "search_path" TO 'public'
+--     AS $$
+-- BEGIN
+--   IF "auth"."uid"() IS NOT NULL AND "auth"."uid"() <> p_user_id THEN
+--     RAISE EXCEPTION 'Cannot create a profile for another user';
+--   END IF;
 
-CREATE OR REPLACE FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") RETURNS TABLE("id" "uuid", "user_id" "uuid", "display_name" "text", "email" "text", "avatar_url" "text", "username" "text", "bio" "text", "github_url" "text", "linkedin_url" "text", "bluesky_url" "text", "created_at" timestamp with time zone, "updated_at" timestamp with time zone, "is_setup" boolean)
-    LANGUAGE "plpgsql" SECURITY DEFINER
-    SET "search_path" TO 'public'
-    AS $$
-BEGIN
-  IF "auth"."uid"() IS NOT NULL AND "auth"."uid"() <> p_user_id THEN
-    RAISE EXCEPTION 'Cannot create a profile for another user';
-  END IF;
+--   INSERT INTO public.profiles (
+--     user_id, email, display_name, username, bio, avatar_url,
+--     github_url, linkedin_url, bluesky_url, is_setup
+--   ) VALUES (
+--     p_user_id, p_email, p_display_name, null, null, null,
+--     null, null, null, false
+--   )
+--   ON CONFLICT ON CONSTRAINT "profiles_user_id_key" DO NOTHING;
 
-  INSERT INTO public.profiles (
-    user_id, email, display_name, username, bio, avatar_url,
-    github_url, linkedin_url, bluesky_url, is_setup
-  ) VALUES (
-    p_user_id, p_email, p_display_name, null, null, null,
-    null, null, null, false
-  )
-  ON CONFLICT ON CONSTRAINT "profiles_user_id_key" DO NOTHING;
+--   RETURN QUERY
+--   SELECT * FROM public.profiles p
+--   WHERE p.user_id = p_user_id;
+-- END;
+-- $$;
 
-  RETURN QUERY
-  SELECT * FROM public.profiles p
-  WHERE p.user_id = p_user_id;
-END;
-$$;
-
-ALTER FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") OWNER TO "postgres";
+-- ALTER FUNCTION "public"."create_user_profile"("p_user_id" "uuid", "p_email" "text", "p_display_name" "text") OWNER TO "postgres";

--- a/supabase/migrations/20260721030000_performance_advisor_fixes.sql
+++ b/supabase/migrations/20260721030000_performance_advisor_fixes.sql
@@ -1,0 +1,357 @@
+-- 20260721030000_performance_advisor_fixes.sql
+--
+-- Addresses Supabase Performance Advisor findings.
+--
+-- Part A: auth_rls_initplan (WARN, 53 policies). Every RLS policy in this
+-- schema called "auth"."uid"() directly inside its USING/WITH CHECK
+-- expression. Postgres cannot treat a directly-referenced function call as a
+-- one-time InitPlan, so it gets re-evaluated once per row scanned instead of
+-- once per query. Wrapping it as (select auth.uid()) makes it a scalar
+-- subquery, which the planner *can* cache for the statement -- this is
+-- Supabase's own documented fix and is semantically identical: auth.uid()
+-- is STABLE (same result for the whole statement), so caching it changes
+-- nothing about which rows match, only how many times the function runs.
+-- Every policy below is DROP + CREATE with the exact same USING/WITH
+-- CHECK/FOR/TO as before, only the auth.uid() calls are wrapped.
+--
+-- (One exception: "Users can manage vault papers" on vault_papers uses the
+-- already-corrected definition from 20260721010000_security_advisor_fixes.sql
+-- -- not the original schema.sql text -- since that migration rewrote this
+-- policy's USING/FOR/TO already.)
+
+DROP POLICY IF EXISTS "Authenticated users can fork public vaults" ON "public"."vault_forks";
+CREATE POLICY "Authenticated users can fork public vaults" ON "public"."vault_forks" FOR INSERT TO "authenticated" WITH CHECK (((( SELECT "auth"."uid"() ) = "forked_by") AND (EXISTS ( SELECT 1
+   FROM "public"."vaults" "v"
+  WHERE (("v"."id" = "vault_forks"."original_vault_id") AND ("v"."visibility" = 'public'::"public"."vault_visibility"))))));
+
+DROP POLICY IF EXISTS "Users can access publication tags for accessible publications" ON "public"."publication_tags";
+CREATE POLICY "Users can access publication tags for accessible publications" ON "public"."publication_tags" FOR SELECT TO "authenticated", "anon" USING (((("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM "public"."publications" "p"
+  WHERE (("p"."id" = "publication_tags"."publication_id") AND ("p"."user_id" = ( SELECT "auth"."uid"() )))))) OR (("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM ((("public"."publications" "p"
+     LEFT JOIN "public"."vault_papers" "vp" ON (("p"."id" = "vp"."publication_id")))
+     LEFT JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("p"."id" = "publication_tags"."publication_id") AND (("p"."user_id" = ( SELECT "auth"."uid"() )) OR (("v"."id" IS NOT NULL) AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL)) OR ("v"."visibility" = 'public'::"public"."vault_visibility")))))))) OR (("vault_publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM (("public"."vault_publications" "vp"
+     LEFT JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("vp"."id" = "publication_tags"."vault_publication_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL)) OR ("v"."visibility" = 'public'::"public"."vault_visibility"))))))));
+
+DROP POLICY IF EXISTS "Users can add favorites" ON "public"."vault_favorites";
+CREATE POLICY "Users can add favorites" ON "public"."vault_favorites" FOR INSERT TO "authenticated" WITH CHECK ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can add favorites for accessible vaults" ON "public"."vault_favorites";
+CREATE POLICY "Users can add favorites for accessible vaults" ON "public"."vault_favorites" FOR INSERT TO "authenticated" WITH CHECK (((( SELECT "auth"."uid"() ) = "user_id") AND (EXISTS ( SELECT 1
+   FROM "public"."vaults" "v"
+  WHERE (("v"."id" = "vault_favorites"."vault_id") AND ("v"."visibility" = ANY (ARRAY['public'::"public"."vault_visibility", 'protected'::"public"."vault_visibility"])))))));
+
+DROP POLICY IF EXISTS "Users can delete own fork records" ON "public"."vault_forks";
+CREATE POLICY "Users can delete own fork records" ON "public"."vault_forks" FOR DELETE TO "authenticated" USING (("forked_by" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can delete own notifications" ON "public"."notifications";
+CREATE POLICY "Users can delete own notifications" ON "public"."notifications" FOR DELETE TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can delete their own forks" ON "public"."vault_forks";
+CREATE POLICY "Users can delete their own forks" ON "public"."vault_forks" FOR DELETE TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "forked_by"));
+
+DROP POLICY IF EXISTS "Users can delete their own google drive link" ON "public"."user_google_drive_links";
+CREATE POLICY "Users can delete their own google drive link" ON "public"."user_google_drive_links" FOR DELETE TO "authenticated" USING (("user_id" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can delete their own publication pdf assets" ON "public"."publication_pdf_assets";
+CREATE POLICY "Users can delete their own publication pdf assets" ON "public"."publication_pdf_assets" FOR DELETE TO "authenticated" USING (("user_id" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can fork public vaults" ON "public"."vault_forks";
+CREATE POLICY "Users can fork public vaults" ON "public"."vault_forks" FOR INSERT TO "authenticated" WITH CHECK (((( SELECT "auth"."uid"() ) = "forked_by") AND (EXISTS ( SELECT 1
+   FROM "public"."vaults" "v"
+  WHERE (("v"."id" = "vault_forks"."original_vault_id") AND ("v"."visibility" = 'public'::"public"."vault_visibility") AND ("v"."user_id" <> ( SELECT "auth"."uid"() )))))));
+
+DROP POLICY IF EXISTS "Users can insert their own google drive link" ON "public"."user_google_drive_links";
+CREATE POLICY "Users can insert their own google drive link" ON "public"."user_google_drive_links" FOR INSERT TO "authenticated" WITH CHECK (("user_id" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can insert their own publication pdf assets" ON "public"."publication_pdf_assets";
+CREATE POLICY "Users can insert their own publication pdf assets" ON "public"."publication_pdf_assets" FOR INSERT TO "authenticated" WITH CHECK (("user_id" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can manage own publications and publications in editable " ON "public"."publications";
+CREATE POLICY "Users can manage own publications and publications in editable " ON "public"."publications" TO "authenticated" USING (((( SELECT "auth"."uid"() ) = "user_id") OR (EXISTS ( SELECT 1
+   FROM (("public"."vault_papers" "vp"
+     JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("vp"."publication_id" = "publications"."id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility"))))))) WITH CHECK (((( SELECT "auth"."uid"() ) = "user_id") OR (EXISTS ( SELECT 1
+   FROM (("public"."vault_papers" "vp"
+     JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("vp"."publication_id" = "publications"."id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility")))))));
+
+DROP POLICY IF EXISTS "Users can manage own tags and tags in editable vaults" ON "public"."tags";
+CREATE POLICY "Users can manage own tags and tags in editable vaults" ON "public"."tags" TO "authenticated" USING (((( SELECT "auth"."uid"() ) = "user_id") OR (("vault_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM ("public"."vaults" "v"
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("v"."id" = "tags"."vault_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility")))))))) WITH CHECK (((( SELECT "auth"."uid"() ) = "user_id") OR (("vault_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM ("public"."vaults" "v"
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("v"."id" = "tags"."vault_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility"))))))));
+
+DROP POLICY IF EXISTS "Users can manage own vaults" ON "public"."vaults";
+CREATE POLICY "Users can manage own vaults" ON "public"."vaults" TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "user_id")) WITH CHECK ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can manage publication tags for own publications and acce" ON "public"."publication_tags";
+CREATE POLICY "Users can manage publication tags for own publications and acce" ON "public"."publication_tags" TO "authenticated" USING (((("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM "public"."publications" "p"
+  WHERE (("p"."id" = "publication_tags"."publication_id") AND ("p"."user_id" = ( SELECT "auth"."uid"() )))))) OR (("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM ((("public"."publications" "p"
+     LEFT JOIN "public"."vault_papers" "vp" ON (("p"."id" = "vp"."publication_id")))
+     LEFT JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("p"."id" = "publication_tags"."publication_id") AND (("p"."user_id" = ( SELECT "auth"."uid"() )) OR (("v"."id" IS NOT NULL) AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility")))))))) OR (("vault_publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM (("public"."vault_publications" "vp"
+     LEFT JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("vp"."id" = "publication_tags"."vault_publication_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility")))))))) WITH CHECK (((("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM "public"."publications" "p"
+  WHERE (("p"."id" = "publication_tags"."publication_id") AND ("p"."user_id" = ( SELECT "auth"."uid"() )))))) OR (("publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM ((("public"."publications" "p"
+     LEFT JOIN "public"."vault_papers" "vp" ON (("p"."id" = "vp"."publication_id")))
+     LEFT JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("p"."id" = "publication_tags"."publication_id") AND (("p"."user_id" = ( SELECT "auth"."uid"() )) OR (("v"."id" IS NOT NULL) AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility")))))))) OR (("vault_publication_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM (("public"."vault_publications" "vp"
+     LEFT JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("vp"."id" = "publication_tags"."vault_publication_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility"))))))));
+
+DROP POLICY IF EXISTS "Users can manage vault publications in editable vaults" ON "public"."vault_publications";
+CREATE POLICY "Users can manage vault publications in editable vaults" ON "public"."vault_publications" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM ("public"."vaults" "v"
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("v"."id" = "vault_publications"."vault_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility")))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM ("public"."vaults" "v"
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("v"."id" = "vault_publications"."vault_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL) AND ("vs"."role" <> 'viewer'::"public"."vault_permission")) OR ("v"."visibility" = 'public'::"public"."vault_visibility"))))));
+
+DROP POLICY IF EXISTS "Users can remove own favorites" ON "public"."vault_favorites";
+CREATE POLICY "Users can remove own favorites" ON "public"."vault_favorites" FOR DELETE TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can remove their own favorites" ON "public"."vault_favorites";
+CREATE POLICY "Users can remove their own favorites" ON "public"."vault_favorites" FOR DELETE TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can request access to vaults" ON "public"."vault_access_requests";
+CREATE POLICY "Users can request access to vaults" ON "public"."vault_access_requests" FOR INSERT WITH CHECK ((( SELECT "auth"."uid"() ) = "requester_id"));
+
+DROP POLICY IF EXISTS "Users can select their own google drive link" ON "public"."user_google_drive_links";
+CREATE POLICY "Users can select their own google drive link" ON "public"."user_google_drive_links" FOR SELECT TO "authenticated" USING (("user_id" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can select their own publication pdf assets" ON "public"."publication_pdf_assets";
+CREATE POLICY "Users can select their own publication pdf assets" ON "public"."publication_pdf_assets" FOR SELECT TO "authenticated" USING (("user_id" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can update own notifications" ON "public"."notifications";
+CREATE POLICY "Users can update own notifications" ON "public"."notifications" FOR UPDATE TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "user_id")) WITH CHECK ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can update own profile" ON "public"."profiles";
+CREATE POLICY "Users can update own profile" ON "public"."profiles" FOR UPDATE TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "user_id")) WITH CHECK ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can update their own google drive link" ON "public"."user_google_drive_links";
+CREATE POLICY "Users can update their own google drive link" ON "public"."user_google_drive_links" FOR UPDATE TO "authenticated" USING (("user_id" = ( SELECT "auth"."uid"() ))) WITH CHECK (("user_id" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can update their own publication pdf assets" ON "public"."publication_pdf_assets";
+CREATE POLICY "Users can update their own publication pdf assets" ON "public"."publication_pdf_assets" FOR UPDATE TO "authenticated" USING (("user_id" = ( SELECT "auth"."uid"() ))) WITH CHECK (("user_id" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can view favorites for accessible vaults" ON "public"."vault_favorites";
+CREATE POLICY "Users can view favorites for accessible vaults" ON "public"."vault_favorites" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."vaults"
+  WHERE (("vaults"."id" = "vault_favorites"."vault_id") AND (("vaults"."user_id" = ( SELECT "auth"."uid"() )) OR "public"."user_can_access_vault"("vaults"."id", 'viewer'::"text"))))));
+
+DROP POLICY IF EXISTS "Users can view fork relationships" ON "public"."vault_forks";
+CREATE POLICY "Users can view fork relationships" ON "public"."vault_forks" FOR SELECT TO "authenticated" USING ((("forked_by" = ( SELECT "auth"."uid"() )) OR (EXISTS ( SELECT 1
+   FROM "public"."vaults" "v"
+  WHERE (("v"."id" = "vault_forks"."original_vault_id") AND (("v"."visibility" = 'public'::"public"."vault_visibility") OR ("v"."user_id" = ( SELECT "auth"."uid"() ))))))));
+
+DROP POLICY IF EXISTS "Users can view forks for accessible vaults" ON "public"."vault_forks";
+CREATE POLICY "Users can view forks for accessible vaults" ON "public"."vault_forks" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."vaults"
+  WHERE (("vaults"."id" = "vault_forks"."original_vault_id") AND (("vaults"."user_id" = ( SELECT "auth"."uid"() )) OR "public"."user_can_access_vault"("vaults"."id", 'viewer'::"text"))))));
+
+DROP POLICY IF EXISTS "Users can view notifications" ON "public"."notifications";
+CREATE POLICY "Users can view notifications" ON "public"."notifications" FOR SELECT USING ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can view own access requests" ON "public"."vault_access_requests";
+CREATE POLICY "Users can view own access requests" ON "public"."vault_access_requests" FOR SELECT USING ((( SELECT "auth"."uid"() ) = "requester_id"));
+
+DROP POLICY IF EXISTS "Users can view own favorites" ON "public"."vault_favorites";
+CREATE POLICY "Users can view own favorites" ON "public"."vault_favorites" FOR SELECT TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can view own fork records" ON "public"."vault_forks";
+CREATE POLICY "Users can view own fork records" ON "public"."vault_forks" FOR SELECT TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "forked_by"));
+
+DROP POLICY IF EXISTS "Users can view own publications and publications in accessible " ON "public"."publications";
+CREATE POLICY "Users can view own publications and publications in accessible " ON "public"."publications" FOR SELECT TO "authenticated" USING (((( SELECT "auth"."uid"() ) = "user_id") OR (EXISTS ( SELECT 1
+   FROM (("public"."vault_papers" "vp"
+     JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("vp"."publication_id" = "publications"."id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL)) OR ("v"."visibility" = 'public'::"public"."vault_visibility")))))));
+
+DROP POLICY IF EXISTS "Users can view own tags and tags in accessible vaults" ON "public"."tags";
+CREATE POLICY "Users can view own tags and tags in accessible vaults" ON "public"."tags" FOR SELECT TO "authenticated" USING (((( SELECT "auth"."uid"() ) = "user_id") OR (("vault_id" IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM ("public"."vaults" "v"
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("v"."id" = "tags"."vault_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL)) OR ("v"."visibility" = 'public'::"public"."vault_visibility"))))))));
+
+DROP POLICY IF EXISTS "Users can view relevant shares" ON "public"."vault_shares";
+CREATE POLICY "Users can view relevant shares" ON "public"."vault_shares" FOR SELECT TO "authenticated" USING (((( SELECT "auth"."uid"() ) = "shared_by") OR (( SELECT "auth"."uid"() ) = "shared_with_user_id")));
+
+DROP POLICY IF EXISTS "Users can view stats for accessible vaults" ON "public"."vault_stats";
+CREATE POLICY "Users can view stats for accessible vaults" ON "public"."vault_stats" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."vaults"
+  WHERE (("vaults"."id" = "vault_stats"."vault_id") AND (("vaults"."user_id" = ( SELECT "auth"."uid"() )) OR ("vaults"."visibility" = 'public'::"public"."vault_visibility") OR "public"."user_can_access_vault"("vaults"."id", 'viewer'::"text"))))));
+
+DROP POLICY IF EXISTS "Users can view their own favorites" ON "public"."vault_favorites";
+CREATE POLICY "Users can view their own favorites" ON "public"."vault_favorites" FOR SELECT TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "user_id"));
+
+DROP POLICY IF EXISTS "Users can view their own forks" ON "public"."vault_forks";
+CREATE POLICY "Users can view their own forks" ON "public"."vault_forks" FOR SELECT TO "authenticated" USING ((( SELECT "auth"."uid"() ) = "forked_by"));
+
+DROP POLICY IF EXISTS "Users can view vault papers" ON "public"."vault_papers";
+CREATE POLICY "Users can view vault papers" ON "public"."vault_papers" FOR SELECT USING (((( SELECT "auth"."uid"() ) = "added_by") OR (EXISTS ( SELECT 1
+   FROM "public"."vaults" "v"
+  WHERE (("v"."id" = "vault_papers"."vault_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR ("v"."visibility" = 'public'::"public"."vault_visibility") OR (EXISTS ( SELECT 1
+           FROM "public"."vault_shares" "vs"
+          WHERE (("vs"."vault_id" = "v"."id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))))))));
+
+DROP POLICY IF EXISTS "Users can view vault publications in accessible vaults" ON "public"."vault_publications";
+CREATE POLICY "Users can view vault publications in accessible vaults" ON "public"."vault_publications" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM ("public"."vaults" "v"
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("v"."id" = "vault_publications"."vault_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" IS NOT NULL)) OR ("v"."visibility" = 'public'::"public"."vault_visibility"))))));
+
+DROP POLICY IF EXISTS "Vault owners can manage shares" ON "public"."vault_shares";
+CREATE POLICY "Vault owners can manage shares" ON "public"."vault_shares" TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."vaults" "v"
+  WHERE (("v"."id" = "vault_shares"."vault_id") AND ("v"."user_id" = ( SELECT "auth"."uid"() )))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."vaults" "v"
+  WHERE (("v"."id" = "vault_shares"."vault_id") AND ("v"."user_id" = ( SELECT "auth"."uid"() ))))));
+
+DROP POLICY IF EXISTS "Vault owners can update access requests" ON "public"."vault_access_requests";
+CREATE POLICY "Vault owners can update access requests" ON "public"."vault_access_requests" FOR UPDATE USING ((EXISTS ( SELECT 1
+   FROM "public"."vaults"
+  WHERE (("vaults"."id" = "vault_access_requests"."vault_id") AND ("vaults"."user_id" = ( SELECT "auth"."uid"() ))))));
+
+DROP POLICY IF EXISTS "Vault owners can view access requests" ON "public"."vault_access_requests";
+CREATE POLICY "Vault owners can view access requests" ON "public"."vault_access_requests" FOR SELECT USING ((EXISTS ( SELECT 1
+   FROM "public"."vaults"
+  WHERE (("vaults"."id" = "vault_access_requests"."vault_id") AND ("vaults"."user_id" = ( SELECT "auth"."uid"() ))))));
+
+DROP POLICY IF EXISTS "Vault owners can view forks of their vault" ON "public"."vault_forks";
+CREATE POLICY "Vault owners can view forks of their vault" ON "public"."vault_forks" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."vaults" "v"
+  WHERE (("v"."id" = "vault_forks"."original_vault_id") AND ("v"."user_id" = ( SELECT "auth"."uid"() ))))));
+
+DROP POLICY IF EXISTS "publication_relations_delete" ON "public"."publication_relations";
+CREATE POLICY "publication_relations_delete" ON "public"."publication_relations" FOR DELETE TO "authenticated" USING ((("created_by" = ( SELECT "auth"."uid"() )) OR (EXISTS ( SELECT 1
+   FROM ("public"."vault_publications" "vp"
+     JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+  WHERE ((("vp"."id" = "publication_relations"."publication_id") OR ("vp"."id" = "publication_relations"."related_publication_id")) AND ("v"."user_id" = ( SELECT "auth"."uid"() )))))));
+
+DROP POLICY IF EXISTS "publication_relations_insert" ON "public"."publication_relations";
+CREATE POLICY "publication_relations_insert" ON "public"."publication_relations" FOR INSERT TO "authenticated" WITH CHECK ((("created_by" = ( SELECT "auth"."uid"() )) AND (EXISTS ( SELECT 1
+   FROM (("public"."vault_publications" "vp"
+     JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE (("vp"."id" = "publication_relations"."publication_id") AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR (("vs"."shared_with_user_id" IS NOT NULL) AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"])))))))));
+
+DROP POLICY IF EXISTS "publication_relations_select" ON "public"."publication_relations";
+CREATE POLICY "publication_relations_select" ON "public"."publication_relations" FOR SELECT TO "authenticated", "anon" USING ((EXISTS ( SELECT 1
+   FROM (("public"."vault_publications" "vp"
+     JOIN "public"."vaults" "v" ON (("vp"."vault_id" = "v"."id")))
+     LEFT JOIN "public"."vault_shares" "vs" ON ((("v"."id" = "vs"."vault_id") AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() )))))
+  WHERE ((("vp"."id" = "publication_relations"."publication_id") OR ("vp"."id" = "publication_relations"."related_publication_id")) AND (("v"."user_id" = ( SELECT "auth"."uid"() )) OR ("vs"."shared_with_user_id" IS NOT NULL) OR ("v"."visibility" = 'public'::"public"."vault_visibility"))))));
+
+DROP POLICY IF EXISTS "publication_relations_update" ON "public"."publication_relations";
+CREATE POLICY "publication_relations_update" ON "public"."publication_relations" FOR UPDATE TO "authenticated" USING (("created_by" = ( SELECT "auth"."uid"() ))) WITH CHECK (("created_by" = ( SELECT "auth"."uid"() )));
+
+DROP POLICY IF EXISTS "Users can manage vault papers" ON "public"."vault_papers";
+CREATE POLICY "Users can manage vault papers" ON "public"."vault_papers"
+    FOR ALL TO "authenticated"
+    USING (
+        (( SELECT "auth"."uid"() ) = "added_by")
+        OR (EXISTS (
+            SELECT 1 FROM "public"."vaults" "v"
+            WHERE ("v"."id" = "vault_papers"."vault_id")
+              AND (
+                ("v"."user_id" = ( SELECT "auth"."uid"() ))
+                OR (EXISTS (
+                    SELECT 1 FROM "public"."vault_shares" "vs"
+                    WHERE ("vs"."vault_id" = "v"."id")
+                      AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() ))
+                      AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"]))
+                ))
+              )
+        ))
+    )
+    WITH CHECK (
+        (( SELECT "auth"."uid"() ) = "added_by")
+        OR (EXISTS (
+            SELECT 1 FROM "public"."vaults" "v"
+            WHERE ("v"."id" = "vault_papers"."vault_id")
+              AND (
+                ("v"."user_id" = ( SELECT "auth"."uid"() ))
+                OR (EXISTS (
+                    SELECT 1 FROM "public"."vault_shares" "vs"
+                    WHERE ("vs"."vault_id" = "v"."id")
+                      AND ("vs"."shared_with_user_id" = ( SELECT "auth"."uid"() ))
+                      AND ("vs"."role" = ANY (ARRAY['editor'::"public"."vault_permission", 'owner'::"public"."vault_permission"]))
+                ))
+              )
+        ))
+    );
+
+-- Part B: unindexed_foreign_keys (INFO)
+CREATE INDEX IF NOT EXISTS "idx_api_keys_created_by" ON "public"."api_keys" USING "btree" ("created_by");
+CREATE INDEX IF NOT EXISTS "idx_publication_pdf_assets_user_id" ON "public"."publication_pdf_assets" USING "btree" ("user_id");
+CREATE INDEX IF NOT EXISTS "idx_publication_tags_tag_id" ON "public"."publication_tags" USING "btree" ("tag_id");
+CREATE INDEX IF NOT EXISTS "idx_publications_user_id" ON "public"."publications" USING "btree" ("user_id");
+CREATE INDEX IF NOT EXISTS "idx_tags_user_id" ON "public"."tags" USING "btree" ("user_id");
+CREATE INDEX IF NOT EXISTS "idx_vault_access_requests_requester_id" ON "public"."vault_access_requests" USING "btree" ("requester_id");
+CREATE INDEX IF NOT EXISTS "idx_vault_publications_created_by" ON "public"."vault_publications" USING "btree" ("created_by");
+CREATE INDEX IF NOT EXISTS "idx_vault_shares_shared_by" ON "public"."vault_shares" USING "btree" ("shared_by");
+CREATE INDEX IF NOT EXISTS "idx_vault_shares_vault_id" ON "public"."vault_shares" USING "btree" ("vault_id");
+CREATE INDEX IF NOT EXISTS "idx_vaults_user_id" ON "public"."vaults" USING "btree" ("user_id");
+
+-- Part C: multiple_permissive_policies -- drop policies proven redundant or, in one
+-- case, an outright access-control gap. See migration comments for the proof per policy.
+
+-- profiles/SELECT: "Authenticated users can view profiles" is USING (true), a strict
+-- superset of "...view set up profiles"'s USING (is_setup = true).
+DROP POLICY IF EXISTS "Authenticated users can view set up profiles" ON "public"."profiles";
+
+-- vault_favorites: exact duplicates under a different name (same USING clause, verified
+-- byte-for-byte).
+DROP POLICY IF EXISTS "Users can remove their own favorites" ON "public"."vault_favorites";
+DROP POLICY IF EXISTS "Users can view their own favorites" ON "public"."vault_favorites";
+
+-- vault_forks: same duplication pattern.
+DROP POLICY IF EXISTS "Users can delete their own forks" ON "public"."vault_forks";
+DROP POLICY IF EXISTS "Users can view their own forks" ON "public"."vault_forks";
+
+-- vault_forks/INSERT: "Users can create forks" only checks (auth.uid() = forked_by),
+-- with NO restriction on the original vault's visibility. Since permissive policies are
+-- OR'd, this alone was already sufficient to let any authenticated user insert a
+-- vault_forks row against ANY vault_id (private included) -- it fully defeated the
+-- "public vaults only" restriction that "Authenticated users can fork public vaults" and
+-- "Users can fork public vaults" were written to enforce (confirmed against
+-- src/lib/vaultFork.ts, which only ever forks vaults fetched with
+-- .eq('visibility', 'public'), and enforce_forked_vaults_public's own "forked vaults
+-- must remain public" intent). Dropping it; the two visibility-gated policies already
+-- cover every legitimate fork path.
+DROP POLICY IF EXISTS "Users can create forks" ON "public"."vault_forks";
+
+-- vaults/SELECT: "Users can view own vaults" (auth.uid() = user_id) is a strict subset
+-- of "Users can view shared vaults" (public.user_can_access_vault(id, 'viewer')), whose
+-- body checks vault ownership first and returns true immediately -- see
+-- supabase/schema.sql's user_can_access_vault definition.
+DROP POLICY IF EXISTS "Users can view own vaults" ON "public"."vaults";
+
+-- publications: "Users can manage own publications" (auth.uid() = user_id) is textually
+-- the first disjunct inside "...manage own publications and publications in editable "'s
+-- own USING/WITH CHECK OR-chain, so it can never permit anything the latter doesn't
+-- already permit.
+DROP POLICY IF EXISTS "Users can manage own publications" ON "public"."publications";


### PR DESCRIPTION
## Summary
- Enables RLS on `semantic_scholar_rate_limit_state` and `openalex_budget_state` (both Security Advisor **errors**) — both tables already revoke all privileges from PUBLIC and grant only `service_role`, so this changes no behavior, it just removes the "any future GRANT is instantly exploitable" gap.
- Fixes `vault_papers`' "Users can manage vault papers" RLS policy, which had only a `WITH CHECK` and no `USING`/`FOR`/`TO`, silently defaulting to `FOR ALL TO public USING (true)`. Since `WITH CHECK` isn't consulted for `DELETE`, **any role — including anon — could delete any row in the table**. Now scoped to `authenticated` with an explicit matching `USING` clause.
- Pins `search_path` on the 10 functions the linter flagged as mutable.
- Revokes unnecessary anon/authenticated `EXECUTE` on 8 trigger-only `SECURITY DEFINER` functions (trigger firing isn't gated by EXECUTE grants, so they keep working), on `has_vault_access` (dead code, unused anywhere, was letting anon probe arbitrary user/vault access relationships), and narrows `user_can_access_vault`/`delete_user`/`create_user_profile` to drop the anon grant where nothing calls them as anon.
- Adds an `auth.uid() = p_user_id` guard inside `create_user_profile` (found while auditing the above) — it's `SECURITY DEFINER` and previously trusted its `p_user_id` argument outright, so any authenticated caller could have created a profile row for someone else's user id. The guard is skipped when `auth.uid()` is `NULL` so the trigger-internal call from `handle_new_user` during signup (which runs without a request JWT) still works.
- **Revokes anon/authenticated `EXECUTE` on `update_vault_publication_with_rollup`.** A live grant check against production (`information_schema.role_routine_grants`) confirmed anon and authenticated both currently hold EXECUTE on this function, contradicting its own source migration's intent (service_role-only). This one is serious: the function runs `SECURITY INVOKER` but spoofs `auth.uid()` via `set_config('request.jwt.claim.sub', p_actor_user_id, true)` before its UPDATEs. Any authenticated user could call it directly, pass an arbitrary victim's user id as `p_actor_user_id`, and have the `vault_publications` RLS policy authorize the write against the *impersonated* victim instead of themselves — gaining unauthorized write access to any vault_publication that victim can edit, then fanning the patch out to the canonical `publications` row and every sibling vault_publication. (anon alone isn't exploitable — that RLS policy is `TO authenticated` only — but authenticated is.) Restoring the intended service_role-only grant closes it.
- Not covered here: `auth_leaked_password_protection` is a project-level Auth setting, not something a migration can flip — needs to be enabled in the Supabase Dashboard under Authentication → Providers → Email.

## Performance Advisor fixes
- Wraps `auth.uid()` as `(select auth.uid())` in 50 RLS policies (`auth_rls_initplan`). `auth.uid()` is `STABLE`, so this lets Postgres evaluate it once per query as an InitPlan instead of once per row — semantically identical, purely a query-plan optimization.
- Adds 10 missing covering indexes on foreign-key columns (`unindexed_foreign_keys`): `api_keys.created_by`, `publication_pdf_assets.user_id`, `publication_tags.tag_id`, `publications.user_id`, `tags.user_id`, `vault_access_requests.requester_id`, `vault_publications.created_by`, `vault_shares.shared_by`, `vault_shares.vault_id`, `vaults.user_id`.
- Drops 8 of the ~30 flagged redundant/overlapping permissive RLS policies (`multiple_permissive_policies`) — only ones verified to be exact duplicates or strict subsets of another policy already covering the same role+action, so dropping them changes no access outcome. The rest of the flagged set are left alone; they represent legitimate distinct-population or viewer/editor-asymmetric designs that need case-by-case review rather than a mechanical merge.
- One of the 8 drops fixes a real access-control bug found in the process: `vault_forks`' "Users can create forks" policy had **no visibility check at all**, so any authenticated user could insert a fork row against a *private* vault directly via the table/API, bypassing the intent (enforced everywhere else — the app's `forkVault()` client code, the other two fork-insert policies, and the `enforce_forked_vaults_public` trigger) that only public vaults can be forked. Removing this duplicate-but-unsafe policy leaves the two correctly-scoped "forks require public vault" policies as the only path to insert.
- Not covered here: `unused_index` INFO items are left alone — they're informational, not a warning, and this app is early enough that pruning "unused" indexes now carries more risk (premature removal ahead of real traffic patterns) than benefit.

## Test plan
- [x] Verified locally: reconstructed the pre-fix schema (roles, enums, tables, original function/policy bodies) in a throwaway `postgres:15` Docker container, applied this migration on top, confirmed it runs with no errors, and confirmed the resulting function ACLs and `vault_papers` policy match intent (anon grants removed where expected, `authenticated` retained where policies still need it).
- [x] Regression-tested the trigger-based revokes: in Postgres, revoked EXECUTE from a role and confirmed that same role's UPDATE still fires the trigger normally — confirms the bibliographic rollup/fan-out trigger (`set_vault_publication_updated_by`) and all `notify_vault_*` collaboration-notification triggers are unaffected.
- [x] Regression-tested the new `create_user_profile` guard against all three cases: no-JWT-context call (simulating the `handle_new_user` signup trigger) succeeds, a user creating their own profile succeeds, a user attempting to create a profile for a different user id correctly raises.
- [x] Simulated production's actual over-permissive grant on `update_vault_publication_with_rollup` (anon+authenticated+service_role) in Docker, applied this migration, confirmed only `service_role` (and the owner) retain EXECUTE afterward.
- [x] Rebuilt the full schema (all tables/policies/functions/indexes/triggers, including the security-fix migration applied first) in a fresh Docker container, applied the performance migration on top, and confirmed: zero unwrapped `auth.uid()` calls remain in any `public` schema policy, all 8 intended policy drops succeeded with the other 9 similarly-named policies left intact, and all 10 new FK indexes were created successfully.
- [ ] Apply to the actual Supabase project and re-run both the Security Advisor and Performance Advisor to confirm the flagged items clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
