### PR TITLE
Fix vault favorites publication count querying wrong table

### DIFF
--- a/src/hooks/useVaultFavorites.ts
+++ b/src/hooks/useVaultFavorites.ts
@@ -48,7 +48,7 @@ export function useVaultFavorites() {
             const enrichedVaults = await Promise.all(
               vaultsData.map(async (vault) => {
                 const { count } = await supabase
-                  .from('publications')
+                  .from('vault_publications')
                   .select('*', { count: 'exact', head: true })
                   .eq('vault_id', vault.id);
 


### PR DESCRIPTION
## Summary
- `useVaultFavorites` enriches each favorited vault with a publication count by querying `publications.vault_id`. That column doesn't exist — `vault_id` lives on `vault_publications`; `publications` is the user's flat personal library keyed by `user_id`.
- This threw a Postgres `42703` (undefined_column) error every time a user with at least one favorited vault loaded their favorites list, once per favorited vault (fired in parallel via `Promise.all`).
- Found while investigating `supabase_logs_errors.json`: 148 of 153 log entries over ~24h were exactly this error (`column publications.vault_id does not exist`), in bursts matching the parallel-per-vault query pattern. The remaining few entries (`unexpected EOF on standby connection`, `connection reset by peer`) are unrelated Postgres replication/connection noise, not app bugs.

## Fix
Query `vault_publications` (which has `vault_id`) instead of `publications`.

## Test plan
- [x] `tsc --noEmit` passes.
- [ ] Manually verify: favorite a vault with publications in it, load the favorites list, confirm the publication count displays correctly and no error appears in the Supabase logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)