### PR TITLE
Fix /about page sign-in state and mobile hero badge overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this
 project uses [Semantic Versioning](https://semver.org/). History prior to
 1.4.2 was not tracked in this file.
 
+## [1.8.4] - 2026-08-01
+
+### Fixed
+- The public /about page kept showing "sign in" / "get_started" even when you were already signed in — it now shows "dashboard" / "go_to_dashboard" and links straight to the app instead of `/auth`.
+- The /about page's hero eyebrow badge (a long unbroken snake_case string) had no natural word-break points and got silently clipped on narrow/mobile viewports; it now wraps.
+
 ## [1.8.3] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refhub.io",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refhub.io",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refhub.io",
   "private": true,
-  "version": "1.8.3",
+  "version": "1.8.4",
   "type": "module",
   "description": "a modern reference manager for the command line generation",
   "author": "velitchko",

--- a/src/pages/Landing.test.tsx
+++ b/src/pages/Landing.test.tsx
@@ -1,9 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Landing from './Landing';
+import { useAuth } from '@/hooks/useAuth';
+
+vi.mock('@/hooks/useAuth', () => ({ useAuth: vi.fn() }));
+
+const mockedUseAuth = vi.mocked(useAuth);
 
 describe('Landing', () => {
+  beforeEach(() => {
+    // Default: signed out. Individual tests override this to cover the signed-in case.
+    mockedUseAuth.mockReturnValue({ user: null } as ReturnType<typeof useAuth>);
+  });
+
   it('renders without requiring authentication and shows a sign-in CTA', () => {
     render(
       <MemoryRouter>
@@ -12,6 +22,20 @@ describe('Landing', () => {
     );
     expect(screen.getByText(/get_started/i)).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: /sign in/i }).length).toBeGreaterThan(0);
+  });
+
+  it('shows a dashboard CTA instead of sign-in copy when already signed in', () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-1' } } as ReturnType<typeof useAuth>);
+    render(
+      <MemoryRouter>
+        <Landing />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: 'dashboard' })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: /go_to_dashboard/i })).toHaveAttribute('href', '/');
+    expect(screen.queryByText(/sign in/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('get_started')).not.toBeInTheDocument();
   });
 
   it('links to the codex and legal pages', () => {
@@ -67,5 +91,19 @@ describe('Landing', () => {
     );
     expect(screen.getByText('// agentic_workflows')).toBeInTheDocument();
     expect(screen.getByText(/claude skills for the refhub cli and drafting papers/i)).toBeInTheDocument();
+  });
+
+  it('lets the hero eyebrow badge wrap on narrow viewports instead of overflowing', () => {
+    render(
+      <MemoryRouter>
+        <Landing />
+      </MemoryRouter>
+    );
+    const badge = screen.getByText(/reference_manager_for_the_command_line_generation/i);
+    // Regression: this single unbroken snake_case string has no natural word-break
+    // points, and the page root has `overflow-hidden`, so on narrow viewports it
+    // used to get silently clipped instead of wrapping.
+    expect(badge.className).toMatch(/(^|\s)break-words(\s|$)/);
+    expect(badge.className).toMatch(/(^|\s)max-w-full(\s|$)/);
   });
 });

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, BookOpen, Network, FileDown, Bot } from 'lucide-react';
 import { BrandMark } from '@/components/branding/BrandMark';
 import { ThemeToggle } from '@/components/layout/ThemeToggle';
 import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/useAuth';
 
 // `label` is the snake_case comment heading rendered above each card. It is kept
 // separate from `title` on purpose: deriving it from the human-readable title
@@ -36,6 +37,8 @@ const FEATURES = [
 ];
 
 export default function Landing() {
+  const { user } = useAuth();
+
   return (
     <div className="min-h-screen overflow-hidden bg-background text-foreground">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_hsl(var(--electric-purple)/0.16),_transparent_42%)]" />
@@ -55,8 +58,8 @@ export default function Landing() {
             </span>
           </Link>
           <div className="flex items-center gap-3">
-            <Link to="/auth" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-              sign in
+            <Link to={user ? '/' : '/auth'} className="text-sm text-muted-foreground transition-colors hover:text-foreground">
+              {user ? 'dashboard' : 'sign in'}
             </Link>
             <ThemeToggle />
           </div>
@@ -64,7 +67,7 @@ export default function Landing() {
 
         <main className="flex-1 flex flex-col justify-center gap-10 py-10">
           <div className="space-y-6 max-w-3xl">
-            <div className="inline-flex items-center gap-3 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-xs font-mono uppercase tracking-[0.24em] text-primary">
+            <div className="inline-flex max-w-full items-center gap-3 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-center text-[10px] font-mono uppercase tracking-[0.12em] text-primary break-words sm:text-xs sm:tracking-[0.24em]">
               // reference_manager_for_the_command_line_generation
             </div>
             <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
@@ -77,8 +80,8 @@ export default function Landing() {
             </p>
             <div className="flex flex-wrap items-center gap-3 pt-2">
               <Button asChild variant="glow" size="lg" className="font-mono gap-2">
-                <Link to="/auth">
-                  get_started
+                <Link to={user ? '/' : '/auth'}>
+                  {user ? 'go_to_dashboard' : 'get_started'}
                   <ArrowRight className="w-4 h-4" />
                 </Link>
               </Button>


### PR DESCRIPTION
## Summary
- `Landing.tsx` (the public `/about` page) always showed "sign in" / "get_started" linking to `/auth`, even when the visitor was already signed in. Now checks `useAuth()`'s `user` (same `user ? 'x' : 'y'` pattern already used in `VaultDetail.tsx`) and shows "dashboard" / "go_to_dashboard" linking to `/` instead when signed in.
- Checked `TermsOfService`/`PrivacyPolicy` (both share `LegalDocumentLayout`) for the same issue — their header only has a "back" link with no auth-state-dependent copy, so nothing needed there.
- The hero eyebrow badge (`// reference_manager_for_the_command_line_generation`) is one long unbroken snake_case string with no natural word-break points, sitting inside a page root with `overflow-hidden` — on narrow/mobile viewports it silently clipped instead of wrapping. Added `break-words`/`max-w-full` (the same fix already applied to the feature-card labels earlier this session) plus a tighter mobile font-size/letter-spacing so it's less likely to need to wrap at all.

## Test plan
- [x] Added a test covering the signed-in header/CTA state (mocking `useAuth`).
- [x] Added a test asserting the hero badge carries `break-words`/`max-w-full`.
- [x] `npx tsc --noEmit`, `npx eslint`, `npx vitest run` (187/187 passing)
- [ ] No browser available in this environment to visually confirm the mobile wrap — flagging rather than claiming a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)