### PR TITLE
Fix Ctrl+A/D/E shortcuts being swallowed by the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this
 project uses [Semantic Versioning](https://semver.org/). History prior to
 1.4.2 was not tracked in this file.
 
+## [1.8.2] - 2026-08-01
+
+### Fixed
+- Ctrl+A (select all), Ctrl+D (deselect all), and Ctrl+E (export) keyboard shortcuts were silently swallowed by the browser's own defaults (e.g. select-page-text) whenever the list wasn't already the active keyboard context — now app-wide like the app's other list shortcuts.
+
 ## [1.8.1] - 2026-08-01
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/hooks/useKeyboardNavigation.test.tsx
+++ b/src/hooks/useKeyboardNavigation.test.tsx
@@ -59,8 +59,8 @@ describe('useKeyboardNavigation app-wide Ctrl shortcuts', () => {
   });
 
   it('lets Ctrl+E invoke onExport app-wide, defaulting to every item when nothing is selected', () => {
-    const onExport = (ids: string[]) => exported.push(ids);
     const exported: string[][] = [];
+    const onExport = (ids: string[]) => exported.push(ids);
 
     renderHook(
       () =>

--- a/src/hooks/useKeyboardNavigation.test.tsx
+++ b/src/hooks/useKeyboardNavigation.test.tsx
@@ -1,0 +1,95 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KeyboardProvider } from '@/contexts/KeyboardContext';
+import { useKeyboardNavigation } from './useKeyboardNavigation';
+
+function pressCtrl(key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, ctrlKey: true, bubbles: true, cancelable: true });
+  act(() => {
+    window.dispatchEvent(event);
+  });
+  return event;
+}
+
+describe('useKeyboardNavigation app-wide Ctrl shortcuts', () => {
+  // Regression test: Ctrl+A/Ctrl+D/Ctrl+E were registered without `appWide`,
+  // unlike their sibling shortcuts (v, Shift+g, j, k) in the same hotkey list.
+  // That meant they only fired once this hook's own `context` was the active
+  // one -- e.g. before activateOnMount's effect has run, or while a sibling
+  // list/dialog holds the active context -- so the browser's own Ctrl+A
+  // (select page text) / Ctrl+E ran instead, even though the UI advertises
+  // these as working shortcuts via <KbdHint>.
+  it('lets Ctrl+A select all and calls preventDefault even when this context is not yet the active one', () => {
+    const { result } = renderHook(
+      () =>
+        useKeyboardNavigation({
+          context: 'publication-list',
+          itemIds: ['a', 'b', 'c'],
+          appWideShortcuts: true,
+        }),
+      { wrapper: KeyboardProvider },
+    );
+
+    // No activateOnMount/bootstrapOnNav here, so the active context is still 'global'.
+    expect(result.current.selectedIds.size).toBe(0);
+
+    const event = pressCtrl('a');
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(result.current.selectedIds).toEqual(new Set(['a', 'b', 'c']));
+  });
+
+  it('lets Ctrl+D clear the selection app-wide too', () => {
+    const { result } = renderHook(
+      () =>
+        useKeyboardNavigation({
+          context: 'publication-list',
+          itemIds: ['a', 'b'],
+          appWideShortcuts: true,
+        }),
+      { wrapper: KeyboardProvider },
+    );
+
+    pressCtrl('a');
+    expect(result.current.selectedIds.size).toBe(2);
+
+    const event = pressCtrl('d');
+    expect(event.defaultPrevented).toBe(true);
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it('lets Ctrl+E invoke onExport app-wide, defaulting to every item when nothing is selected', () => {
+    const onExport = (ids: string[]) => exported.push(ids);
+    const exported: string[][] = [];
+
+    renderHook(
+      () =>
+        useKeyboardNavigation({
+          context: 'publication-list',
+          itemIds: ['a', 'b'],
+          appWideShortcuts: true,
+          onExport,
+        }),
+      { wrapper: KeyboardProvider },
+    );
+
+    const event = pressCtrl('e');
+    expect(event.defaultPrevented).toBe(true);
+    expect(exported).toEqual([['a', 'b']]);
+  });
+
+  it('does not fire Ctrl+A when appWideShortcuts is not set and this context is inactive (scoped lists stay scoped)', () => {
+    const { result } = renderHook(
+      () =>
+        useKeyboardNavigation({
+          context: 'publication-list',
+          itemIds: ['a', 'b', 'c'],
+        }),
+      { wrapper: KeyboardProvider },
+    );
+
+    const event = pressCtrl('a');
+    expect(event.defaultPrevented).toBe(false);
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+});

--- a/src/hooks/useKeyboardNavigation.tsx
+++ b/src/hooks/useKeyboardNavigation.tsx
@@ -444,6 +444,7 @@ export function useKeyboardNavigation(
       {
         combo: 'Ctrl+a',
         description: 'Select all',
+        appWide: appWideShortcuts,
         handler: (e) => { e.preventDefault(); selectAll(); return true; },
         allowInInput: false,
       },
@@ -451,6 +452,7 @@ export function useKeyboardNavigation(
       {
         combo: 'Ctrl+e',
         description: 'Export selected',
+        appWide: appWideShortcuts,
         handler: (e) => {
           e.preventDefault();
           const ids = Array.from(selectedIdsRef.current);
@@ -519,6 +521,7 @@ export function useKeyboardNavigation(
       {
         combo: 'Ctrl+d',
         description: 'Deselect all',
+        appWide: appWideShortcuts,
         handler: (e) => {
           e.preventDefault();
           clearSelection();


### PR DESCRIPTION
## Summary
- Root cause: `Ctrl+a`, `Ctrl+d`, and `Ctrl+e` hotkey defs in `useKeyboardNavigation.tsx` were missing `appWide: appWideShortcuts`, unlike their sibling shortcuts (`v`, `Shift+g`, `j`, `k`) in the same array.
- `isContextActive()` only lets a non-`appWide` shortcut fire once its own registered `context` is the currently active keyboard context. Before that (e.g. the narrow window before `activateOnMount`'s effect runs, or while a sibling list/dialog holds the active context), the dispatch loop skips past the shortcut entirely, `preventDefault()` never gets called, and the browser's own default (Ctrl+A selects page text, etc.) runs instead — even though the UI advertises these as working shortcuts via `<KbdHint>`.
- Fix: add `appWide: appWideShortcuts` to all three, matching the pattern already used elsewhere in the same hotkey list.

## Test plan
- [x] Added `src/hooks/useKeyboardNavigation.test.tsx` — dispatches real `KeyboardEvent`s and asserts `defaultPrevented` + resulting state, without first activating the list's own context.
- [x] Verified the new tests fail without the fix (temporarily reverted the source change) and pass with it.
- [x] `npx tsc --noEmit`, `npx eslint`, `npx vitest run` (184/184 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)