### PR TITLE
CSV export: drop refhub_id, table-ize the preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this
 project uses [Semantic Versioning](https://semver.org/). History prior to
 1.4.2 was not tracked in this file.
 
+## [1.8.1] - 2026-08-01
+
+### Changed
+- CSV export: dropped the `refhub_id` column from the exportable field list.
+- CSV export preview now renders as a table capped at 5 rows instead of dumping the full raw CSV text.
+
 ## [1.8.0] - 2026-07-31
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/ExportDialog.test.tsx
+++ b/src/components/publications/ExportDialog.test.tsx
@@ -35,8 +35,7 @@ describe('ExportDialog CSV tab', () => {
     const csvTab = screen.getByRole('tab', { name: /csv/i });
     fireEvent.mouseDown(csvTab);
     // Dialog content is portaled to document.body, so query there directly.
-    const preview = document.body.querySelector('pre');
-    expect(preview?.textContent).toContain('refhub_id');
+    const preview = document.body.querySelector('table');
     expect(preview?.textContent).toContain('A Paper');
   });
 
@@ -44,16 +43,32 @@ describe('ExportDialog CSV tab', () => {
     render(<ExportDialog open onOpenChange={() => {}} publications={[pub as never]} />);
     fireEvent.mouseDown(screen.getByRole('tab', { name: /csv/i }));
 
-    // All fields start checked; uncheck "notes".
-    const notesCheckbox = screen.getByText('notes').closest('label')!.querySelector('button[role="checkbox"]')!;
+    // All fields start checked; uncheck "notes". "notes" also appears as a table
+    // header once the preview renders, so disambiguate by picking the match
+    // that's inside a checkbox <label>, not a <th>.
+    const notesLabel = screen.getAllByText('notes').map(el => el.closest('label')).find((el): el is HTMLLabelElement => !!el)!;
+    const notesCheckbox = notesLabel.querySelector('button[role="checkbox"]')!;
     fireEvent.click(notesCheckbox);
 
-    const preview = document.body.querySelector('pre');
-    expect(preview?.textContent?.split('\n')[0]).not.toContain('notes');
+    const headerCells = Array.from(document.body.querySelectorAll('table thead th')).map(th => th.textContent);
+    expect(headerCells).not.toContain('notes');
 
     fireEvent.click(screen.getByRole('button', { name: /export_\.csv/i }));
     const [content] = mockedDownloadTextFile.mock.calls[0];
     expect(content.split('\r\n')[0]).not.toContain('notes');
+  });
+
+  it('truncates the preview table to a handful of rows and says how many were left out', () => {
+    const pubs = Array.from({ length: 7 }, (_, i) => ({ ...pub, id: `pub-${i}`, title: `Paper ${i}` }));
+    render(<ExportDialog open onOpenChange={() => {}} publications={pubs as never[]} />);
+    fireEvent.mouseDown(screen.getByRole('tab', { name: /csv/i }));
+
+    expect(document.body.querySelectorAll('table tbody tr').length).toBe(5);
+    expect(screen.getByText('// 5 of 7 rows')).toBeInTheDocument();
+    // The full file (not just the preview) still contains every row.
+    fireEvent.click(screen.getByRole('button', { name: /export_\.csv/i }));
+    const [content] = mockedDownloadTextFile.mock.calls[0];
+    expect(content.split('\r\n').length).toBe(8); // 1 header row + 7 publication rows
   });
 
   it('disables copy/export and shows a warning when no CSV fields are selected', () => {
@@ -91,7 +106,7 @@ describe('ExportDialog CSV tab', () => {
   it('does not put a BOM in the on-screen CSV preview', () => {
     render(<ExportDialog open onOpenChange={() => {}} publications={[pub as never]} />);
     fireEvent.mouseDown(screen.getByRole('tab', { name: /csv/i }));
-    const preview = document.body.querySelector('pre');
-    expect(preview?.textContent?.startsWith('\uFEFF')).toBe(false);
+    const preview = document.body.querySelector('table');
+    expect(preview?.textContent?.includes('\uFEFF')).toBe(false);
   });
 });

--- a/src/components/publications/ExportDialog.tsx
+++ b/src/components/publications/ExportDialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Download, FileText, Copy, Check, BookOpen, Table } from 'lucide-react';
 import { exportMultipleToBibtexWithFields, publicationToBibtex, downloadBibtex, BibtexField } from '@/lib/bibtex';
-import { formatAPA, formatMultipleAPA, formatCSV, buildTagKeywords, downloadTextFile, CsvField, ALL_CSV_FIELDS } from '@/lib/export';
+import { formatAPA, formatMultipleAPA, formatCSV, getCsvRows, buildTagKeywords, downloadTextFile, CsvField, ALL_CSV_FIELDS } from '@/lib/export';
 import { useToast } from '@/hooks/use-toast';
 import { useKeyboardContext } from '@/contexts/KeyboardContext';
 import { KbdHint } from '@/components/ui/KbdHint';
@@ -42,6 +42,8 @@ const BIBTEX_FIELDS: { key: BibtexField; label: string; description: string }[] 
 
 const DEFAULT_SELECTED: BibtexField[] = ['title', 'author', 'year', 'journal', 'doi'];
 
+const CSV_PREVIEW_ROW_LIMIT = 5;
+
 const CSV_FIELDS: { key: CsvField; label: string; description: string }[] = [
   { key: 'title', label: 'title', description: 'publication title' },
   { key: 'authors', label: 'authors', description: 'author names' },
@@ -52,7 +54,6 @@ const CSV_FIELDS: { key: CsvField; label: string; description: string }[] = [
   { key: 'abstract', label: 'abstract', description: 'paper abstract' },
   { key: 'tags', label: 'tags', description: 'hierarchical tag path' },
   { key: 'notes', label: 'notes', description: 'your notes' },
-  { key: 'refhub_id', label: 'refhub_id', description: 'internal record id' },
 ];
 
 type ExportFormat = 'bibtex' | 'apa' | 'csv';
@@ -190,6 +191,13 @@ export function ExportDialog({
 
   const csvContent = useMemo(
     () => formatCSV(publications, selectedCsvFields, tagsByPublicationId),
+    [publications, selectedCsvFields, tagsByPublicationId]
+  );
+
+  // Preview only ever shows a handful of rows as a readable table -- the raw
+  // CSV text (with its escaping/quoting) is what actually gets copied/downloaded.
+  const csvPreviewRows = useMemo(
+    () => getCsvRows(publications.slice(0, CSV_PREVIEW_ROW_LIMIT), selectedCsvFields, tagsByPublicationId),
     [publications, selectedCsvFields, tagsByPublicationId]
   );
 
@@ -403,9 +411,41 @@ export function ExportDialog({
                 </p>
               ) : (
                 <div className="space-y-2 min-w-0">
-                  <Label className="text-xs sm:text-sm font-medium font-mono">preview:</Label>
-                  <ScrollArea className="max-h-[30vh] border rounded-lg bg-muted/30 p-3">
-                    <pre className="text-xs font-mono whitespace-pre-wrap break-words">{csvContent}</pre>
+                  <div className="flex items-center justify-between gap-2">
+                    <Label className="text-xs sm:text-sm font-medium font-mono">preview:</Label>
+                    <span className="text-xs text-muted-foreground font-mono">
+                      {`// ${Math.min(CSV_PREVIEW_ROW_LIMIT, publications.length)} of ${publications.length} rows`}
+                    </span>
+                  </div>
+                  <ScrollArea className="max-h-[30vh] border rounded-lg bg-muted/30">
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-xs font-mono border-collapse">
+                        <thead>
+                          <tr className="border-b border-border">
+                            {csvPreviewRows.columns.map(column => (
+                              <th key={column} className="text-left font-semibold px-3 py-2 whitespace-nowrap">
+                                {column}
+                              </th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {csvPreviewRows.rows.map((row, rowIndex) => (
+                            <tr key={rowIndex} className="border-b border-border/50 last:border-0">
+                              {row.map((cell, cellIndex) => (
+                                <td
+                                  key={cellIndex}
+                                  title={cell || undefined}
+                                  className="px-3 py-2 max-w-[220px] truncate align-top text-muted-foreground"
+                                >
+                                  {cell || '—'}
+                                </td>
+                              ))}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
                   </ScrollArea>
                 </div>
               )}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,7 +29,7 @@ const changelog: ChangelogEntry[] = [
         tag: 'feature',
         title: 'csv export',
         description:
-          'export publications to csv format with all key metadata: title, authors, year, venue, doi, url, abstract, tags, notes, and refhub id.',
+          'export publications to csv format with all key metadata: title, authors, year, venue, doi, url, abstract, tags, and notes.',
       },
       {
         tag: 'feature',

--- a/src/lib/export.test.ts
+++ b/src/lib/export.test.ts
@@ -41,8 +41,8 @@ describe('formatCSV', () => {
   it('emits a header row followed by one row per publication', () => {
     const csv = formatCSV([makePub()]);
     const lines = csv.split('\r\n');
-    expect(lines[0]).toBe('title,authors,year,venue,doi,url,abstract,tags,notes,refhub_id');
-    expect(lines[1]).toBe('A Paper,Ada Lovelace; Grace Hopper,2024,Journal of Things,10.1234/abc,,An abstract.,,,pub-1');
+    expect(lines[0]).toBe('title,authors,year,venue,doi,url,abstract,tags,notes');
+    expect(lines[1]).toBe('A Paper,Ada Lovelace; Grace Hopper,2024,Journal of Things,10.1234/abc,,An abstract.,,');
   });
 
   it('falls back to booktitle when journal is absent', () => {
@@ -77,7 +77,7 @@ describe('formatCSV', () => {
 
   it('handles an empty publication list by returning just the header', () => {
     const csv = formatCSV([]);
-    expect(csv).toBe('title,authors,year,venue,doi,url,abstract,tags,notes,refhub_id');
+    expect(csv).toBe('title,authors,year,venue,doi,url,abstract,tags,notes');
   });
 
   it('neutralizes formula injection in title by prefixing with apostrophe', () => {

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -136,10 +136,10 @@ export function formatMultipleAPA(publications: Publication[]): string {
   return sorted.map(pub => formatAPA(pub)).join('\n\n');
 }
 
-export type CsvField = 'title' | 'authors' | 'year' | 'venue' | 'doi' | 'url' | 'abstract' | 'tags' | 'notes' | 'refhub_id';
+export type CsvField = 'title' | 'authors' | 'year' | 'venue' | 'doi' | 'url' | 'abstract' | 'tags' | 'notes';
 
 /** Canonical column order. `formatCSV` follows this order regardless of the order `fields` is passed in. */
-export const ALL_CSV_FIELDS: CsvField[] = ['title', 'authors', 'year', 'venue', 'doi', 'url', 'abstract', 'tags', 'notes', 'refhub_id'];
+export const ALL_CSV_FIELDS: CsvField[] = ['title', 'authors', 'year', 'venue', 'doi', 'url', 'abstract', 'tags', 'notes'];
 
 function getCsvFieldValue(pub: Publication, field: CsvField, tagsByPublicationId?: Record<string, string>): string {
   switch (field) {
@@ -152,8 +152,29 @@ function getCsvFieldValue(pub: Publication, field: CsvField, tagsByPublicationId
     case 'abstract': return pub.abstract || '';
     case 'tags': return tagsByPublicationId?.[pub.id] || '';
     case 'notes': return pub.notes || '';
-    case 'refhub_id': return pub.id;
   }
+}
+
+export interface CsvRows {
+  columns: CsvField[];
+  /** Raw (unescaped) cell values, one array per publication, in column order. */
+  rows: string[][];
+}
+
+/**
+ * Shared by `formatCSV` (which escapes and joins these into file text) and
+ * the export dialog's table preview (which renders them directly — escaping
+ * for CSV syntax would just show stray quotes in a UI table).
+ */
+export function getCsvRows(
+  publications: Publication[],
+  fields: CsvField[] = ALL_CSV_FIELDS,
+  tagsByPublicationId?: Record<string, string>,
+): CsvRows {
+  const selected = new Set(fields);
+  const columns = ALL_CSV_FIELDS.filter(f => selected.has(f));
+  const rows = publications.map(pub => columns.map(f => getCsvFieldValue(pub, f, tagsByPublicationId)));
+  return { columns, rows };
 }
 
 export function formatCSV(
@@ -161,9 +182,7 @@ export function formatCSV(
   fields: CsvField[] = ALL_CSV_FIELDS,
   tagsByPublicationId?: Record<string, string>,
 ): string {
-  const selected = new Set(fields);
-  const columns = ALL_CSV_FIELDS.filter(f => selected.has(f));
-  const rows = publications.map(pub => columns.map(f => getCsvFieldValue(pub, f, tagsByPublicationId)));
+  const { columns, rows } = getCsvRows(publications, fields, tagsByPublicationId);
   return [columns, ...rows].map(row => row.map(csvEscape).join(',')).join('\r\n');
 }
 


### PR DESCRIPTION
## Summary
- Drops `refhub_id` (internal record UUID) from the CSV export field list — not useful in an exported spreadsheet.
- Replaces the CSV tab's on-screen preview: was a `<pre>` dump of the full raw/escaped CSV text (unreadable past a handful of rows), now an actual `<table>` capped at 5 rows with a "N of M rows" note. Copy/download still produce the complete file — only the preview is truncated.
- `formatCSV` refactored on top of a new `getCsvRows()` helper so the dialog can render raw cell values directly instead of re-parsing escaped CSV text.

Follow-up to #170 (this branch was cut from `main` after that PR's squash-merge, so it only contains this one incremental change).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (180/180 passing)
- [x] `npx eslint` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)