### PR TITLE
Fix CSV export preview table clipping columns instead of scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this
 project uses [Semantic Versioning](https://semver.org/). History prior to
 1.4.2 was not tracked in this file.
 
+## [1.8.3] - 2026-08-01
+
+### Fixed
+- CSV export preview: columns beyond what fit the dialog's width were silently clipped with no way to reach them, since the table was forced to exactly fit its container and `<ScrollArea>` only ships a vertical scrollbar by default. The preview table now sizes to its natural content width inside a horizontally-scrollable container.
+
 ## [1.8.2] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.8.2",
+  "version": "1.8.3",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/components/publications/ExportDialog.test.tsx
+++ b/src/components/publications/ExportDialog.test.tsx
@@ -39,6 +39,23 @@ describe('ExportDialog CSV tab', () => {
     expect(preview?.textContent).toContain('A Paper');
   });
 
+  it('lets the preview table scroll horizontally instead of clipping columns', () => {
+    render(<ExportDialog open onOpenChange={() => {}} publications={[pub as never]} />);
+    fireEvent.mouseDown(screen.getByRole('tab', { name: /csv/i }));
+
+    const table = document.body.querySelector('table');
+    // Regression: the table previously had `w-full`, which let the browser
+    // satisfy that width by shrinking/ellipsis-truncating columns instead of
+    // ever overflowing its container -- so extra columns were unreachable,
+    // with no scrollbar. It must size to its natural content width instead.
+    expect(table?.className).not.toMatch(/(^|\s)w-full(\s|$)/);
+
+    // Its scroll container must allow horizontal overflow (not just vertical,
+    // which is all <ScrollArea>'s default scrollbar provides).
+    const scrollContainer = table?.parentElement;
+    expect(scrollContainer?.className).toMatch(/overflow-(auto|x-auto)/);
+  });
+
   it('lets the user deselect a CSV field, removing it from the preview and download', () => {
     render(<ExportDialog open onOpenChange={() => {}} publications={[pub as never]} />);
     fireEvent.mouseDown(screen.getByRole('tab', { name: /csv/i }));

--- a/src/components/publications/ExportDialog.tsx
+++ b/src/components/publications/ExportDialog.tsx
@@ -417,36 +417,44 @@ export function ExportDialog({
                       {`// ${Math.min(CSV_PREVIEW_ROW_LIMIT, publications.length)} of ${publications.length} rows`}
                     </span>
                   </div>
-                  <ScrollArea className="max-h-[30vh] border rounded-lg bg-muted/30">
-                    <div className="overflow-x-auto">
-                      <table className="w-full text-xs font-mono border-collapse">
-                        <thead>
-                          <tr className="border-b border-border">
-                            {csvPreviewRows.columns.map(column => (
-                              <th key={column} className="text-left font-semibold px-3 py-2 whitespace-nowrap">
-                                {column}
-                              </th>
+                  {/*
+                    Plain scrollable div, not <ScrollArea>: ScrollArea only ships a
+                    vertical scrollbar by default, and the table previously had
+                    `w-full`, which let the browser satisfy that width by shrinking
+                    + ellipsis-truncating columns instead of ever overflowing --
+                    so extra columns just got clipped with no way to reach them.
+                    Dropping `w-full` lets the table size to its natural content
+                    width so this container's overflow-x-auto has something to
+                    actually scroll.
+                  */}
+                  <div className="max-h-[30vh] overflow-auto border rounded-lg bg-muted/30">
+                    <table className="text-xs font-mono border-collapse">
+                      <thead>
+                        <tr className="border-b border-border">
+                          {csvPreviewRows.columns.map(column => (
+                            <th key={column} className="text-left font-semibold px-3 py-2 whitespace-nowrap">
+                              {column}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {csvPreviewRows.rows.map((row, rowIndex) => (
+                          <tr key={rowIndex} className="border-b border-border/50 last:border-0">
+                            {row.map((cell, cellIndex) => (
+                              <td
+                                key={cellIndex}
+                                title={cell || undefined}
+                                className="px-3 py-2 max-w-[220px] truncate align-top text-muted-foreground"
+                              >
+                                {cell || '—'}
+                              </td>
                             ))}
                           </tr>
-                        </thead>
-                        <tbody>
-                          {csvPreviewRows.rows.map((row, rowIndex) => (
-                            <tr key={rowIndex} className="border-b border-border/50 last:border-0">
-                              {row.map((cell, cellIndex) => (
-                                <td
-                                  key={cellIndex}
-                                  title={cell || undefined}
-                                  className="px-3 py-2 max-w-[220px] truncate align-top text-muted-foreground"
-                                >
-                                  {cell || '—'}
-                                </td>
-                              ))}
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  </ScrollArea>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               )}
             </TabsContent>

--- a/src/components/publications/ExportDialog.tsx
+++ b/src/components/publications/ExportDialog.tsx
@@ -424,7 +424,7 @@ export function ExportDialog({
                     + ellipsis-truncating columns instead of ever overflowing --
                     so extra columns just got clipped with no way to reach them.
                     Dropping `w-full` lets the table size to its natural content
-                    width so this container's overflow-x-auto has something to
+                    width so this container's overflow-auto has something to
                     actually scroll.
                   */}
                   <div className="max-h-[30vh] overflow-auto border rounded-lg bg-muted/30">


### PR DESCRIPTION
## Summary
- Root cause: the preview `<table>` had `w-full`, so the browser satisfied that width constraint by shrinking + ellipsis-truncating columns rather than ever overflowing its container — extra columns (beyond whatever fit the dialog width) were simply unreachable, with no scrollbar. Compounding it, the wrapper was `<ScrollArea>`, which only renders a vertical scrollbar by default.
- Fix: drop `w-full` so the table sizes to its natural content width, inside a plain `overflow-auto` div instead of `<ScrollArea>`, so it can exceed the container and scroll in both directions as needed.

Note: this branch bumps to **1.8.3** (not 1.8.2) since #172 already claimed 1.8.2 from an independent parallel branch off the same base — whichever of the two merges second will need a quick version-bump rebase, which is expected.

## Test plan
- [x] Added a regression test asserting the table has no `w-full` class and its scroll container has `overflow-auto`/`overflow-x-auto`.
- [x] `npx tsc --noEmit`, `npx eslint`, `npx vitest run` (181/181 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)